### PR TITLE
fix(macos): 修复网页白屏

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - 为移动端竖屏手机切换到底部导航，并为窄屏保留顶栏入口，修复低 DPI 竖屏下导航栏缺失的问题
 - 为 Linux Release 显式补齐并校验主程序可执行权限，同时补充压缩包解压与 `chmod +x` 使用说明
 - 收窄“刷新官网消息”的手动刷新范围，避免微信公众号抓取串入官网刷新链路导致信息中心长时间卡在加载状态
+- 为 macOS Debug / Release entitlements 补充 `com.apple.security.network.client`，修复官网刷新与内嵌 WebView 页面统一空白的问题
 
 ## [0.1.5-alpha] - 2026-04-21
 

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
 </dict>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## 背景与目标
修复 macOS 端官网刷新与内嵌 WebView 页面统一空白的问题，恢复应用内网页加载能力。

## 关联事项
Closes #31

## 变更类型
- [ ] feat：新功能
- [x] fix：缺陷修复
- [ ] refactor：代码重构
- [ ] docs：文档更新
- [ ] style：代码风格调整
- [ ] test：测试补充
- [ ] perf：性能优化
- [ ] build / ci：构建或 CI 变更
- [ ] chore：其他杂项

## 影响范围
- [ ] Flutter 前端（`lib/`）
- [x] 平台工程（Android / iOS / macOS / Linux / Windows / Web）
- [ ] 依赖 / 工具链
- [ ] GitHub 工作流 / Release
- [ ] 仓库治理（Issue / PR 模板、CODEOWNERS、Labeler、Dependabot）
- [x] 文档

## 风险与回滚
- 风险等级：
  - [x] 低
  - [ ] 中
  - [ ] 高
- 主要风险：为 macOS 沙盒补充出站网络权限后，应用可正常访问网页与官网接口；若后续上架需要更严格权限审查，需重新评估 entitlements 集合。
- 回滚方案：回退本 PR，恢复当前 macOS entitlements 配置。

## 验证记录
- [x] `flutter analyze`
- [x] `flutter test`
- [ ] 手动验证（请补充关键路径）
- [x] 未执行部分验证（请说明原因）
  - 当前会话运行于 Windows 环境，无法直接执行 `flutter build macos` 或在 macOS 设备上手动验证 WebView；已完成配置级根因分析与仓库自动化验证。

## 截图 / 录屏（如涉及 UI）
无

## 发布说明（如涉及 Release / 配置 / 依赖）
- macOS `DebugProfile.entitlements` 与 `Release.entitlements` 新增 `com.apple.security.network.client`。
- 该变更会恢复 macOS 沙盒应用对外部网页与官网接口的访问能力。

## 自查清单
- [x] 命名清晰，类型完整
- [x] 注释有效（注释率 20%~50%）
- [x] 无残留调试代码
- [x] 无未说明的 TODO / FIXME
- [x] 相关 `docs/` 已同步更新
- [x] `docs/CHANGELOG.md` 已同步更新（如适用）
- [ ] 依赖 / 工作流变更已说明版本与平台影响
- [ ] 如 PR 目标为 `main`，已确认后续是否需要回合并到 `develop`