### PR TITLE
ci(release): 修复 Windows arm64 构建 JDK 架构

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
+      - uses: actions/setup-java@v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+          architecture: x64
+
       - name: 安装 Flutter arm64 SDK
         shell: pwsh
         run: |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 修复
 
 - 修复 Android 启动前等待本地状态目录、通知和自动刷新初始化导致首帧无法渲染、界面纯白的问题
+- 修复 Windows arm64 Release 构建中 JDK 架构与 Flutter Windows toolchain 不一致导致 `jni` 插件链接失败的问题
 
 ## [0.2.1-alpha] - 2026-04-23
 


### PR DESCRIPTION
## 变更说明

修复 Windows arm64 Release 构建时 JDK 架构与 Flutter Windows toolchain 不一致的问题。

具体调整：
- 在 `build-windows-arm64` job 中显式安装 Temurin JDK 21 x64
- 避免 `jni` 插件在 x64 Windows 构建中链接到 arm64 `jvm.lib`
- 同步更新变更日志

## 关联 Issue

Closes #82

## 检查清单

- [x] 已完成自测
- [x] 没有提交无关文件
- [x] 没有引入敏感信息

## 验证记录

- [x] `flutter analyze`
- [x] 本地检查 Release workflow 中已包含 `actions/setup-java@v5.2.0` 与 `architecture: x64`
