### PR TITLE
fix(release): 发布 0.2.3-alpha+2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,9 +323,13 @@ jobs:
             exit 1
           }
 
+          # Flutter/Xcode 可能在最终签名中残留 sandbox 相关 entitlement，打包前统一剥离。
+          codesign --force --deep --sign - "$macos_app_bundle"
           codesign --verify --deep --strict --verbose=2 "$macos_app_bundle"
 
-          if codesign -d --entitlements :- "$macos_app_bundle" 2>/dev/null | grep -Eq 'com\.apple\.security\.|keychain-access-groups'; then
+          app_entitlements="$(codesign -d --entitlements :- "$macos_app_bundle" 2>/dev/null || true)"
+          if printf '%s\n' "$app_entitlements" | grep -Eq 'com\.apple\.security\.|keychain-access-groups'; then
+            printf '%s\n' "$app_entitlements" >&2
             echo "unsigned macOS 产物不得携带 App Sandbox 或 Keychain Access Groups 等受限 entitlement。" >&2
             exit 1
           fi

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,24 @@
 
 ---
 
+## [0.2.3-alpha+2] - 2026-04-26
+
+### 修复
+
+- Release workflow 在打包 macOS unsigned DMG 前重新 ad-hoc 签名 `.app`，剥离 Flutter/Xcode 构建后残留的受限 entitlement
+
+### 测试
+
+- 补充 macOS Release workflow 回归测试，确保打包前先清理签名权限再执行 entitlement 拦截
+
+### 文档
+
+- 补充 macOS unsigned DMG 打包前重新 ad-hoc 签名的发布约束
+
+### 发布
+
+- 以 `0.2.3-alpha+2` 重新发布 alpha 构建批次，使用 `v0.2.3-alpha` Tag，并通过完整版本号区分新产物
+
 ## [0.2.3-alpha+1] - 2026-04-26
 
 ### 修复
@@ -18,7 +36,7 @@
 
 ### 发布
 
-- 以 `0.2.3-alpha+1` 发布 alpha 构建批次，使用 `v0.2.3-alpha` Tag，并通过完整版本号区分发布产物
+- 尝试以 `0.2.3-alpha+1` 发布 alpha 构建批次；因 macOS DMG entitlement 校验失败，未生成 GitHub Release
 
 ## [0.2.2-alpha+4] - 2026-04-25
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -300,6 +300,7 @@ SSPU-All-in-One-v0.2.0+1-web-universal-static.zip
 4. 当前仓库自动化默认产出未签名 DMG，因此公开 Release 资产使用：
    `SSPU-All-in-One-v{version}-macos-universal-unsigned.dmg`
 5. unsigned DMG 的 Release 构建不得携带 App Sandbox、Keychain Access Groups 等受限 entitlement；若改为 Developer ID 签名与公证，必须同步调整签名配置、产物命名和发布说明
+6. unsigned DMG 打包前必须对 `.app` 重新 ad-hoc 签名，确保 Flutter/Xcode 构建后残留的受限 entitlement 被剥离
 
 ### 7.4 Linux
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.2.3-alpha+1
+version: 0.2.3-alpha+2
 
 environment:
   sdk: ^3.11.5

--- a/test/macos_release_entitlements_test.dart
+++ b/test/macos_release_entitlements_test.dart
@@ -20,4 +20,19 @@ void main() {
     expect(releaseEntitlements, isNot(contains('com.apple.security.')));
     expect(releaseEntitlements, isNot(contains('keychain-access-groups')));
   });
+
+  test('macOS DMG 打包前重新 ad-hoc 签名清理残留 entitlement', () {
+    final releaseWorkflow = File('.github/workflows/release.yml').readAsStringSync();
+
+    // Release workflow 必须先剥离构建产物签名中的残留权限，再执行发布前拦截。
+    final adHocSigningIndex = releaseWorkflow.indexOf(
+      'codesign --force --deep --sign -',
+    );
+    final entitlementCheckIndex = releaseWorkflow.indexOf(
+      'unsigned macOS 产物不得携带',
+    );
+
+    expect(adHocSigningIndex, greaterThanOrEqualTo(0));
+    expect(entitlementCheckIndex, greaterThan(adHocSigningIndex));
+  });
 }


### PR DESCRIPTION
# Release Pull Request

## 背景与目标
重发 SSPU All-in-One `0.2.3-alpha+2` alpha 版本，修复上一轮 `0.2.3-alpha+1` 在 macOS DMG 打包阶段暴露的 entitlement 校验失败。

## 关联事项
- 无

## 发布信息
- 版本号：`0.2.3-alpha+2`
- Git Tag：`v0.2.3-alpha`
- 发布通道：alpha
- [ ] stable：正式发布
- [x] alpha：早期预发布
- [ ] beta：测试版
- [ ] rc：候选发布版

## 发布类型
- [ ] 正式发布
- [x] 预发布
- [ ] 热修复发布
- [x] 重新发布
- [ ] 仅更新构建产物 / Release 说明

## 影响范围
- [ ] Flutter 前端（`lib/`）
- [x] 平台工程（Android / iOS / macOS / Linux / Windows / Web）
- [ ] 依赖 / 工具链
- [x] GitHub 工作流 / Release
- [x] 安装包 / 构建产物
- [x] 文档
- [ ] 其他：

## 风险与回滚
- 风险等级：低
- 主要风险：macOS 产物仍为 unsigned DMG，首次运行仍需用户按系统安全策略确认打开。
- 回滚方案：若 Build & Release 失败，不会发布 GitHub Release；根据失败内容修复后继续递增 `+BUILD` 并重新创建 Release PR。

## 验证记录
- [x] `flutter analyze`
- [x] `flutter test`
- [ ] Android 构建验证
- [ ] Windows 构建验证
- [ ] macOS 构建验证
- [ ] Linux 构建验证
- [ ] Web 构建验证
- [ ] 手动验证（请补充关键路径）
- [x] 未执行部分验证（平台 release build 由 merge 后 Build & Release workflow 执行）

## 发布触发说明
- [x] 本 PR 需要在 merge 后触发公开 Release，并已人工添加 `release` 标签
- [ ] 如为正式发布，目标分支为 `main`
- [x] 如为预发布，目标分支为 `develop`
- [x] 已确认 `pubspec.yaml` 中的版本号符合发布规范
- [x] 已确认 build number 已递增

## 截图 / 录屏（如涉及 UI）
无

---

## 发布说明

## 亮点
- 重发 `0.2.3-alpha+2`，修复 `0.2.3-alpha+1` 在 macOS DMG 打包阶段发现的残留 entitlement 问题。
- macOS unsigned DMG 打包前会重新 ad-hoc 签名 `.app`，再执行受限 entitlement 拦截。

## 新增
- 新增 macOS Release workflow 回归测试，覆盖打包前重新 ad-hoc 签名和后续 entitlement 校验顺序。

## 修复
- 修复 Flutter/Xcode 构建后的 macOS `.app` 仍残留受限 entitlement，导致 unsigned DMG 打包前校验失败的问题。

## 优化
- 优化 macOS unsigned DMG 发布流程，校验失败时输出实际 entitlement 内容便于后续排查。
- 更新发布文档，明确 unsigned DMG 打包前必须重新 ad-hoc 签名剥离残留权限。

## 破坏性变更
- 无破坏性变更。

## 安装 / 升级说明
- 新装用户：从 GitHub Release 下载对应平台产物安装或解压使用。
- 升级用户：下载 `0.2.3-alpha+2` 对应平台产物覆盖安装或替换旧版本。
- 是否需要清理旧配置：不需要。

## 已知问题
- macOS DMG 仍为 unsigned 产物，首次运行可能需要用户在系统安全设置中确认打开。