### PR TITLE
fix(macos): 修复未签名 DMG 启动失败

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,6 +323,13 @@ jobs:
             exit 1
           }
 
+          codesign --verify --deep --strict --verbose=2 "$macos_app_bundle"
+
+          if codesign -d --entitlements :- "$macos_app_bundle" 2>/dev/null | grep -Eq 'com\.apple\.security\.|keychain-access-groups'; then
+            echo "unsigned macOS 产物不得携带 App Sandbox 或 Keychain Access Groups 等受限 entitlement。" >&2
+            exit 1
+          fi
+
           hdiutil create \
             -volname "SSPU All-in-One" \
             -srcfolder "$macos_app_bundle" \

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 修复
 
+- macOS unsigned Release 移除受限 entitlement，并在打包前校验签名状态，修复 ad-hoc 签名 DMG 被 AMFI 拒绝启动的问题
 - macOS 启动阶段托盘初始化失败时降级为无托盘模式，避免托盘异常中断主窗口启动导致应用无法打开
 - macOS 托盘图标路径补充 App.framework 与 Resources 下的 Flutter assets 候选路径，并保留跨平台回退路径
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -284,6 +284,7 @@ SSPU-All-in-One-v0.2.0+1-web-universal-static.zip
 3. 若必须提供未签名产物，命名应使用 `unsigned`
 4. 当前仓库自动化默认产出未签名 DMG，因此公开 Release 资产使用：
    `SSPU-All-in-One-v{version}-macos-universal-unsigned.dmg`
+5. unsigned DMG 的 Release 构建不得携带 App Sandbox、Keychain Access Groups 等受限 entitlement；若改为 Developer ID 签名与公证，必须同步调整签名配置、产物命名和发布说明
 
 ### 7.4 Linux
 

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.network.client</key>
-	<true/>
-	<key>keychain-access-groups</key>
-	<array/>
-</dict>
+<dict/>
 </plist>

--- a/test/macos_release_entitlements_test.dart
+++ b/test/macos_release_entitlements_test.dart
@@ -1,0 +1,23 @@
+/*
+ * macOS Release entitlement 配置回归测试
+ * @Project : SSPU-all-in-one
+ * @File : macos_release_entitlements_test.dart
+ * @Author : Qintsg
+ * @Date : 2026-04-26
+ */
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('unsigned macOS release 不携带受限 entitlement', () {
+    final releaseEntitlements = File(
+      'macos/Runner/Release.entitlements',
+    ).readAsStringSync();
+
+    // 当前公开 macOS 产物为 unsigned DMG，受限 entitlement 会导致 AMFI 拒绝启动。
+    expect(releaseEntitlements, isNot(contains('com.apple.security.')));
+    expect(releaseEntitlements, isNot(contains('keychain-access-groups')));
+  });
+}


### PR DESCRIPTION
## Summary
- 移除 macOS unsigned Release 的受限 entitlement，避免 ad-hoc 签名产物被 AMFI 拒绝启动。
- 在 Release workflow 打包 DMG 前校验签名和 forbidden entitlements。
- 补充回归测试与发布文档说明。

## Tests
- `flutter test test/macos_release_entitlements_test.dart`
- `flutter analyze`
- `flutter test`
- `git diff --check`

Closes #133