### PR TITLE
chore(release): 发布 0.2.3-alpha+1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,20 @@
 
 ---
 
+## [0.2.3-alpha+1] - 2026-04-26
+
+### 修复
+
+- macOS unsigned Release 移除受限 entitlement，并在打包前校验签名状态，修复 ad-hoc 签名 DMG 被 AMFI 拒绝启动的问题
+
+### 文档
+
+- 补充 alpha 版本自动发布流程、Release PR 要求和失败后递增构建号重发规则
+
+### 发布
+
+- 以 `0.2.3-alpha+1` 发布 alpha 构建批次，使用 `v0.2.3-alpha` Tag，并通过完整版本号区分发布产物
+
 ## [0.2.2-alpha+4] - 2026-04-25
 
 ### 新增
@@ -14,7 +28,6 @@
 
 ### 修复
 
-- macOS unsigned Release 移除受限 entitlement，并在打包前校验签名状态，修复 ad-hoc 签名 DMG 被 AMFI 拒绝启动的问题
 - macOS 启动阶段托盘初始化失败时降级为无托盘模式，避免托盘异常中断主窗口启动导致应用无法打开
 - macOS 托盘图标路径补充 App.framework 与 Resources 下的 Flutter assets 候选路径，并保留跨平台回退路径
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -71,6 +71,21 @@ version: MAJOR.MINOR.PATCH[-CHANNEL]+BUILD
 4. 紧急修复优先使用 `hotfix/*`，修复完成后同时回合到 `main` 与 `develop`
 5. 公开 Release 由目标分支满足上述规则、且带 `release` 标签的 PR merge 自动触发
 
+### 3.3 Alpha 版本自动发布流程
+
+Alpha 版本默认从 `develop` 发起，并通过 Release PR merge 后自动触发公开 Release：
+
+1. 确认 `develop` 已同步远端且工作区干净
+2. 从 `develop` 签出 `release/v{version}` 分支，例如 `release/v0.2.3-alpha+1`
+3. 将 `pubspec.yaml` 中的 `version` 修改为不带前缀 `v` 的完整版本号，例如 `0.2.3-alpha+1`
+4. 在 `docs/CHANGELOG.md` 顶部新增对应版本章节，写清新增、修复、文档和发布说明
+5. 提交版本与文档变更，并推送 `release/v{version}` 分支到远端
+6. 使用 `.github/PULL_REQUEST_TEMPLATE/release.md` 创建目标分支为 `develop` 的 Release PR
+7. 在 Release PR 正文中完整填写 `## 发布说明` 下的真实内容，不保留模板占位文本
+8. 给 Release PR 添加 `release` 标签，等待 CI 通过后再 merge
+9. Release PR merge 后，`Build & Release` workflow 自动开始构建并发布 alpha Release，通常需要 10 到 15 分钟
+10. 若 workflow 失败，则本轮不会发布 GitHub Release；根据失败内容修复后，将版本号的 `+BUILD` 递增 1，并重新走完整 Release PR 流程
+
 ---
 
 ## 4. 发布类型

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.2.2-alpha+4
+version: 0.2.3-alpha+1
 
 environment:
   sdk: ^3.11.5


### PR DESCRIPTION
# Release Pull Request

## 背景与目标
发布 SSPU All-in-One `0.2.3-alpha+1`，验证 macOS unsigned DMG 启动修复，并沉淀 alpha 自动发布流程。

## 关联事项
- 无

## 发布信息
- 版本号：`0.2.3-alpha+1`
- Git Tag：`v0.2.3-alpha`
- 发布通道：alpha
- [ ] stable：正式发布
- [x] alpha：早期预发布
- [ ] beta：测试版
- [ ] rc：候选发布版

## 发布类型
- [ ] 正式发布
- [x] 预发布
- [ ] 热修复发布
- [ ] 重新发布
- [ ] 仅更新构建产物 / Release 说明

## 影响范围
- [ ] Flutter 前端（`lib/`）
- [ ] 平台工程（Android / iOS / macOS / Linux / Windows / Web）
- [ ] 依赖 / 工具链
- [x] GitHub 工作流 / Release
- [x] 安装包 / 构建产物
- [x] 文档
- [ ] 其他：

## 风险与回滚
- 风险等级：低
- 主要风险：跨平台 Release 构建仍依赖 GitHub Actions runner 环境，若构建失败不会发布 GitHub Release。
- 回滚方案：关闭失败 PR 或废弃失败 Release；如 merge 后构建失败，修复后递增 build number 并重新创建 Release PR。

## 验证记录
- [x] `flutter analyze`
- [x] `flutter test`
- [ ] Android 构建验证
- [ ] Windows 构建验证
- [ ] macOS 构建验证
- [ ] Linux 构建验证
- [ ] Web 构建验证
- [ ] 手动验证（请补充关键路径）
- [x] 未执行部分验证（平台 release build 由 merge 后 Build & Release workflow 执行）

## 发布触发说明
- [x] 本 PR 需要在 merge 后触发公开 Release，并已人工添加 `release` 标签
- [ ] 如为正式发布，目标分支为 `main`
- [x] 如为预发布，目标分支为 `develop`
- [x] 已确认 `pubspec.yaml` 中的版本号符合发布规范
- [x] 已确认 build number 已递增

## 截图 / 录屏（如涉及 UI）
无

---

## 发布说明

## 亮点
- 发布 `0.2.3-alpha+1`，集中验证 macOS unsigned DMG 启动修复。
- 文档补充 alpha 自动发版流程，明确 Release PR、CI、merge 和失败重发规则。

## 新增
- 新增 alpha 版本自动发布流程说明，记录从 `develop` 签出 `release/v{version}`、创建目标分支为 `develop` 的 Release PR、添加 `release` 标签和等待自动发布的步骤。

## 修复
- 修复 macOS unsigned DMG 携带受限 entitlement 导致 ad-hoc 签名产物被 AMFI 拒绝启动的问题。

## 优化
- 优化发布流程文档，明确 Build & Release workflow 失败时不发布 Release，后续需递增 `+BUILD` 后重新走 Release PR 流程。

## 破坏性变更
- 无破坏性变更。

## 安装 / 升级说明
- 新装用户：从 GitHub Release 下载对应平台产物安装或解压使用。
- 升级用户：下载 `0.2.3-alpha+1` 对应平台产物覆盖安装或替换旧版本。
- 是否需要清理旧配置：不需要。

## 已知问题
- macOS DMG 仍为 unsigned 产物，首次运行可能需要用户在系统安全设置中确认打开。