### PR TITLE
chore(deps): 升级依赖并修复 Windows 退出流程

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,10 @@
 - 补充改名后的签名边界：Android 现有 keystore 可继续签名新包名产物但不构成旧包名原地升级；Apple Bundle ID 迁移后需要新的 App ID 与 provisioning profile。
 - 补充隐私协议对本地状态文件、系统安全存储、WebView2 运行态、外部服务访问和用户清理方式的说明。
 
+### 依赖
+
+- 升级可解析到最新版本的 Flutter 依赖锁定项：`flutter_secure_storage_windows`、`json_annotation`、`url_launcher_web`、`vm_service`、`win32`。
+
 ## [0.2.5-alpha+1] - 2026-05-15
 
 ### 发布

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,11 @@
 - 项目名称统一迁移为 `SSPU-AllinOne`，同步更新 Dart 包名、Android / Apple / Linux 应用身份、Windows / Linux 主程序名、Release 资产命名、前端展示文案、仓库文档链接与发布元数据。
 - 首次启动确认从单一使用协议扩展为使用协议与隐私协议，并使用当前协议版本键触发既有用户重新确认。
 
+### 修复
+
+- 修复 Windows 构建缓存保留旧项目路径时 `flutter run -d windows` 无法重新生成 CMake 构建文件的问题；清理 `build/windows` 后会按当前目录重新配置。
+- 兼容 Visual Studio 18 / MSVC 14.51 对 `<experimental/coroutine>` 的弃用阻断，避免 Windows 插件编译时因旧协程头静态断言失败。
+
 ### 文档
 
 - 补充改名后的签名边界：Android 现有 keystore 可继续签名新包名产物但不构成旧包名原地升级；Apple Bundle ID 迁移后需要新的 App ID 与 provisioning profile。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,8 @@
 - 修复 Windows 构建缓存保留旧项目路径时 `flutter run -d windows` 无法重新生成 CMake 构建文件的问题；清理 `build/windows` 后会按当前目录重新配置。
 - 兼容 Visual Studio 18 / MSVC 14.51 对 `<experimental/coroutine>` 的弃用阻断，避免 Windows 插件编译时因旧协程头静态断言失败。
 - 修复首页、信息中心、设置页等 surface 组件在窗口约束变化时可能一闪而过的 `Cannot interpolate between finite constraints and unbounded constraints` 运行时异常。
+- 将 Windows WebView2 环境改为首次打开内嵌网页时懒加载，并在退出流程中显式释放已创建环境，避免未打开 WebView 时关闭应用仍触发 Chromium 窗口类清理报错。
+- 优化桌面端退出顺序：关闭应用时优先隐藏前端窗口，再在后台限时释放 WebView2、托盘和窗口管理资源，降低退出时用户可见卡顿。
 
 ### 文档
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 - 修复 Windows 构建缓存保留旧项目路径时 `flutter run -d windows` 无法重新生成 CMake 构建文件的问题；清理 `build/windows` 后会按当前目录重新配置。
 - 兼容 Visual Studio 18 / MSVC 14.51 对 `<experimental/coroutine>` 的弃用阻断，避免 Windows 插件编译时因旧协程头静态断言失败。
+- 修复首页、信息中心、设置页等 surface 组件在窗口约束变化时可能一闪而过的 `Cannot interpolate between finite constraints and unbounded constraints` 运行时异常。
 
 ### 文档
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -429,16 +429,26 @@ flutter doctor -v
 # flutter create .
 ```
 
-### 10.3 fluent_ui 编译问题
+### 10.3 Windows CMake 缓存路径错误
 
-确认 Flutter SDK 版本与 fluent_ui 版本兼容：
+如果项目目录改名后运行 `flutter run -d windows`，并出现 `CMakeCache.txt directory ... is different` 或 `source ... does not match`，说明 `build/windows` 中仍保留旧源码路径缓存。删除可再生缓存后重新构建即可：
+
+```bash
+rm -rf build/windows
+flutter pub get
+flutter run -d windows
+```
+
+### 10.4 Material 3 组件编译问题
+
+确认 Flutter SDK 版本满足 `pubspec.yaml` 的最低要求，并避免重新引入已移除的外部 Fluent UI 依赖：
 
 ```bash
 flutter --version
-flutter pub deps | Select-String "fluent_ui"
+flutter analyze
 ```
 
-### 10.4 Android release 构建失败
+### 10.5 Android release 构建失败
 
 若 `flutter build apk --release` 提示缺少签名配置，请检查：
 
@@ -446,7 +456,7 @@ flutter pub deps | Select-String "fluent_ui"
 - `storeFile` 是否指向实际存在的 keystore 文件
 - `storePassword` / `keyPassword` / `keyAlias` 是否与 keystore 一致
 
-### 10.5 本地状态文件异常
+### 10.6 本地状态文件异常
 
 桌面端会将用户设置、认证信息、消息缓存和 WebView2 运行态写入 `~/.sspu-all-in/`；Android / iOS 会写入系统分配的应用支持目录。设置页提供 `wxmp_config.toml` 内置编辑器，移动端可直接在应用内修改公众号平台认证配置。教务凭据使用系统安全存储单独保存，不写入 `app_state.json`，安全设置页只显示学工号和密码填写状态。若状态文件损坏或需要重建本地状态，可先退出应用，备份后删除对应目录中的文件，再重新启动应用。
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,7 +9,6 @@
 import 'dart:async';
 import 'dart:io';
 import 'widgets/material_compat.dart';
-import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:window_manager/window_manager.dart';
 import 'package:tray_manager/tray_manager.dart';
 import 'app.dart';
@@ -17,13 +16,11 @@ import 'pages/lock_page.dart';
 import 'pages/agreement_page.dart';
 import 'pages/privacy_policy_page.dart';
 import 'services/app_exit_service.dart';
-import 'services/app_data_directory_service.dart';
 import 'services/password_service.dart';
 import 'services/storage_service.dart';
 import 'services/tray_service.dart';
 import 'services/notification_service.dart';
 import 'services/auto_refresh_service.dart';
-import 'utils/webview_env.dart';
 
 /// 全局字体族名称
 import 'theme/app_spacing.dart';
@@ -36,25 +33,8 @@ const String kFontFamily = AppTheme.fontFamily;
 bool get _supportsDesktopShell =>
     !kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS);
 
-/// WebView2 和本地通知当前只面向 Windows 发行包启用。
-bool get _supportsWindowsServices => !kIsWeb && Platform.isWindows;
-
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-
-  // Windows 平台：在 runApp() 前初始化 WebView2 环境
-  // 必须在任何 WebView 实例创建前完成，否则会触发 RPC_E_DISCONNECTED (-2147417848)
-  if (_supportsWindowsServices) {
-    final availableVersion = await WebViewEnvironment.getAvailableVersion();
-    if (availableVersion != null) {
-      // WebView2 运行态同样放入统一应用数据目录，便于用户定位和清理。
-      final webViewDataFolder =
-          await AppDataDirectoryService.ensureDirectoryPath('webview2');
-      globalWebViewEnvironment = await WebViewEnvironment.create(
-        settings: WebViewEnvironmentSettings(userDataFolder: webViewDataFolder),
-      );
-    }
-  }
 
   if (_supportsDesktopShell) {
     // 桌面端拦截关闭事件并提供系统托盘入口。
@@ -392,7 +372,9 @@ class _SSPUAppState extends State<SSPUApp> with WindowListener, TrayListener {
       return Builder(
         builder: (context) {
           _showAgreementDialog(context);
-          return const Scaffold(body: Center(child: CircularProgressIndicator()));
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
         },
       );
     }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -267,15 +267,17 @@ class _HomePageState extends State<HomePage> {
   Widget _buildMessageItem(BuildContext context, MessageItem msg) {
     final theme = FluentTheme.of(context);
     return HoverButton(
-      onPressed: () {
-        // 标记已读并跳转内嵌 WebView
+      onPressed: () async {
+        // 标记已读并跳转内嵌 WebView。
         MessageStateService.instance.markAsRead(msg.id);
+        final webViewEnvironment = await ensureGlobalWebViewEnvironment();
+        if (!context.mounted) return;
         Navigator.of(context).push(
           FluentPageRoute(
             builder: (_) => WebViewPage(
               url: msg.url,
               initialTitle: msg.title,
-              webViewEnvironment: globalWebViewEnvironment,
+              webViewEnvironment: webViewEnvironment,
             ),
           ),
         );

--- a/lib/pages/info_page.dart
+++ b/lib/pages/info_page.dart
@@ -209,13 +209,14 @@ class _InfoPageState extends State<InfoPage> {
   /// WebView 初始化失败时自动 fallback 到外部浏览器
   Future<void> _openMessage(MessageItem message) async {
     await _stateService.markAsRead(message.id);
+    final webViewEnvironment = await ensureGlobalWebViewEnvironment();
     if (mounted) {
       Navigator.of(context).push(
         FluentPageRoute(
           builder: (_) => WebViewPage(
             url: message.url,
             initialTitle: message.title,
-            webViewEnvironment: globalWebViewEnvironment,
+            webViewEnvironment: webViewEnvironment,
           ),
         ),
       );

--- a/lib/services/app_exit_service.dart
+++ b/lib/services/app_exit_service.dart
@@ -14,6 +14,7 @@ import 'package:window_manager/window_manager.dart';
 
 import 'auto_refresh_service.dart';
 import 'tray_service.dart';
+import '../utils/webview_env.dart';
 
 /// 仅桌面平台具备窗口与托盘资源，移动端 / Web 走系统退出。
 bool get _supportsDesktopShell =>
@@ -33,6 +34,14 @@ class AppExitService {
 
   static const Duration _desktopExitStepTimeout = Duration(milliseconds: 200);
 
+  /// 可见窗口优先隐藏的超时；窗口消失优先级高于完整释放资源。
+  static const Duration _visibleWindowCloseTimeout = Duration(
+    milliseconds: 120,
+  );
+
+  /// 桌面端后台收尾总超时，避免无前端窗口时进程长期挂起。
+  static const Duration _desktopExitTotalTimeout = Duration(milliseconds: 1500);
+
   /// 当前是否处于退出流程中，用于避免重复触发。
   bool get isExiting => _isExiting;
 
@@ -45,6 +54,51 @@ class AppExitService {
     }
   }
 
+  /// 先隐藏用户可见窗口，让后续 native 资源释放在后台完成。
+  Future<void> _hideVisibleWindowBeforeExit() async {
+    try {
+      await windowManager.hide().timeout(
+        _visibleWindowCloseTimeout,
+        onTimeout: () {},
+      );
+    } catch (_) {
+      // 隐藏窗口失败时仍继续退出，避免窗口通道异常阻断进程关闭。
+    }
+  }
+
+  /// 执行桌面端后台收尾，并用总超时兜底防止资源释放长期挂起。
+  Future<void> _finishDesktopExitInBackground() async {
+    try {
+      await _finishDesktopExitSteps().timeout(
+        _desktopExitTotalTimeout,
+        onTimeout: () {},
+      );
+    } finally {
+      io.exit(0);
+    }
+  }
+
+  /// 释放桌面端退出相关资源。
+  Future<void> _finishDesktopExitSteps() async {
+    var isPreventClose = true;
+    try {
+      isPreventClose = await windowManager.isPreventClose().timeout(
+        _desktopExitStepTimeout,
+        onTimeout: () => true,
+      );
+    } catch (_) {
+      isPreventClose = true;
+    }
+    if (isPreventClose) {
+      await _runDesktopExitStep(() => windowManager.setPreventClose(false));
+    }
+
+    AutoRefreshService.instance.dispose();
+    await _runDesktopExitStep(disposeGlobalWebViewEnvironment);
+    await _runDesktopExitStep(() => TrayService.instance.destroy());
+    await _runDesktopExitStep(() => windowManager.destroy());
+  }
+
   /// 按平台执行安全退出。
   Future<void> exit() async {
     if (_isExiting) return;
@@ -52,23 +106,8 @@ class AppExitService {
 
     try {
       if (_supportsDesktopShell) {
-        var isPreventClose = true;
-        try {
-          isPreventClose = await windowManager.isPreventClose().timeout(
-            _desktopExitStepTimeout,
-            onTimeout: () => true,
-          );
-        } catch (_) {
-          isPreventClose = true;
-        }
-        if (isPreventClose) {
-          await _runDesktopExitStep(() => windowManager.setPreventClose(false));
-        }
-
-        AutoRefreshService.instance.dispose();
-        await _runDesktopExitStep(() => TrayService.instance.destroy());
-        await _runDesktopExitStep(() => windowManager.destroy());
-        io.exit(0);
+        await _hideVisibleWindowBeforeExit();
+        await _finishDesktopExitInBackground();
       }
 
       await SystemNavigator.pop();

--- a/lib/utils/webview_env.dart
+++ b/lib/utils/webview_env.dart
@@ -1,16 +1,82 @@
 /*
  * WebView2 环境全局单例 — Windows 平台 WebViewEnvironment 持有者
- * flutter_inappwebview 在 Windows 上要求所有 WebView 实例共享同一个
- * WebViewEnvironment，必须在 runApp() 之前完成初始化。
- * 其他文件通过导入本文件访问 globalWebViewEnvironment。
+ * flutter_inappwebview 在 Windows 上要求需要共享 Cookie 的 WebView 实例
+ * 使用同一个 WebViewEnvironment；本文件按需懒加载环境，避免启动即加载
+ * Chromium / WebView2 native 资源导致关闭时产生无页面场景的清理噪声。
  * @Project : SSPU-AllinOne
  * @File : webview_env.dart
  * @Author : Qintsg
  * @Date : 2026-04-21
  */
 
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
-/// Windows 平台全局 WebViewEnvironment 实例
-/// 在 main() 中初始化，非 Windows 平台始终为 null
+import '../services/app_data_directory_service.dart';
+
+/// Windows 平台全局 WebViewEnvironment 实例。
+///
+/// 仅在首次打开内嵌 WebView 或微信公众号登录页时创建；非 Windows 平台始终为 null。
 WebViewEnvironment? globalWebViewEnvironment;
+
+/// 防止短时间内多个页面同时触发 WebView2 环境创建。
+Future<WebViewEnvironment?>? _globalWebViewEnvironmentFuture;
+
+/// 当前平台是否需要自定义 Windows WebView2 环境。
+bool get _supportsWindowsWebView => !kIsWeb && Platform.isWindows;
+
+/// 获取全局 WebView2 环境；未创建时按需初始化。
+///
+/// Windows 自定义用户数据目录依赖同一个环境读取登录 Cookie；因此所有需要
+/// Cookie 共享的页面都应通过此入口获取环境，而不是在应用启动时提前创建。
+Future<WebViewEnvironment?> ensureGlobalWebViewEnvironment() async {
+  if (!_supportsWindowsWebView) return null;
+  final environment = globalWebViewEnvironment;
+  if (environment != null) return environment;
+
+  final pendingEnvironment = _globalWebViewEnvironmentFuture;
+  if (pendingEnvironment != null) return pendingEnvironment;
+
+  final creationFuture = _createGlobalWebViewEnvironment();
+  _globalWebViewEnvironmentFuture = creationFuture;
+  try {
+    globalWebViewEnvironment = await creationFuture;
+    return globalWebViewEnvironment;
+  } finally {
+    _globalWebViewEnvironmentFuture = null;
+  }
+}
+
+/// 释放已创建的全局 WebView2 环境。
+///
+/// 退出应用时显式释放环境，可让插件先销毁隐藏 WebView2 controller，减少
+/// Chromium 窗口类在进程结束阶段才清理造成的 shell 侧错误输出。
+Future<void> disposeGlobalWebViewEnvironment() async {
+  if (!_supportsWindowsWebView) return;
+
+  final pendingEnvironment = _globalWebViewEnvironmentFuture;
+  var environment = globalWebViewEnvironment;
+  _globalWebViewEnvironmentFuture = null;
+  globalWebViewEnvironment = null;
+
+  if (environment == null && pendingEnvironment != null) {
+    environment = await pendingEnvironment;
+  }
+
+  await environment?.dispose();
+}
+
+/// 创建带统一用户数据目录的 Windows WebView2 环境。
+Future<WebViewEnvironment?> _createGlobalWebViewEnvironment() async {
+  final availableVersion = await WebViewEnvironment.getAvailableVersion();
+  if (availableVersion == null) return null;
+
+  final webViewDataFolder = await AppDataDirectoryService.ensureDirectoryPath(
+    'webview2',
+  );
+  return WebViewEnvironment.create(
+    settings: WebViewEnvironmentSettings(userDataFolder: webViewDataFolder),
+  );
+}

--- a/lib/widgets/campus_network_status_indicator.dart
+++ b/lib/widgets/campus_network_status_indicator.dart
@@ -135,39 +135,38 @@ class _CampusNetworkStatusIndicatorState
               key: const Key('campus-network-status-indicator'),
               onTap: _isChecking ? null : _refreshStatus,
               borderRadius: const BorderRadius.all(Radius.circular(999)),
-              child: AnimatedContainer(
-                duration: AppMotion.short,
-                constraints: BoxConstraints(
-                  minWidth: showLabel ? 48 : 48,
-                  minHeight: 48,
-                ),
-                padding: EdgeInsetsDirectional.symmetric(
-                  horizontal: showLabel ? AppSpacing.md : AppSpacing.sm,
-                  vertical: AppSpacing.sm,
-                ),
-                decoration: BoxDecoration(
-                  color: fillColor,
-                  border: Border.all(color: foregroundColor.withValues(alpha: 0.28)),
-                  borderRadius: const BorderRadius.all(Radius.circular(999)),
-                ),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    _buildStatusIcon(foregroundColor),
-                    if (showLabel) ...[
-                      const SizedBox(width: AppSpacing.sm),
-                      Flexible(
-                        child: Text(
-                          _isChecking ? '检测中' : _status.label,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: Theme.of(context).textTheme.labelMedium
-                              ?.copyWith(color: foregroundColor),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(minWidth: 48, minHeight: 48),
+                child: AnimatedContainer(
+                  duration: AppMotion.short,
+                  padding: EdgeInsetsDirectional.symmetric(
+                    horizontal: showLabel ? AppSpacing.md : AppSpacing.sm,
+                    vertical: AppSpacing.sm,
+                  ),
+                  decoration: BoxDecoration(
+                    color: fillColor,
+                    border: Border.all(color: foregroundColor.withValues(alpha: 0.28)),
+                    borderRadius: const BorderRadius.all(Radius.circular(999)),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      _buildStatusIcon(foregroundColor),
+                      if (showLabel) ...[
+                        const SizedBox(width: AppSpacing.sm),
+                        Flexible(
+                          child: Text(
+                            _isChecking ? '检测中' : _status.label,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: Theme.of(context).textTheme.labelMedium
+                                ?.copyWith(color: foregroundColor),
+                          ),
                         ),
-                      ),
+                      ],
                     ],
-                  ],
+                  ),
                 ),
               ),
             ),

--- a/lib/widgets/fluent_surface.dart
+++ b/lib/widgets/fluent_surface.dart
@@ -76,24 +76,35 @@ class _FluentSurfaceState extends State<FluentSurface> {
     final backgroundColor = _resolveBackgroundColor(colorScheme, accentColor);
     final borderColor = _resolveBorderColor(colorScheme, accentColor);
 
+    Widget surfaceContent = AnimatedContainer(
+      duration: AppMotion.medium,
+      curve: Curves.easeOutCubic,
+      margin: widget.margin,
+      padding: widget.padding,
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: widget.borderRadius,
+        border: Border.all(color: borderColor),
+      ),
+      child: widget.child,
+    );
+
+    if (widget.minHeight != null) {
+      surfaceContent = ConstrainedBox(
+        constraints: BoxConstraints(minHeight: widget.minHeight!),
+        child: surfaceContent,
+      );
+    }
+
+    if (widget.width != null) {
+      surfaceContent = SizedBox(width: widget.width, child: surfaceContent);
+    }
+
     final surface = AnimatedScale(
       scale: _isPressed ? 0.995 : (_isHovered && _isInteractive ? 1.004 : 1),
       duration: AppMotion.short,
       curve: Curves.easeOutCubic,
-      child: AnimatedContainer(
-        width: widget.width,
-        constraints: BoxConstraints(minHeight: widget.minHeight ?? 0),
-        duration: AppMotion.medium,
-        curve: Curves.easeOutCubic,
-        margin: widget.margin,
-        padding: widget.padding,
-        decoration: BoxDecoration(
-          color: backgroundColor,
-          borderRadius: widget.borderRadius,
-          border: Border.all(color: borderColor),
-        ),
-        child: widget.child,
-      ),
+      child: surfaceContent,
     );
 
     return MouseRegion(

--- a/lib/widgets/settings_wechat_section.dart
+++ b/lib/widgets/settings_wechat_section.dart
@@ -85,10 +85,12 @@ class _SettingsWechatSectionState extends State<SettingsWechatSection> {
   }
 
   Future<void> _openWxmpLogin() async {
+    final webViewEnvironment = await ensureGlobalWebViewEnvironment();
+    if (!mounted) return;
+
     final success = await Navigator.of(context).push<bool>(
       FluentPageRoute(
-        builder: (_) =>
-            WxmpLoginPage(webViewEnvironment: globalWebViewEnvironment),
+        builder: (_) => WxmpLoginPage(webViewEnvironment: webViewEnvironment),
       ),
     );
     if (success == true) {

--- a/lib/widgets/settings_widgets.dart
+++ b/lib/widgets/settings_widgets.dart
@@ -97,47 +97,49 @@ Widget buildSettingsNavItem({
     child: InkWell(
       onTap: onTap,
       borderRadius: AppShapes.md,
-      child: AnimatedContainer(
-        duration: AppMotion.short,
+      child: SizedBox(
         width: double.infinity,
-        padding: const EdgeInsetsDirectional.symmetric(
-          horizontal: AppSpacing.md,
-          vertical: AppSpacing.sm,
-        ),
-        decoration: BoxDecoration(
-          color: isSelected ? colorScheme.secondaryContainer : null,
-          borderRadius: AppShapes.md,
-        ),
-        child: Row(
-          children: [
-            AnimatedContainer(
-              duration: AppMotion.short,
-              width: 4,
-              height: 24,
-              margin: const EdgeInsetsDirectional.only(end: AppSpacing.sm),
-              decoration: BoxDecoration(
-                color: isSelected ? colorScheme.primary : Colors.transparent,
-                borderRadius: AppShapes.xs,
+        child: AnimatedContainer(
+          duration: AppMotion.short,
+          padding: const EdgeInsetsDirectional.symmetric(
+            horizontal: AppSpacing.md,
+            vertical: AppSpacing.sm,
+          ),
+          decoration: BoxDecoration(
+            color: isSelected ? colorScheme.secondaryContainer : null,
+            borderRadius: AppShapes.md,
+          ),
+          child: Row(
+            children: [
+              AnimatedContainer(
+                duration: AppMotion.short,
+                width: 4,
+                height: 24,
+                margin: const EdgeInsetsDirectional.only(end: AppSpacing.sm),
+                decoration: BoxDecoration(
+                  color: isSelected ? colorScheme.primary : Colors.transparent,
+                  borderRadius: AppShapes.xs,
+                ),
               ),
-            ),
-            Icon(
-              icon,
-              color: isSelected
-                  ? colorScheme.onSecondaryContainer
-                  : colorScheme.onSurfaceVariant,
-            ),
-            const SizedBox(width: AppSpacing.sm),
-            Expanded(
-              child: Text(
-                label,
-                style: isSelected
-                    ? textTheme.titleSmall?.copyWith(
-                        color: colorScheme.onSecondaryContainer,
-                      )
-                    : textTheme.bodyMedium,
+              Icon(
+                icon,
+                color: isSelected
+                    ? colorScheme.onSecondaryContainer
+                    : colorScheme.onSurfaceVariant,
               ),
-            ),
-          ],
+              const SizedBox(width: AppSpacing.sm),
+              Expanded(
+                child: Text(
+                  label,
+                  style: isSelected
+                      ? textTheme.titleSmall?.copyWith(
+                          color: colorScheme.onSecondaryContainer,
+                        )
+                      : textTheme.bodyMedium,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -330,10 +330,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
-      sha256: "0191ba6ae4fca37144d7231a8df5cbdb450f2a858d90a0b60b8ded0af9f40ce7"
+      sha256: "8f42f359f187a94dce7a3ab2ec5903d013dddfc7127078ebab19fa244c3840e8"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "4.2.1"
   flutter_shaders:
     dependency: transitive
     description:
@@ -428,10 +428,10 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.11.0"
+    version: "4.12.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -945,10 +945,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -977,10 +977,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "046d3928e16fa4dc46e8350415661755ab759d9fc97fc21b5ab295f71e4f0499"
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "15.1.0"
+    version: "15.2.0"
   web:
     dependency: transitive
     description:
@@ -993,10 +993,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: ba7d5750e3441caa1bbe31d9e516348fcf8dfcb32aa29ef87a844a59f4d1f1d0
+      sha256: a1fc9eb9248baa05dfc12ed5b66e377b3e23f095eec078e0371622b9033810d9
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "6.2.0"
   window_manager:
     dependency: "direct main"
     description:

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -40,6 +40,10 @@ set(CMAKE_CXX_FLAGS_PROFILE "${CMAKE_CXX_FLAGS_RELEASE}")
 # Use Unicode for all projects.
 add_definitions(-DUNICODE -D_UNICODE)
 
+# Visual Studio 18 / MSVC 14.51 会将 <experimental/coroutine> 的弃用提示升级为阻断错误。
+# 部分 Flutter Windows 插件仍间接包含该旧头文件，按 MSVC 官方提示对所有子工程静默该兼容性告警。
+add_compile_definitions(_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+
 # Compilation settings that should be applied to most targets.
 #
 # Be cautious about adding new options here, as plugins use this function by


### PR DESCRIPTION
## 摘要

- 升级当前 Flutter SDK 约束下可解析到最新版本的依赖锁定项。
- 修复 Windows CMake 旧路径缓存和 MSVC 14.51 `<experimental/coroutine>` 编译阻断。
- 修复 Material 3 surface 隐式动画在窗口约束变化时插值无限约束的运行时异常。
- 将 WebView2 环境改为首次使用时懒加载，并优化桌面端退出顺序，先隐藏前端窗口再后台限时收尾。

## 验证

- `flutter analyze --no-fatal-infos`
- `flutter test test/wxmp_login_page_test.dart test/widget_test.dart test/message_tile_test.dart`
- `flutter build windows --debug`

## 发布说明

- 无需发布。

Qintsg