### PR TITLE
fix(wechat): 优化公众号认证诊断

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 ### 修复
 
+- 优化微信公众平台认证状态检测，增加脱敏调试日志和认证状态诊断，避免无效 Token 被误判为可用
 - 将 macOS Flutter Debug / Release xcconfig wrapper 纳入版本控制，修复新检出后 `flutter run -d macos` 找不到 Flutter 配置文件的问题
 - 过滤官网解析中的 `javascript:` 等无效链接，并为 WebView 增加非法 URL 兜底页，避免点击消息时崩溃
 - 将自动打标中的 `release` 标签更名为 `release-files`，避免仓库治理 / 安装器 / Release 配置类 PR 在合并时误触发发布工作流

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -86,6 +86,9 @@ class _SettingsPageState extends State<SettingsPage> {
   /// 公众号平台是否已认证
   bool _wxmpAuthenticated = false;
 
+  /// 公众号平台认证诊断状态。
+  WxmpAuthStatus? _wxmpAuthStatus;
+
   /// 微信推文获取总开关。
   bool _wechatChannelEnabled = false;
 
@@ -143,7 +146,8 @@ class _SettingsPageState extends State<SettingsPage> {
     final dndSM = await _messageState.getDndStartMinute();
     final dndEH = await _messageState.getDndEndHour();
     final dndEM = await _messageState.getDndEndMinute();
-    final wxmpHasAuth = await _wxmpAuth.hasAuth();
+    final wxmpAuthStatus = await _wxmpAuth.getAuthStatus();
+    final wxmpHasAuth = wxmpAuthStatus.isUsable;
     final wechatEnabled = await _messageState.isChannelEnabled(
       'wechat_public',
       defaultValue: false,
@@ -172,6 +176,7 @@ class _SettingsPageState extends State<SettingsPage> {
         _dndEndHour = dndEH;
         _dndEndMinute = dndEM;
         _wxmpAuthenticated = wxmpHasAuth;
+        _wxmpAuthStatus = wxmpAuthStatus;
         _wechatChannelEnabled = wechatEnabled;
         _wechatAutoRefreshEnabled = wechatAutoEnabled;
         _wechatRefreshInterval = wechatInterval;
@@ -1066,6 +1071,15 @@ class _SettingsPageState extends State<SettingsPage> {
                 '通过公众号管理平台 (mp.weixin.qq.com) 获取推文，需拥有公众号（个人订阅号即可）',
                 style: theme.typography.caption,
               ),
+              if (_wxmpAuthStatus != null) ...[
+                const SizedBox(height: FluentSpacing.xs),
+                Text(
+                  _wxmpAuthStatus!.message,
+                  style: theme.typography.caption?.copyWith(
+                    color: theme.resources.textFillColorSecondary,
+                  ),
+                ),
+              ],
               const SizedBox(height: FluentSpacing.m),
 
               // 认证状态
@@ -1374,8 +1388,12 @@ class _SettingsPageState extends State<SettingsPage> {
     );
 
     if (success == true && mounted) {
-      setState(() => _wxmpAuthenticated = true);
-      await _loadWxmpFollowedMps();
+      final authStatus = await _wxmpAuth.getAuthStatus();
+      setState(() {
+        _wxmpAuthenticated = authStatus.isUsable;
+        _wxmpAuthStatus = authStatus;
+      });
+      if (authStatus.isUsable) await _loadWxmpFollowedMps();
       if (mounted) {
         displayInfoBar(
           context,
@@ -1400,6 +1418,10 @@ class _SettingsPageState extends State<SettingsPage> {
     if (mounted) {
       setState(() {
         _wxmpAuthenticated = false;
+        _wxmpAuthStatus = const WxmpAuthStatus(
+          state: WxmpAuthState.missingCookie,
+          lastUpdate: null,
+        );
         _wxmpFollowedMps = [];
         _wxmpSearchResults = [];
       });

--- a/lib/services/wxmp_article_service.dart
+++ b/lib/services/wxmp_article_service.dart
@@ -11,6 +11,7 @@
 import 'dart:convert';
 import 'package:crypto/crypto.dart';
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 
 import '../models/message_item.dart';
 import 'message_state_service.dart';
@@ -49,6 +50,13 @@ class WxmpArticleService {
   static const int _requestDelayMs = 3000;
 
   // ==================== HTTP 请求 ====================
+
+  /// 输出脱敏调试日志；Release 构建不输出。
+  void _debugLog(String message) {
+    if (kDebugMode) {
+      debugPrint('[WxmpArticleService] $message');
+    }
+  }
 
   /// 构造标准请求头
   Future<Map<String, String>> _buildHeaders() async {
@@ -91,8 +99,11 @@ class WxmpArticleService {
     int begin = 0,
     int count = 5,
   }) async {
-    final hasAuth = await _auth.hasAuth();
-    if (!hasAuth) return [];
+    final authStatus = await _auth.getAuthStatus();
+    if (!authStatus.isUsable) {
+      _debugLog('search skipped: ${authStatus.message}');
+      return [];
+    }
 
     final token = await _auth.getToken();
     final headers = await _buildHeaders();
@@ -140,8 +151,11 @@ class WxmpArticleService {
     int page = 0,
     int count = 5,
   }) async {
-    final hasAuth = await _auth.hasAuth();
-    if (!hasAuth) return [];
+    final authStatus = await _auth.getAuthStatus();
+    if (!authStatus.isUsable) {
+      _debugLog('article list skipped: ${authStatus.message}');
+      return [];
+    }
 
     final token = await _auth.getToken();
     final headers = await _buildHeaders();
@@ -203,8 +217,11 @@ class WxmpArticleService {
     int maxCount = 50,
     Set<String>? knownMessageIds,
   }) async {
-    final hasAuth = await _auth.hasAuth();
-    if (!hasAuth) return [];
+    final authStatus = await _auth.getAuthStatus();
+    if (!authStatus.isUsable) {
+      _debugLog('refresh skipped: ${authStatus.message}');
+      return [];
+    }
 
     final followedMps = await getLocalFollowedMps();
     if (followedMps.isEmpty) return [];
@@ -237,12 +254,15 @@ class WxmpArticleService {
           await Future.delayed(const Duration(milliseconds: _requestDelayMs));
         }
       } on WxmpSessionExpiredException {
+        _debugLog('refresh stopped: session expired');
         // Session 过期，停止后续请求
         break;
       } on WxmpFrequencyLimitException {
+        _debugLog('refresh stopped: frequency limited');
         // 频率限制，停止后续请求
         break;
-      } catch (_) {
+      } catch (error) {
+        _debugLog('refresh skipped one account "$mpName": $error');
         // 单个公众号失败不影响其他
         continue;
       }

--- a/lib/services/wxmp_auth_service.dart
+++ b/lib/services/wxmp_auth_service.dart
@@ -9,6 +9,49 @@
 
 import 'storage_service.dart';
 
+/// 公众号平台认证状态。
+enum WxmpAuthState {
+  /// Cookie 和 Token 均可用。
+  ready,
+
+  /// 缺少 Cookie。
+  missingCookie,
+
+  /// 缺少 Token。
+  missingToken,
+
+  /// Token 不是公众平台常见的数字格式。
+  malformedToken,
+}
+
+/// 公众号平台认证诊断结果。
+class WxmpAuthStatus {
+  /// 状态枚举。
+  final WxmpAuthState state;
+
+  /// 最后更新时间。
+  final DateTime? lastUpdate;
+
+  const WxmpAuthStatus({required this.state, required this.lastUpdate});
+
+  /// 是否具备调用公众号平台接口的本地认证条件。
+  bool get isUsable => state == WxmpAuthState.ready;
+
+  /// 面向设置页和调试日志的状态说明，不包含 Cookie 或 Token。
+  String get message {
+    switch (state) {
+      case WxmpAuthState.ready:
+        return '认证信息可用';
+      case WxmpAuthState.missingCookie:
+        return '缺少 Cookie，请重新扫码登录';
+      case WxmpAuthState.missingToken:
+        return '缺少 Token，请重新扫码登录';
+      case WxmpAuthState.malformedToken:
+        return 'Token 格式异常，请重新扫码登录';
+    }
+  }
+}
+
 /// 微信公众号平台认证服务（单例）
 /// 负责 Cookie 和 Token 的存储、读取、校验和清除
 class WxmpAuthService {
@@ -40,14 +83,36 @@ class WxmpAuthService {
     return StorageService.getString(_keyToken);
   }
 
-  /// 检查是否已配置认证
+  /// 检查是否已配置认证。
   Future<bool> hasAuth() async {
+    return (await getAuthStatus()).isUsable;
+  }
+
+  /// 获取认证诊断状态，避免调用侧直接读取敏感字段。
+  Future<WxmpAuthStatus> getAuthStatus() async {
     final cookie = await getCookie();
     final token = await getToken();
-    return cookie != null &&
-        cookie.isNotEmpty &&
-        token != null &&
-        token.isNotEmpty;
+    final lastUpdate = await getLastUpdate();
+
+    if (cookie == null || cookie.trim().isEmpty) {
+      return WxmpAuthStatus(
+        state: WxmpAuthState.missingCookie,
+        lastUpdate: lastUpdate,
+      );
+    }
+    if (token == null || token.trim().isEmpty) {
+      return WxmpAuthStatus(
+        state: WxmpAuthState.missingToken,
+        lastUpdate: lastUpdate,
+      );
+    }
+    if (!RegExp(r'^\d+$').hasMatch(token.trim())) {
+      return WxmpAuthStatus(
+        state: WxmpAuthState.malformedToken,
+        lastUpdate: lastUpdate,
+      );
+    }
+    return WxmpAuthStatus(state: WxmpAuthState.ready, lastUpdate: lastUpdate);
   }
 
   /// 清除所有认证信息

--- a/test/wxmp_auth_service_test.dart
+++ b/test/wxmp_auth_service_test.dart
@@ -1,0 +1,58 @@
+/*
+ * 微信公众号平台认证服务测试 — 校验认证状态诊断
+ * @Project : SSPU-all-in-one
+ * @File : wxmp_auth_service_test.dart
+ * @Author : Qintsg
+ * @Date : 2026-04-22
+ */
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sspu_all_in_one/services/storage_service.dart';
+import 'package:sspu_all_in_one/services/wxmp_auth_service.dart';
+
+void main() {
+  test('缺少 Cookie 或 Token 时返回不可用认证状态', () async {
+    SharedPreferences.setMockInitialValues({});
+    await StorageService.init();
+    final authService = WxmpAuthService.instance;
+
+    await authService.clearAuth();
+    final missingCookie = await authService.getAuthStatus();
+    expect(missingCookie.state, WxmpAuthState.missingCookie);
+    expect(missingCookie.isUsable, isFalse);
+
+    await authService.saveAuth('appmsg_token=abc;', '');
+    final missingToken = await authService.getAuthStatus();
+    expect(missingToken.state, WxmpAuthState.missingToken);
+    expect(missingToken.isUsable, isFalse);
+  });
+
+  test('Token 格式异常时拒绝作为有效认证', () async {
+    SharedPreferences.setMockInitialValues({});
+    await StorageService.init();
+    final authService = WxmpAuthService.instance;
+
+    await authService.saveAuth('appmsg_token=abc;', 'not-a-number');
+    final status = await authService.getAuthStatus();
+
+    // 公众平台 token 正常为数字，异常字符串通常来自提取失败或页面变更。
+    expect(status.state, WxmpAuthState.malformedToken);
+    expect(status.isUsable, isFalse);
+    expect(await authService.hasAuth(), isFalse);
+  });
+
+  test('Cookie 与数字 Token 同时存在时认证可用', () async {
+    SharedPreferences.setMockInitialValues({});
+    await StorageService.init();
+    final authService = WxmpAuthService.instance;
+
+    await authService.saveAuth('appmsg_token=abc;', '123456');
+    final status = await authService.getAuthStatus();
+
+    expect(status.state, WxmpAuthState.ready);
+    expect(status.isUsable, isTrue);
+    expect(await authService.hasAuth(), isTrue);
+    expect(status.message, '认证信息可用');
+  });
+}


### PR DESCRIPTION
## 变更说明
- 增加公众号平台认证诊断状态，区分缺 Cookie、缺 Token、Token 格式异常和可用状态
- 设置页展示认证诊断文案，避免无效 Token 被误判为已认证
- 公众号抓取链路增加 debug 模式脱敏日志，不输出 Cookie/Token
- 增加 WxmpAuthService 单元测试

## 验证
- flutter analyze
- NO_PROXY=localhost,127.0.0.1,::1 flutter test

Closes #53