### PR TITLE
fix(ci): 同步 release 标签误触发修复到 main（sync）

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -55,7 +55,9 @@ ci:
       - any-glob-to-any-file:
           - '.github/workflows/**'
 
-release:
+# Release 相关文件变更
+# 注意：`release` 标签保留给人工触发 Release 工作流，不在这里自动添加。
+release-files:
   - changed-files:
       - any-glob-to-any-file:
           - '.github/workflows/release.yml'

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## [Unreleased]
 
+### 修复
+
+- 将自动打标中的 `release` 标签更名为 `release-files`，避免仓库治理 / 安装器 / Release 配置类 PR 在合并时误触发发布工作流
+
 ## [0.1.5-alpha] - 2026-04-21
 
 ### 新增


### PR DESCRIPTION
## 背景与目标
将 `develop` 上已合并的 release 标签误触发修复同步到 `main`。

## 说明
- 该 PR 仅包含 `#23` 已验证通过的修复提交
- 使用临时同步分支是为了绕过 direct `develop -> main` PR #24 的历史冲突