### PR TITLE
fix(webview): 过滤官网无效链接

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 ### 修复
 
+- 过滤官网解析中的 `javascript:` 等无效链接，并为 WebView 增加非法 URL 兜底页，避免点击消息时崩溃
 - 将自动打标中的 `release` 标签更名为 `release-files`，避免仓库治理 / 安装器 / Release 配置类 PR 在合并时误触发发布工作流
 - 调整 `develop` / `main` 同步策略：移除导致历史持续分叉的线性历史要求，并明确同步 PR 必须使用 merge commit
 - 统一桌面端退出流程，修复 Windows 点击关闭后选择“退出应用”时窗口未响应、退出失败的问题

--- a/lib/pages/webview_page.dart
+++ b/lib/pages/webview_page.dart
@@ -67,6 +67,13 @@ class _WebViewPageState extends State<WebViewPage> {
     _currentUrl = widget.url;
   }
 
+  /// 判断链接是否可由内嵌 WebView 安全加载。
+  bool _isSupportedWebUrl(String url) {
+    final uri = Uri.tryParse(url.trim());
+    if (uri == null || uri.host.isEmpty) return false;
+    return uri.scheme == 'http' || uri.scheme == 'https';
+  }
+
   /// 更新导航按钮状态（前进/后退可用性）
   Future<void> _updateNavigationState() async {
     if (_controller == null) return;
@@ -83,7 +90,9 @@ class _WebViewPageState extends State<WebViewPage> {
   /// 使用系统默认浏览器打开当前 URL（fallback 方案）
   Future<void> _fallbackToExternalBrowser() async {
     final uri = Uri.tryParse(_currentUrl);
-    if (uri != null) {
+    if (uri != null &&
+        uri.host.isNotEmpty &&
+        (uri.scheme == 'http' || uri.scheme == 'https')) {
       await launchUrl(uri, mode: LaunchMode.externalApplication);
     }
   }
@@ -117,6 +126,42 @@ class _WebViewPageState extends State<WebViewPage> {
                 onPressed: () => Navigator.of(context).pop(),
               ),
             ],
+          ),
+        ),
+      );
+    }
+
+    if (!_isSupportedWebUrl(_currentUrl)) {
+      return ScaffoldPage(
+        header: PageHeader(
+          title: Text(widget.initialTitle),
+          commandBar: IconButton(
+            icon: const Icon(FluentIcons.chrome_back),
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+        ),
+        content: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(FluentIcons.warning, size: 48, color: theme.inactiveColor),
+                const SizedBox(height: 12),
+                Text('链接无效，无法打开', style: theme.typography.bodyStrong),
+                const SizedBox(height: 8),
+                Text(
+                  _currentUrl,
+                  style: theme.typography.caption,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 16),
+                Button(
+                  child: const Text('返回'),
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              ],
+            ),
           ),
         ),
       );

--- a/lib/services/college_news_service.dart
+++ b/lib/services/college_news_service.dart
@@ -1731,6 +1731,7 @@ class CollegeNewsService {
         if (href.isEmpty || title.isEmpty) continue;
 
         final fullUrl = _buildFullUrl(href, 'https://jxxy.sspu.edu.cn');
+        if (fullUrl.isEmpty) continue;
         final messageId = _generateId(fullUrl);
         if (knownMessageIds?.contains(messageId) ?? false) break;
 
@@ -1781,6 +1782,7 @@ class CollegeNewsService {
         if (href.isEmpty || title.isEmpty) continue;
 
         final fullUrl = _buildFullUrl(href, 'https://imce.sspu.edu.cn');
+        if (fullUrl.isEmpty) continue;
         final messageId = _generateId(fullUrl);
         if (knownMessageIds?.contains(messageId) ?? false) break;
 
@@ -1831,6 +1833,7 @@ class CollegeNewsService {
         if (href.isEmpty || title.isEmpty) continue;
 
         final fullUrl = _buildFullUrl(href, 'https://zihuan.sspu.edu.cn');
+        if (fullUrl.isEmpty) continue;
         final messageId = _generateId(fullUrl);
         if (knownMessageIds?.contains(messageId) ?? false) break;
 
@@ -1955,6 +1958,7 @@ class CollegeNewsService {
         if (href.isEmpty || title.isEmpty) continue;
 
         final fullUrl = _buildFullUrl(href, 'https://wywh.sspu.edu.cn');
+        if (fullUrl.isEmpty) continue;
         final messageId = _generateId(fullUrl);
         if (knownMessageIds?.contains(messageId) ?? false) break;
 
@@ -2016,6 +2020,7 @@ class CollegeNewsService {
         if (href.isEmpty || title.isEmpty) continue;
 
         final fullUrl = _buildFullUrl(href, 'https://sltj.sspu.edu.cn');
+        if (fullUrl.isEmpty) continue;
         final messageId = _generateId(fullUrl);
         if (knownMessageIds?.contains(messageId) ?? false) break;
 
@@ -2297,6 +2302,7 @@ class CollegeNewsService {
       if (title.isEmpty || href.isEmpty) continue;
 
       final fullUrl = _buildFullUrl(href, config.baseUrl);
+      if (fullUrl.isEmpty) continue;
       final messageId = _generateId(fullUrl);
       if (knownMessageIds?.contains(messageId) ?? false) break;
 
@@ -2373,6 +2379,7 @@ class CollegeNewsService {
       if (title.isEmpty || href.isEmpty) continue;
 
       final fullUrl = _buildFullUrl(href, config.baseUrl);
+      if (fullUrl.isEmpty) continue;
       final messageId = _generateId(fullUrl);
       if (knownMessageIds?.contains(messageId) ?? false) break;
 
@@ -2425,6 +2432,7 @@ class CollegeNewsService {
       if (href.isEmpty) continue;
 
       final fullUrl = _buildFullUrl(href, config.baseUrl);
+      if (fullUrl.isEmpty) continue;
       final messageId = _generateId(fullUrl);
       if (knownMessageIds?.contains(messageId) ?? false) break;
 
@@ -2492,6 +2500,7 @@ class CollegeNewsService {
       if (href.isEmpty) continue;
 
       final fullUrl = _buildFullUrl(href, config.baseUrl);
+      if (fullUrl.isEmpty) continue;
       final messageId = _generateId(fullUrl);
       if (knownMessageIds?.contains(messageId) ?? false) break;
 
@@ -2543,10 +2552,29 @@ class CollegeNewsService {
 
   // ==================== 工具方法 ====================
 
-  /// 构建完整 URL：相对路径拼接 baseUrl，绝对路径直接返回
+  /// 构建完整 URL：过滤脚本/锚点等无效链接，避免 WebView 加载非法 URL。
   String _buildFullUrl(String href, String baseUrl) {
-    if (href.startsWith('http')) return href;
-    return '$baseUrl$href';
+    final normalizedHref = href.trim();
+    if (normalizedHref.isEmpty) return '';
+
+    final lowerHref = normalizedHref.toLowerCase();
+    if (lowerHref == '#' ||
+        lowerHref.startsWith('#') ||
+        lowerHref.startsWith('javascript:') ||
+        lowerHref.startsWith('mailto:') ||
+        lowerHref.startsWith('tel:')) {
+      return '';
+    }
+
+    final baseUri = Uri.tryParse(baseUrl);
+    if (baseUri == null || !baseUri.hasScheme || baseUri.host.isEmpty) {
+      return '';
+    }
+
+    final resolved = baseUri.resolve(normalizedHref);
+    if (!resolved.hasScheme || resolved.host.isEmpty) return '';
+    if (resolved.scheme != 'http' && resolved.scheme != 'https') return '';
+    return resolved.toString();
   }
 
   /// 基于 URL 生成稳定的消息唯一 ID（MD5 哈希）

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sspu_all_in_one/app.dart';
 import 'package:sspu_all_in_one/main.dart';
+import 'package:sspu_all_in_one/pages/webview_page.dart';
 
 void main() {
   testWidgets('应用启动冒烟测试', (WidgetTester tester) async {
@@ -44,5 +45,21 @@ void main() {
       tester.view.resetPhysicalSize();
       tester.view.resetDevicePixelRatio();
     }
+  });
+
+  testWidgets('WebView 遇到无效链接时显示错误页', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const FluentApp(
+        home: WebViewPage(
+          url: 'https://wywh.sspu.edu.cnjavascript:void(0);',
+          initialTitle: '无效链接',
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 100));
+
+    // 历史缓存中的非法 URL 不应继续传给 WebView 构造器。
+    expect(find.text('链接无效，无法打开'), findsOneWidget);
+    expect(find.text('返回'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## 变更说明
- 过滤官网解析中的 javascript、锚点、mailto、tel 等无效链接
- 使用 Uri.resolve 规范化官网相对链接，避免拼出非法 URL
- WebView 遇到历史缓存中的非法 URL 时显示错误页而不是崩溃
- 增加 WebView 无效链接 widget 回归测试

## 验证
- flutter analyze
- NO_PROXY=localhost,127.0.0.1,::1 flutter test

Closes #54