### PR TITLE
release: v0.2.0-alpha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,6 +215,11 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release'))
     runs-on: ubuntu-latest
+    env:
+      ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+      ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+      ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -233,16 +238,22 @@ jobs:
         run: flutter pub get
 
       - name: 准备 Android release 签名
-        if: ${{ secrets.ANDROID_KEYSTORE_BASE64 != '' && secrets.ANDROID_KEYSTORE_PASSWORD != '' && secrets.ANDROID_KEY_ALIAS != '' && secrets.ANDROID_KEY_PASSWORD != '' }}
         shell: bash
         run: |
-          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > android/app/ci-release.jks
-          cat > android/key.properties <<'EOF'
-          storePassword=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
-          keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}
-          storeFile=app/ci-release.jks
-          EOF
+          if [ -n "$ANDROID_KEYSTORE_BASE64" ] && \
+             [ -n "$ANDROID_KEYSTORE_PASSWORD" ] && \
+             [ -n "$ANDROID_KEY_ALIAS" ] && \
+             [ -n "$ANDROID_KEY_PASSWORD" ]; then
+            printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 --decode > android/app/ci-release.jks
+            cat > android/key.properties <<EOF
+            storePassword=$ANDROID_KEYSTORE_PASSWORD
+            keyPassword=$ANDROID_KEY_PASSWORD
+            keyAlias=$ANDROID_KEY_ALIAS
+            storeFile=app/ci-release.jks
+            EOF
+          else
+            echo "Android release signing secrets are not configured; fallback signing will be used."
+          fi
 
       - name: 构建 Android arm32 / arm64 / x64 APK
         run: flutter build apk --release --target-platform android-arm,android-arm64,android-x64 --split-per-abi


### PR DESCRIPTION
## Release v0.2.0-alpha

### 修复内容
- 修复 `Build & Release` 工作流中 Android 签名步骤直接在 `if:` 中引用 `secrets.*` 导致的 workflow file issue
- 将 secrets 注入调整为 job 级环境变量，并在 shell 脚本内判断是否存在签名材料

### 说明
- 目标分支：`develop`
- 本 PR 不包含新的功能代码，仅修复 release build action

Relates to #70
