### PR TITLE
fix(macos): 补齐 Flutter 构建配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,8 +72,6 @@ app.*.map.json
 **/ios/ServiceDefinitions.json
 **/ios/Runner/GeneratedPluginRegistrant.*
 **/macos/Flutter/ephemeral/
-**/macos/Flutter/Flutter-Debug.xcconfig
-**/macos/Flutter/Flutter-Release.xcconfig
 **/macos/Flutter/GeneratedPluginRegistrant.swift
 
 # Linux

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 ### 修复
 
+- 将 macOS Flutter Debug / Release xcconfig wrapper 纳入版本控制，修复新检出后 `flutter run -d macos` 找不到 Flutter 配置文件的问题
 - 过滤官网解析中的 `javascript:` 等无效链接，并为 WebView 增加非法 URL 兜底页，避免点击消息时崩溃
 - 将自动打标中的 `release` 标签更名为 `release-files`，避免仓库治理 / 安装器 / Release 配置类 PR 在合并时误触发发布工作流
 - 调整 `develop` / `main` 同步策略：移除导致历史持续分叉的线性历史要求，并明确同步 PR 必须使用 merge commit

--- a/macos/Flutter/Flutter-Debug.xcconfig
+++ b/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,0 +1,1 @@
+#include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/Flutter-Release.xcconfig
+++ b/macos/Flutter/Flutter-Release.xcconfig
@@ -1,0 +1,1 @@
+#include "ephemeral/Flutter-Generated.xcconfig"


### PR DESCRIPTION
## 变更说明
- 将 macOS Flutter Debug / Release xcconfig wrapper 纳入版本控制
- 保留 ephemeral 生成目录继续忽略，避免提交机器本地构建产物
- 更新 CHANGELOG 记录 macOS dev 构建修复

## 验证
- flutter analyze
- NO_PROXY=localhost,127.0.0.1,::1 flutter test

## 备注
- 当前执行环境是 Windows，无法直接运行 flutter run -d macos；本修复针对 issue 日志中的缺失 xcconfig 文件。

Closes #49