### PR TITLE
fix(settings): 适配窄屏设置页布局

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 ### 修复
 
+- 设置页在窄屏设备改用顶部下拉切换分区，避免固定左侧导航挤压内容导致移动端出框
 - 优化微信公众平台认证状态检测，增加脱敏调试日志和认证状态诊断，避免无效 Token 被误判为可用
 - 将 macOS Flutter Debug / Release xcconfig wrapper 纳入版本控制，修复新检出后 `flutter run -d macos` 找不到 Flutter 配置文件的问题
 - 过滤官网解析中的 `javascript:` 等无效链接，并为 WebView 增加非法 URL 兜底页，避免点击消息时崩溃

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -274,112 +274,164 @@ class _SettingsPageState extends State<SettingsPage> {
 
     return ScaffoldPage(
       header: const PageHeader(title: Text('设置')),
-      content: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // 左侧垂直导航栏
-          SizedBox(
-            width: 180,
-            child: Padding(
-              padding: const EdgeInsets.only(left: 16, top: 8),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(12, 4, 12, 8),
-                    child: Text(
-                      '系统设置',
-                      style: FluentTheme.of(context).typography.caption
-                          ?.copyWith(
-                            color: FluentTheme.of(
-                              context,
-                            ).resources.textFillColorSecondary,
-                          ),
-                    ),
-                  ),
-                  buildSettingsNavItem(
-                    context: context,
-                    index: 0,
-                    selectedIndex: _selectedTab,
-                    icon: FluentIcons.settings,
-                    label: '常规设置',
-                    onTap: () => setState(() => _selectedTab = 0),
-                  ),
-                  const SizedBox(height: FluentSpacing.xxs),
-                  buildSettingsNavItem(
-                    context: context,
-                    index: 1,
-                    selectedIndex: _selectedTab,
-                    icon: FluentIcons.lock,
-                    label: '安全设置',
-                    onTap: () => setState(() => _selectedTab = 1),
-                  ),
-                  const Padding(
-                    padding: EdgeInsets.symmetric(vertical: 8, horizontal: 12),
-                    child: Divider(),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
-                    child: Text(
-                      '消息推送设置',
-                      style: FluentTheme.of(context).typography.caption
-                          ?.copyWith(
-                            color: FluentTheme.of(
-                              context,
-                            ).resources.textFillColorSecondary,
-                          ),
-                    ),
-                  ),
-                  buildSettingsNavItem(
-                    context: context,
-                    index: 2,
-                    selectedIndex: _selectedTab,
-                    icon: FluentIcons.education,
-                    label: '职能部门',
-                    onTap: () => setState(() => _selectedTab = 2),
-                  ),
-                  const SizedBox(height: FluentSpacing.xxs),
-                  buildSettingsNavItem(
-                    context: context,
-                    index: 3,
-                    selectedIndex: _selectedTab,
-                    icon: FluentIcons.library,
-                    label: '教学单位',
-                    onTap: () => setState(() => _selectedTab = 3),
-                  ),
-                  const SizedBox(height: FluentSpacing.xxs),
-                  buildSettingsNavItem(
-                    context: context,
-                    index: 4,
-                    selectedIndex: _selectedTab,
-                    icon: FluentIcons.chat,
-                    label: '微信推文',
-                    onTap: () => setState(() => _selectedTab = 4),
-                  ),
-                ],
-              ),
-            ),
-          ),
-          // 左侧分隔线
-          const Padding(
-            padding: EdgeInsets.symmetric(vertical: 8),
-            child: Divider(direction: Axis.vertical),
-          ),
-          // 右侧内容区
-          Expanded(
-            child: SingleChildScrollView(
-              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
-              child: _buildContentPanel(context)
-                  .animate(key: ValueKey(_selectedTab))
-                  .fadeIn(
-                    duration: FluentDuration.slow,
-                    curve: FluentEasing.decelerate,
-                  )
-                  .slideY(begin: 0.02, end: 0),
-            ),
-          ),
-        ],
+      content: LayoutBuilder(
+        builder: (context, constraints) {
+          final isNarrow = constraints.maxWidth < 720;
+          return isNarrow
+              ? _buildNarrowSettingsLayout(context)
+              : _buildWideSettingsLayout(context);
+        },
       ),
+    );
+  }
+
+  /// 构建宽屏设置页布局，保留左侧垂直导航。
+  Widget _buildWideSettingsLayout(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 180,
+          child: Padding(
+            padding: const EdgeInsets.only(left: 16, top: 8),
+            child: _buildSettingsNavigation(context),
+          ),
+        ),
+        const Padding(
+          padding: EdgeInsets.symmetric(vertical: 8),
+          child: Divider(direction: Axis.vertical),
+        ),
+        Expanded(
+          child: _buildScrollableContent(
+            const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// 构建窄屏设置页布局，使用顶部下拉选择分区。
+  Widget _buildNarrowSettingsLayout(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+          child: _buildSettingsTabCombo(context),
+        ),
+        const Divider(),
+        Expanded(
+          child: _buildScrollableContent(
+            const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// 构建设置导航栏。
+  Widget _buildSettingsNavigation(BuildContext context) {
+    final theme = FluentTheme.of(context);
+    final captionStyle = theme.typography.caption?.copyWith(
+      color: theme.resources.textFillColorSecondary,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(12, 4, 12, 8),
+          child: Text('系统设置', style: captionStyle),
+        ),
+        buildSettingsNavItem(
+          context: context,
+          index: 0,
+          selectedIndex: _selectedTab,
+          icon: FluentIcons.settings,
+          label: '常规设置',
+          onTap: () => setState(() => _selectedTab = 0),
+        ),
+        const SizedBox(height: FluentSpacing.xxs),
+        buildSettingsNavItem(
+          context: context,
+          index: 1,
+          selectedIndex: _selectedTab,
+          icon: FluentIcons.lock,
+          label: '安全设置',
+          onTap: () => setState(() => _selectedTab = 1),
+        ),
+        const Padding(
+          padding: EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+          child: Divider(),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
+          child: Text('消息推送设置', style: captionStyle),
+        ),
+        buildSettingsNavItem(
+          context: context,
+          index: 2,
+          selectedIndex: _selectedTab,
+          icon: FluentIcons.education,
+          label: '职能部门',
+          onTap: () => setState(() => _selectedTab = 2),
+        ),
+        const SizedBox(height: FluentSpacing.xxs),
+        buildSettingsNavItem(
+          context: context,
+          index: 3,
+          selectedIndex: _selectedTab,
+          icon: FluentIcons.library,
+          label: '教学单位',
+          onTap: () => setState(() => _selectedTab = 3),
+        ),
+        const SizedBox(height: FluentSpacing.xxs),
+        buildSettingsNavItem(
+          context: context,
+          index: 4,
+          selectedIndex: _selectedTab,
+          icon: FluentIcons.chat,
+          label: '微信推文',
+          onTap: () => setState(() => _selectedTab = 4),
+        ),
+      ],
+    );
+  }
+
+  /// 构建窄屏分区下拉框。
+  Widget _buildSettingsTabCombo(BuildContext context) {
+    return Row(
+      children: [
+        const Icon(FluentIcons.global_nav_button, size: 16),
+        const SizedBox(width: FluentSpacing.s),
+        Expanded(
+          child: ComboBox<int>(
+            value: _selectedTab,
+            isExpanded: true,
+            items: const [
+              ComboBoxItem(value: 0, child: Text('常规设置')),
+              ComboBoxItem(value: 1, child: Text('安全设置')),
+              ComboBoxItem(value: 2, child: Text('职能部门')),
+              ComboBoxItem(value: 3, child: Text('教学单位')),
+              ComboBoxItem(value: 4, child: Text('微信推文')),
+            ],
+            onChanged: (value) {
+              if (value != null) setState(() => _selectedTab = value);
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// 构建带动画的滚动内容区。
+  Widget _buildScrollableContent(EdgeInsets padding) {
+    return SingleChildScrollView(
+      padding: padding,
+      child: _buildContentPanel(context)
+          .animate(key: ValueKey(_selectedTab))
+          .fadeIn(duration: FluentDuration.slow, curve: FluentEasing.decelerate)
+          .slideY(begin: 0.02, end: 0),
     );
   }
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -9,9 +9,12 @@
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sspu_all_in_one/app.dart';
 import 'package:sspu_all_in_one/main.dart';
+import 'package:sspu_all_in_one/pages/settings_page.dart';
 import 'package:sspu_all_in_one/pages/webview_page.dart';
+import 'package:sspu_all_in_one/services/storage_service.dart';
 
 void main() {
   testWidgets('应用启动冒烟测试', (WidgetTester tester) async {
@@ -61,5 +64,27 @@ void main() {
     // 历史缓存中的非法 URL 不应继续传给 WebView 构造器。
     expect(find.text('链接无效，无法打开'), findsOneWidget);
     expect(find.text('返回'), findsOneWidget);
+  });
+
+  testWidgets('设置页窄屏使用顶部下拉切换分区', (WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues({});
+    await StorageService.init();
+
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1.0;
+
+    try {
+      await tester.pumpWidget(const FluentApp(home: SettingsPage()));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // 窄屏不渲染固定左侧导航，避免挤压设置内容。
+      expect(find.byType(ComboBox<int>), findsOneWidget);
+      expect(find.text('系统设置'), findsNothing);
+    } finally {
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump(const Duration(milliseconds: 300));
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    }
   });
 }


### PR DESCRIPTION
## 变更说明
- 设置页使用 LayoutBuilder 适配宽窄屏
- 宽屏保留左侧垂直导航，窄屏改为顶部下拉切换分区
- 窄屏内容区缩小横向内边距，避免移动端固定导航挤压内容
- 增加设置页窄屏 widget 回归测试

## 验证
- flutter analyze
- NO_PROXY=localhost,127.0.0.1,::1 flutter test

Closes #45