### PR TITLE
release: v0.2.0-alpha

### DIFF
--- a/.github/installer/windows-arm64.iss
+++ b/.github/installer/windows-arm64.iss
@@ -18,8 +18,8 @@ OutputBaseFilename=SSPU-All-in-One-v{#AppVersion}-windows-arm64-installer
 Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
-ArchitecturesAllowed=arm64compatible
-ArchitecturesInstallIn64BitMode=arm64compatible
+ArchitecturesAllowed=arm64
+ArchitecturesInstallIn64BitMode=arm64
 SetupIconFile={#WorkspaceDir}\windows\runner\resources\app_icon.ico
 UninstallDisplayIcon={app}\{#AppExeName}
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -115,7 +115,7 @@
 
 - 修复 Release 工作流中的 macOS DMG 打包路径错误，改为自动发现真实 `.app` 产物
 - 修复 Windows 安装器编译依赖宿主机缺失中文语言文件导致的发布失败
-- 修复 Windows arm64 Release 安装器脚本中的 Inno Setup 架构标识，改用 `arm64compatible` 以匹配当前编译器支持的架构名称
+- 修复 Windows arm64 Release 安装器脚本中的 Inno Setup 架构标识，恢复为当前编译器支持的 `arm64`
 - 修复 Windows arm64 Release workflow 对 Flutter 输出目录的硬编码假设，改为构建后自动定位主程序目录并传入 Inno Setup
 - 暂时收敛未验证的 Windows arm64 / Linux arm64 桌面发布矩阵，避免 Release 因官方 Flutter SDK 架构解析失败而整体中断
 - 修复 macOS Runner 的 Xcode 配置引用错误，恢复 Flutter 生成配置与 CocoaPods 支持文件的正确加载，解决 `flutter build macos` 编译失败问题


### PR DESCRIPTION
## 亮点
- 统一仓库发布规则，发布版本号、Tag、资产命名、Release Notes、校验文件与元数据统一从 `pubspec.yaml` 和发布脚本生成。
- 公开 Release 资产覆盖 Android universal APK、Windows x64 / arm64 installer 与 portable、macOS universal unsigned DMG、Linux x64 / arm64 的 AppImage / deb / rpm / portable，以及 Web static.zip。
- 修复 Windows arm64 安装器失败问题：保留构建目录自动定位逻辑，并将 Inno Setup 架构标识恢复为当前编译器支持的 `arm64`。

## 破坏性变更
- 无破坏性变更。

## 平台清单
- Android：`SSPU-All-in-One-v0.2.0-alpha+1-android-universal.apk`
- Windows x64 / arm64：installer 与 portable 同时发布。
- macOS universal：公开 Release 提供 unsigned DMG。
- Linux x64 / arm64：同时提供 AppImage、deb、rpm、portable tar.gz。
- Web：提供 `static.zip` 静态站点压缩包。
- iOS：默认不进入公开 GitHub Release，本次仍不作为公开发布资产。

## 安装 / 升级说明
- 新装用户：按平台下载对应安装包或便携包即可使用，Android 优先使用 universal APK，Windows 优先使用 installer，Web 使用 `static.zip` 部署到静态服务器。
- 升级用户：桌面端建议覆盖安装或替换到同一应用目录；Android 建议直接覆盖安装同签名 APK；Web 建议整体替换站点目录后刷新缓存。
- 是否需要清理旧配置：默认不需要。若历史版本存在本地状态异常，可在升级前备份并按需清理 `~/.sspu-all-in-one/` 中的状态文件。

## Linux 安装说明
- Debian / Ubuntu / Linux Mint / Deepin / UOS 用户优先使用 `.deb`。
- Fedora / openSUSE / RHEL 系用户优先使用 `.rpm`。
- 需要免安装时优先使用 `.AppImage`，首次运行前如缺少执行权限请执行 `chmod +x`。
- 无法直接安装或需要手工部署时使用 `.tar.gz`，解压后从应用目录直接运行 `sspu_all_in_one`。

## 已知问题
- macOS 当前公开资产为 unsigned DMG，首次运行可能需要在系统安全设置中手动放行。
- iOS 仍未纳入公开 Release；如需内部测试，需另行处理签名与分发。
- 桌面端部分第三方依赖仍会在构建日志中输出 warning，但当前不影响仓库内公开 Release 资产生成。

## 校验信息
- 合并后 Release 将自动附带 `SHA256SUMS.txt`，用于校验所有公开资产的 SHA-256。
- 合并后 Release 将自动附带 `manifest.json`，包含版本、通道、Tag、发布日期、工具链版本与各平台资产元数据。
- 合并后 Release 将自动生成 `release-notes.md`，其内容与 GitHub Release 正文保持一致。

Relates to #70
