### PR TITLE
release: v0.2.0-alpha

### DIFF
--- a/.github/installer/windows-arm64.iss
+++ b/.github/installer/windows-arm64.iss
@@ -3,6 +3,7 @@
 #define AppExeName "sspu_all_in_one.exe"
 #define AppVersion GetEnv("APP_VERSION")
 #define WorkspaceDir GetEnv("GITHUB_WORKSPACE")
+#define BundleDir GetEnv("WINDOWS_ARM64_BUNDLE_DIR")
 
 [Setup]
 AppId={{2E2255D6-4905-4708-A6B7-B3F70E04F3A0}
@@ -17,8 +18,8 @@ OutputBaseFilename=SSPU-All-in-One-v{#AppVersion}-windows-arm64-installer
 Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
-ArchitecturesAllowed=arm64
-ArchitecturesInstallIn64BitMode=arm64
+ArchitecturesAllowed=arm64compatible
+ArchitecturesInstallIn64BitMode=arm64compatible
 SetupIconFile={#WorkspaceDir}\windows\runner\resources\app_icon.ico
 UninstallDisplayIcon={app}\{#AppExeName}
 
@@ -29,7 +30,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "{#WorkspaceDir}\build\windows\arm64\runner\Release\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#BundleDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
 Name: "{autoprograms}\{#AppName}"; Filename: "{app}\{#AppExeName}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,6 +210,19 @@ jobs:
       - name: 构建 Windows arm64
         run: flutter build windows --release
 
+      - name: 定位 Windows arm64 构建目录
+        shell: pwsh
+        run: |
+          $windowsExecutables = Get-ChildItem -Path 'build\windows' -Filter 'sspu_all_in_one.exe' -Recurse
+          if ($windowsExecutables.Count -eq 0) {
+            Get-ChildItem -Path 'build\windows' -Recurse | Select-Object FullName
+            throw '未找到 Windows arm64 构建产物中的主程序。'
+          }
+
+          $bundlePath = $windowsExecutables[0].Directory.FullName
+          "WINDOWS_ARM64_BUNDLE_DIR=$bundlePath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          Write-Host "Windows arm64 bundle path: $bundlePath"
+
       - name: 安装 Inno Setup
         shell: pwsh
         run: choco install innosetup --no-progress -y
@@ -218,14 +231,13 @@ jobs:
         shell: pwsh
         run: |
           $installerCompiler = Join-Path ${env:ProgramFiles(x86)} 'Inno Setup 6\ISCC.exe'
-          $bundlePath = 'build\windows\arm64\runner\Release'
 
           if (-not (Test-Path $installerCompiler)) {
             throw "未找到 Inno Setup 编译器：$installerCompiler"
           }
 
-          if (-not (Test-Path $bundlePath)) {
-            throw "未找到 Windows arm64 构建目录：$bundlePath"
+          if (-not (Test-Path $env:WINDOWS_ARM64_BUNDLE_DIR)) {
+            throw "未找到 Windows arm64 构建目录：$env:WINDOWS_ARM64_BUNDLE_DIR"
           }
 
           New-Item -ItemType Directory -Force -Path dist | Out-Null
@@ -234,7 +246,7 @@ jobs:
       - name: 生成 Windows arm64 Portable ZIP
         shell: pwsh
         run: |
-          $bundlePath = 'build\windows\arm64\runner\Release'
+          $bundlePath = $env:WINDOWS_ARM64_BUNDLE_DIR
           $portableRoot = Join-Path $env:RUNNER_TEMP 'SSPU-All-in-One'
           $portableFile = "dist\SSPU-All-in-One-v${env:APP_VERSION}-windows-arm64-portable.zip"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,15 @@ on:
       - main
       - develop
       - release/**
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: '本次手动发布对应的目标分支（正式版填 main；预发布填 main / develop / release/*）'
+        required: true
+        default: 'develop'
+      release_notes:
+        description: '手动触发时使用的 Release Notes，必须包含标准 7 个章节'
+        required: true
 
 env:
   FLUTTER_VERSION: '3.41.7'
@@ -20,8 +29,11 @@ permissions:
 jobs:
   prepare:
     if: >
-      github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'release')
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.pull_request.merged == true &&
+        contains(github.event.pull_request.labels.*.name, 'release')
+      )
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.release.outputs.version }}
@@ -42,7 +54,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          base_ref='${{ github.event.pull_request.base.ref }}'
+          if [[ '${{ github.event_name }}' == 'workflow_dispatch' ]]; then
+            base_ref='${{ github.event.inputs.base_ref }}'
+          else
+            base_ref='${{ github.event.pull_request.base.ref }}'
+          fi
+
           channel='${{ steps.release.outputs.channel }}'
 
           if [[ "$channel" == "stable" ]]; then
@@ -749,9 +766,16 @@ jobs:
         shell: bash
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
+          MANUAL_RELEASE_NOTES: ${{ github.event.inputs.release_notes }}
         run: |
           set -euo pipefail
-          printf '%s' "$PR_BODY" > pr-body.md
+
+          if [[ '${{ github.event_name }}' == 'workflow_dispatch' ]]; then
+            printf '%s' "$MANUAL_RELEASE_NOTES" > pr-body.md
+          else
+            printf '%s' "$PR_BODY" > pr-body.md
+          fi
+
           python scripts/release/render_release_notes.py \
             --body-file pr-body.md \
             --output dist/release-notes.md

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -109,6 +109,7 @@
 - Release 工作流新增 Windows arm64、Linux arm64 正式构建与打包步骤，删除独立实验性架构发布分叉
 - 预发布 Release 的目标分支约束调整为允许 `main`、`develop` 与 `release/*`，并同步到 CI、Release workflow 与仓库模板
 - 依赖升级：`package_info_plus` 升级到 `10.1.0`，并同步刷新锁文件中的 `package_info_plus_platform_interface` 与 `win32`
+- `Build & Release` 工作流新增 `workflow_dispatch` 手动触发入口，支持显式传入目标分支与 Release Notes
 
 ### 修复
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -114,6 +114,8 @@
 
 - 修复 Release 工作流中的 macOS DMG 打包路径错误，改为自动发现真实 `.app` 产物
 - 修复 Windows 安装器编译依赖宿主机缺失中文语言文件导致的发布失败
+- 修复 Windows arm64 Release 安装器脚本中的 Inno Setup 架构标识，改用 `arm64compatible` 以匹配当前编译器支持的架构名称
+- 修复 Windows arm64 Release workflow 对 Flutter 输出目录的硬编码假设，改为构建后自动定位主程序目录并传入 Inno Setup
 - 暂时收敛未验证的 Windows arm64 / Linux arm64 桌面发布矩阵，避免 Release 因官方 Flutter SDK 架构解析失败而整体中断
 - 修复 macOS Runner 的 Xcode 配置引用错误，恢复 Flutter 生成配置与 CocoaPods 支持文件的正确加载，解决 `flutter build macos` 编译失败问题
 - 修复 Android 启动阶段调用桌面插件导致黑屏闪退的问题，并同步 Android / iOS / macOS / Linux / Web 的应用名称与图标资源


### PR DESCRIPTION
## 亮点
- 统一仓库发布规则，发布版本号、Tag、资产命名、Release Notes、校验文件与元数据统一从 `pubspec.yaml` 和发布脚本生成。
- 公开 Release 资产覆盖 Android universal APK、Windows x64 / arm64 installer 与 portable、macOS universal unsigned DMG、Linux x64 / arm64 的 AppImage / deb / rpm / portable，以及 Web static.zip。
- Windows arm64 Release workflow 已修复 SDK 安装、构建产物目录定位与 Inno Setup 安装器架构标识问题。

## 破坏性变更
- 无破坏性变更。

## 平台清单
- Android：`SSPU-All-in-One-v0.2.0-alpha+1-android-universal.apk`
- Windows x64 / arm64：installer 与 portable 同时发布。
- macOS universal：公开 Release 提供 unsigned DMG。
- Linux x64 / arm64：同时提供 AppImage、deb、rpm、portable tar.gz。
- Web：提供 `static.zip` 静态站点压缩包。
- iOS：默认不进入公开 GitHub Release，本次仍不作为公开发布资产。

## 安装 / 升级说明
- 新装用户：按平台下载对应安装包或便携包即可使用，Android 优先使用 universal APK，Windows 优先使用 installer，Web 使用 `static.zip` 部署到静态服务器。
- 升级用户：桌面端建议覆盖安装或替换到同一应用目录；Android 建议直接覆盖安装同签名 APK；Web 建议整体替换站点目录后刷新缓存。
- 是否需要清理旧配置：默认不需要。若历史版本存在本地状态异常，可在升级前备份并按需清理 `~/.sspu-all-in-one/` 中的状态文件。

## Linux 安装说明
- Debian / Ubuntu / Linux Mint / Deepin / UOS 用户优先使用 `.deb`。
- Fedora / openSUSE / RHEL 系用户优先使用 `.rpm`。
- 需要免安装时优先使用 `.AppImage`，首次运行前如缺少执行权限请执行 `chmod +x`。
- 无法直接安装或需要手工部署时使用 `.tar.gz`，解压后从应用目录直接运行 `sspu_all_in_one`。

## 已知问题
- macOS 当前公开资产为 unsigned DMG，首次运行可能需要在系统安全设置中手动放行。
- iOS 仍未纳入公开 Release；如需内部测试，需另行处理签名与分发。
- 桌面端部分第三方依赖仍会在构建日志中输出 warning，但当前不影响仓库内公开 Release 资产生成。

## 校验信息
- 合并后 Release 将自动附带 `SHA256SUMS.txt`，用于校验所有公开资产的 SHA-256。
- 合并后 Release 将自动附带 `manifest.json`，包含版本、通道、Tag、发布日期、工具链版本与各平台资产元数据。
- 合并后 Release 将自动生成 `release-notes.md`，其内容与 GitHub Release 正文保持一致。

Relates to #70
