### PR TITLE
feat(ui): 添加桌面标题栏校园网状态

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -18,7 +18,6 @@ import 'pages/settings_page.dart';
 import 'services/campus_network_status_service.dart';
 import 'theme/app_breakpoints.dart';
 import 'theme/app_spacing.dart';
-import 'widgets/campus_network_status_indicator.dart';
 
 part 'app_navigation_items.dart';
 
@@ -55,11 +54,13 @@ class _AppShellState extends State<AppShell> {
   final Set<int> _visitedDestinationIndexes = <int>{0};
 
   List<_AppDestination> get _destinations => [
-    const _AppDestination(
+    _AppDestination(
       title: '主页',
       icon: FluentIcons.home,
       selectedIcon: FluentIcons.home,
-      body: HomePage(),
+      body: HomePage(
+        campusNetworkStatusService: widget.campusNetworkStatusService,
+      ),
     ),
     const _AppDestination(
       title: '教务',
@@ -131,7 +132,6 @@ class _AppShellState extends State<AppShell> {
         selectedIndex: _selectedIndex,
         visitedIndexes: _visitedDestinationIndexes,
         onChanged: _selectDestination,
-        campusNetworkStatusService: widget.campusNetworkStatusService,
       );
     }
 
@@ -141,7 +141,6 @@ class _AppShellState extends State<AppShell> {
       visitedIndexes: _visitedDestinationIndexes,
       extended: sizeClass == WindowSizeClass.expanded,
       onChanged: _selectDestination,
-      campusNetworkStatusService: widget.campusNetworkStatusService,
     );
   }
 
@@ -314,7 +313,6 @@ class _RailNavigationShell extends StatelessWidget {
   final Set<int> visitedIndexes;
   final bool extended;
   final ValueChanged<int> onChanged;
-  final CampusNetworkStatusService? campusNetworkStatusService;
 
   const _RailNavigationShell({
     required this.destinations,
@@ -322,7 +320,6 @@ class _RailNavigationShell extends StatelessWidget {
     required this.visitedIndexes,
     required this.extended,
     required this.onChanged,
-    required this.campusNetworkStatusService,
   });
 
   @override
@@ -350,14 +347,6 @@ class _RailNavigationShell extends StatelessWidget {
                       extended: extended,
                       onTap: () => onChanged(i),
                     ),
-                  const Spacer(),
-                  Padding(
-                    key: const Key('campus-network-status-pane-item'),
-                    padding: const EdgeInsetsDirectional.all(AppSpacing.sm),
-                    child: CampusNetworkStatusIndicator(
-                      service: campusNetworkStatusService,
-                    ),
-                  ),
                 ],
               ),
             ),
@@ -380,14 +369,12 @@ class _DrawerNavigationShell extends StatelessWidget {
   final int selectedIndex;
   final Set<int> visitedIndexes;
   final ValueChanged<int> onChanged;
-  final CampusNetworkStatusService? campusNetworkStatusService;
 
   const _DrawerNavigationShell({
     required this.destinations,
     required this.selectedIndex,
     required this.visitedIndexes,
     required this.onChanged,
-    required this.campusNetworkStatusService,
   });
 
   @override
@@ -431,19 +418,6 @@ class _DrawerNavigationShell extends StatelessWidget {
                       extended: true,
                       onTap: () => onChanged(i),
                     ),
-                  const Padding(
-                    padding: EdgeInsetsDirectional.symmetric(
-                      horizontal: AppSpacing.md,
-                    ),
-                    child: Divider(),
-                  ),
-                  Padding(
-                    key: const Key('campus-network-status-pane-item'),
-                    padding: const EdgeInsetsDirectional.all(AppSpacing.md),
-                    child: CampusNetworkStatusIndicator(
-                      service: campusNetworkStatusService,
-                    ),
-                  ),
                 ],
               ),
             ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,10 +18,12 @@ import 'pages/agreement_page.dart';
 import 'pages/privacy_policy_page.dart';
 import 'services/app_exit_service.dart';
 import 'services/password_service.dart';
+import 'services/campus_network_status_service.dart';
 import 'services/storage_service.dart';
 import 'services/tray_service.dart';
 import 'services/notification_service.dart';
 import 'services/auto_refresh_service.dart';
+import 'widgets/desktop_window_frame.dart';
 
 /// 全局字体族名称
 import 'theme/app_motion.dart';
@@ -42,6 +44,10 @@ void main() async {
   if (_supportsDesktopShell) {
     // 桌面端拦截关闭事件并提供系统托盘入口。
     await windowManager.ensureInitialized();
+    await windowManager.setTitleBarStyle(
+      TitleBarStyle.hidden,
+      windowButtonVisibility: false,
+    );
     await windowManager.setPreventClose(true);
     await TrayService.instance.init();
   }
@@ -80,6 +86,10 @@ class _SSPUAppState extends State<SSPUApp> with WindowListener, TrayListener {
 
   /// MaterialApp 内部导航器 key，用于在 WindowListener 回调中弹出对话框
   final _navigatorKey = GlobalKey<NavigatorState>();
+
+  /// 主界面共享的校园网 / VPN 状态检测服务。
+  final CampusNetworkStatusService _campusNetworkStatusService =
+      CampusNetworkStatusService.instance;
 
   @override
   void initState() {
@@ -217,7 +227,9 @@ class _SSPUAppState extends State<SSPUApp> with WindowListener, TrayListener {
                       child: GestureDetector(
                         behavior: HitTestBehavior.opaque,
                         onTap: () {
-                          setDialogState(() => rememberChoice = !rememberChoice);
+                          setDialogState(
+                            () => rememberChoice = !rememberChoice,
+                          );
                         },
                         child: Row(
                           children: [
@@ -227,7 +239,9 @@ class _SSPUAppState extends State<SSPUApp> with WindowListener, TrayListener {
                               height: 20,
                               decoration: BoxDecoration(
                                 color: rememberChoice
-                                    ? Theme.of(dialogContext).colorScheme.primary
+                                    ? Theme.of(
+                                        dialogContext,
+                                      ).colorScheme.primary
                                     : Colors.transparent,
                                 borderRadius: AppShapes.sm,
                                 border: Border.all(
@@ -404,7 +418,26 @@ class _SSPUAppState extends State<SSPUApp> with WindowListener, TrayListener {
       themeMode: ThemeMode.system,
       debugShowCheckedModeBanner: false,
       home: _buildHome(),
+      builder: (context, child) {
+        final content = child ?? const SizedBox.shrink();
+        if (!_supportsDesktopShell) return content;
+
+        return DesktopWindowFrame(
+          campusNetworkStatusService: _shouldShowCampusNetworkStatus
+              ? _campusNetworkStatusService
+              : null,
+          child: content,
+        );
+      },
     );
+  }
+
+  /// 是否允许展示并触发校园网状态检测。
+  bool get _shouldShowCampusNetworkStatus {
+    return _isInitialized &&
+        _startupErrorMessage == null &&
+        _agreementsAccepted &&
+        _isUnlocked;
   }
 
   /// 根据初始化、协议确认和密码验证状态构建首屏
@@ -429,9 +462,7 @@ class _SSPUAppState extends State<SSPUApp> with WindowListener, TrayListener {
       return Builder(
         builder: (context) {
           _showAgreementDialog(context);
-          return const Scaffold(
-            body: Center(child: FluentProgressRing()),
-          );
+          return const Scaffold(body: Center(child: FluentProgressRing()));
         },
       );
     }
@@ -446,6 +477,9 @@ class _SSPUAppState extends State<SSPUApp> with WindowListener, TrayListener {
     }
 
     // 已解锁，进入主界面
-    return AppShell(onLock: _lockApp);
+    return AppShell(
+      onLock: _lockApp,
+      campusNetworkStatusService: _campusNetworkStatusService,
+    );
   }
 }

--- a/lib/models/campus_network_status.dart
+++ b/lib/models/campus_network_status.dart
@@ -7,7 +7,8 @@
  */
 
 /// 校园受限服务可访问模式。
-/// 当前默认探针只能确认“校园网或 VPN 可达”，后续可替换为更细粒度检测。
+///
+/// 通过 VPN 入口与体育部站点双探针区分 VPN、校园网、校外网络与未知网络。
 enum CampusNetworkAccessMode {
   /// 尚未完成检测或检测状态不可确定。
   unknown,
@@ -18,11 +19,8 @@ enum CampusNetworkAccessMode {
   /// 已识别为学校 VPN 连接。
   vpn,
 
-  /// 可访问校园内网资源，但暂不能区分校园网直连或 VPN。
-  campusOrVpn,
-
-  /// 无法访问校园内网资源。
-  unavailable,
+  /// 已识别为非校园网环境，受限校园服务暂不可用。
+  outsideCampus,
 }
 
 /// 校园网 / VPN 前置检测结果。
@@ -32,14 +30,19 @@ class CampusNetworkStatus {
     required this.accessMode,
     required this.probeUri,
     required this.detail,
+    this.vpnProbeUri,
     this.checkedAt,
   });
 
   /// 构建初始未知状态，避免 UI 在首次检测前误报未连接。
-  factory CampusNetworkStatus.unknown({required Uri probeUri}) {
+  factory CampusNetworkStatus.unknown({
+    required Uri probeUri,
+    Uri? vpnProbeUri,
+  }) {
     return CampusNetworkStatus(
       accessMode: CampusNetworkAccessMode.unknown,
       probeUri: probeUri,
+      vpnProbeUri: vpnProbeUri,
       detail: '尚未检测校园网 / VPN 状态',
     );
   }
@@ -48,7 +51,12 @@ class CampusNetworkStatus {
   final CampusNetworkAccessMode accessMode;
 
   /// 本次检测使用的目标地址。
+  ///
+  /// 双探针检测中该地址表示校园受限站点探针。
   final Uri probeUri;
+
+  /// 本次检测使用的 VPN 入口探针地址。
+  final Uri? vpnProbeUri;
 
   /// 检测完成时间；未知状态下为空。
   final DateTime? checkedAt;
@@ -59,11 +67,9 @@ class CampusNetworkStatus {
   /// 受限校园查询入口是否可以继续访问。
   bool get canAccessRestrictedServices {
     return switch (accessMode) {
-      CampusNetworkAccessMode.campus ||
-      CampusNetworkAccessMode.vpn ||
-      CampusNetworkAccessMode.campusOrVpn => true,
+      CampusNetworkAccessMode.campus || CampusNetworkAccessMode.vpn => true,
       CampusNetworkAccessMode.unknown ||
-      CampusNetworkAccessMode.unavailable => false,
+      CampusNetworkAccessMode.outsideCampus => false,
     };
   }
 
@@ -71,10 +77,19 @@ class CampusNetworkStatus {
   String get label {
     return switch (accessMode) {
       CampusNetworkAccessMode.campus => '校园网',
-      CampusNetworkAccessMode.vpn => '校园 VPN',
-      CampusNetworkAccessMode.campusOrVpn => '校园网/VPN',
-      CampusNetworkAccessMode.unavailable => '未连接校园网/VPN',
-      CampusNetworkAccessMode.unknown => '校园网检测',
+      CampusNetworkAccessMode.vpn => 'VPN 环境',
+      CampusNetworkAccessMode.outsideCampus => '非校园网',
+      CampusNetworkAccessMode.unknown => '网络未知',
+    };
+  }
+
+  /// 小尺寸状态指示使用的短文案。
+  String get shortLabel {
+    return switch (accessMode) {
+      CampusNetworkAccessMode.campus => '校园网',
+      CampusNetworkAccessMode.vpn => 'VPN',
+      CampusNetworkAccessMode.outsideCampus => '校外',
+      CampusNetworkAccessMode.unknown => '未知',
     };
   }
 
@@ -83,11 +98,9 @@ class CampusNetworkStatus {
     return switch (accessMode) {
       CampusNetworkAccessMode.campus => '当前处于校园网环境，可访问受限查询服务。',
       CampusNetworkAccessMode.vpn => '当前已连接学校 VPN，可访问受限查询服务。',
-      CampusNetworkAccessMode.campusOrVpn =>
-        '已通过 ${probeUri.host} 验证，可访问校园网 / VPN 受限服务。',
-      CampusNetworkAccessMode.unavailable =>
-        '无法访问 ${probeUri.host}，教务等受限查询入口需要先连接校园网或学校 VPN。',
-      CampusNetworkAccessMode.unknown => '正在等待首次校园网 / VPN 状态检测。',
+      CampusNetworkAccessMode.outsideCampus =>
+        '当前处于非校园网环境，教务等受限查询入口需要先连接校园网或学校 VPN。',
+      CampusNetworkAccessMode.unknown => '暂无法确认当前网络环境，请检查网络后重新检测。',
     };
   }
 }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -13,9 +13,11 @@ import 'package:flutter_animate/flutter_animate.dart';
 import '../models/campus_card.dart';
 import '../models/message_item.dart';
 import '../services/campus_card_service.dart';
+import '../services/campus_network_status_service.dart';
 import '../services/message_state_service.dart';
 import '../theme/fluent_tokens.dart';
 import '../utils/webview_env.dart';
+import '../widgets/campus_network_status_indicator.dart';
 import '../widgets/responsive_layout.dart';
 import 'webview_page.dart';
 
@@ -28,6 +30,9 @@ class HomePage extends StatefulWidget {
   /// 校园卡余额查询服务，测试中可替换为 fake。
   final CampusCardBalanceClient? campusCardService;
 
+  /// 校园网 / VPN 状态检测服务，测试中可替换为 fake。
+  final CampusNetworkStatusService? campusNetworkStatusService;
+
   /// 测试专用：覆盖校园卡余额自动刷新开关。
   final bool? campusCardAutoRefreshEnabledOverride;
 
@@ -37,6 +42,7 @@ class HomePage extends StatefulWidget {
   const HomePage({
     super.key,
     this.campusCardService,
+    this.campusNetworkStatusService,
     this.campusCardAutoRefreshEnabledOverride,
     this.campusCardAutoRefreshIntervalOverride,
   });
@@ -144,7 +150,14 @@ class _HomePageState extends State<HomePage> {
         };
 
         return FluentPage.scrollable(
-          header: const FluentPageHeader(title: Text('主页')),
+          header: FluentPageHeader(
+            title: const Text('主页'),
+            commandBar: CampusNetworkStatusIndicator(
+              service: widget.campusNetworkStatusService,
+              variant: CampusNetworkStatusIndicatorVariant.home,
+              indicatorKey: const Key('campus-network-status-home'),
+            ),
+          ),
           padding: EdgeInsets.all(pagePadding),
           children: [
             FluentSurface(

--- a/lib/services/campus_network_status_service.dart
+++ b/lib/services/campus_network_status_service.dart
@@ -16,7 +16,6 @@ import 'http_service.dart';
 import 'storage_service.dart';
 
 /// 校园网检测探针签名。
-/// 后续若需要区分直连校园网与 VPN，只需替换探针实现，不影响调用方。
 typedef CampusNetworkProbe =
     Future<CampusNetworkProbeResult> Function(Uri probeUri, Duration timeout);
 
@@ -43,49 +42,119 @@ class CampusNetworkStatusService extends ChangeNotifier {
   CampusNetworkStatusService({
     CampusNetworkProbe? probe,
     Uri? probeUri,
+    Uri? vpnProbeUri,
     Duration? timeout,
   }) : _probe = probe ?? _defaultProbe,
        probeUri = probeUri ?? defaultProbeUri,
-       timeout = timeout ?? const Duration(seconds: 5);
+       vpnProbeUri = vpnProbeUri ?? defaultVpnProbeUri,
+       timeout = timeout ?? const Duration(seconds: 5) {
+    _currentStatus = CampusNetworkStatus.unknown(
+      probeUri: this.probeUri,
+      vpnProbeUri: this.vpnProbeUri,
+    );
+  }
 
   /// 全局单例，供应用顶栏与后续受限入口共用。
   static final CampusNetworkStatusService instance =
       CampusNetworkStatusService();
 
-  /// 默认检测目标：本专科教务系统域名。
-  static final Uri defaultProbeUri = Uri.parse('https://tygl.sspu.edu.cn/');
+  /// 默认校园受限站点检测目标：体育部查询系统域名。
+  static final Uri defaultProbeUri = defaultCampusProbeUri;
+
+  /// 默认校园受限站点检测目标：体育部查询系统域名。
+  static final Uri defaultCampusProbeUri = Uri.parse(
+    'https://tygl.sspu.edu.cn/',
+  );
+
+  /// 默认 VPN 入口检测目标：学校 VPN 入口域名。
+  static final Uri defaultVpnProbeUri = Uri.parse('https://vpn.sspu.edu.cn/');
 
   /// 默认检测间隔，兼顾状态新鲜度与校园站点访问频率。
   static const int defaultDetectionIntervalMinutes = 15;
 
-  /// 实际检测目标地址。
+  /// 实际校园受限站点检测目标地址。
   final Uri probeUri;
+
+  /// 实际 VPN 入口检测目标地址。
+  final Uri vpnProbeUri;
 
   /// 单次检测超时时间，避免启动后长期占用 UI 状态。
   final Duration timeout;
 
   final CampusNetworkProbe _probe;
 
+  late CampusNetworkStatus _currentStatus;
+
+  /// 当前缓存的校园网 / VPN 状态，供多个入口共享展示。
+  CampusNetworkStatus get currentStatus => _currentStatus;
+
+  /// 当前自动检测间隔；0 表示只允许手动刷新。
+  int get detectionIntervalMinutes => _detectionIntervalMinutes;
+
+  /// 当前是否已有检测任务在执行。
+  bool get isChecking => _isChecking;
+
+  int _detectionIntervalMinutes = defaultDetectionIntervalMinutes;
+  int _activeStatusConsumerCount = 0;
+  bool _isChecking = false;
+  Timer? _refreshTimer;
+  Future<CampusNetworkStatus>? _refreshFuture;
+
+  /// 启动共享状态监听；首次有展示入口挂载时立即刷新一次。
+  Future<void> startStatusMonitoring() async {
+    _activeStatusConsumerCount++;
+    if (_activeStatusConsumerCount > 1) return;
+
+    await _loadDetectionIntervalFromStorage();
+    if (_activeStatusConsumerCount <= 0) return;
+    await refreshStatus();
+  }
+
+  /// 停止共享状态监听；最后一个展示入口卸载时取消自动刷新。
+  void stopStatusMonitoring() {
+    if (_activeStatusConsumerCount <= 0) return;
+
+    _activeStatusConsumerCount--;
+    if (_activeStatusConsumerCount > 0) return;
+
+    _refreshTimer?.cancel();
+    _refreshTimer = null;
+  }
+
+  /// 刷新共享校园网 / VPN 状态，并合并同时触发的检测请求。
+  Future<CampusNetworkStatus> refreshStatus() {
+    final pendingRefresh = _refreshFuture;
+    if (pendingRefresh != null) return pendingRefresh;
+
+    _refreshTimer?.cancel();
+    _refreshTimer = null;
+    _isChecking = true;
+
+    final refresh = _refreshAndStoreStatus();
+    _refreshFuture = refresh;
+    notifyListeners();
+    return refresh;
+  }
+
   /// 执行一次校园网 / VPN 状态检测。
   Future<CampusNetworkStatus> checkStatus() async {
-    try {
-      final result = await _probe(probeUri, timeout);
-      return CampusNetworkStatus(
-        accessMode: result.reachable
-            ? CampusNetworkAccessMode.campusOrVpn
-            : CampusNetworkAccessMode.unavailable,
-        probeUri: probeUri,
-        checkedAt: DateTime.now(),
-        detail: result.detail,
-      );
-    } catch (error) {
-      return CampusNetworkStatus(
-        accessMode: CampusNetworkAccessMode.unavailable,
-        probeUri: probeUri,
-        checkedAt: DateTime.now(),
-        detail: '校园网检测失败：$error',
-      );
-    }
+    final results = await Future.wait([
+      _safeProbe(vpnProbeUri),
+      _safeProbe(probeUri),
+    ]);
+    final vpnResult = results.first;
+    final campusResult = results.last;
+
+    return CampusNetworkStatus(
+      accessMode: _resolveAccessMode(
+        vpnReachable: vpnResult.reachable,
+        campusReachable: campusResult.reachable,
+      ),
+      probeUri: probeUri,
+      vpnProbeUri: vpnProbeUri,
+      checkedAt: DateTime.now(),
+      detail: 'VPN 入口：${vpnResult.detail}\n校园站点：${campusResult.detail}',
+    );
   }
 
   /// 读取校园网 / VPN 状态自动检测间隔。
@@ -103,12 +172,76 @@ class CampusNetworkStatusService extends ChangeNotifier {
       StorageKeys.campusNetworkDetectionIntervalMinutes,
       normalized,
     );
+    _detectionIntervalMinutes = normalized;
+    _scheduleNextRefresh();
     notifyListeners();
+  }
+
+  Future<void> _loadDetectionIntervalFromStorage() async {
+    _detectionIntervalMinutes = await getDetectionIntervalMinutes();
+    _scheduleNextRefresh();
+    notifyListeners();
+  }
+
+  Future<CampusNetworkStatus> _refreshAndStoreStatus() async {
+    try {
+      final nextStatus = await checkStatus();
+      _currentStatus = nextStatus;
+      return nextStatus;
+    } finally {
+      _isChecking = false;
+      _refreshFuture = null;
+      _scheduleNextRefresh();
+      notifyListeners();
+    }
+  }
+
+  void _scheduleNextRefresh() {
+    _refreshTimer?.cancel();
+    _refreshTimer = null;
+    if (_activeStatusConsumerCount <= 0 || _detectionIntervalMinutes <= 0) {
+      return;
+    }
+
+    _refreshTimer = Timer(Duration(minutes: _detectionIntervalMinutes), () {
+      unawaited(refreshStatus());
+    });
   }
 
   /// 间隔只接受非负分钟数；0 表示关闭自动检测但保留手动点击刷新。
   int _normalizeInterval(int minutes) {
     return minutes < 0 ? 0 : minutes;
+  }
+
+  @override
+  void dispose() {
+    _refreshTimer?.cancel();
+    super.dispose();
+  }
+
+  /// 执行单个探针并将异常收敛为不可达结果，避免一次失败中断整体判定。
+  Future<CampusNetworkProbeResult> _safeProbe(Uri uri) async {
+    try {
+      return await _probe(uri, timeout);
+    } catch (error) {
+      return CampusNetworkProbeResult(
+        reachable: false,
+        detail: '访问 ${uri.host} 失败：$error',
+      );
+    }
+  }
+
+  /// 按双探针结果解析当前网络环境。
+  CampusNetworkAccessMode _resolveAccessMode({
+    required bool vpnReachable,
+    required bool campusReachable,
+  }) {
+    if (vpnReachable && campusReachable) return CampusNetworkAccessMode.vpn;
+    if (!vpnReachable && campusReachable) return CampusNetworkAccessMode.campus;
+    if (vpnReachable && !campusReachable) {
+      return CampusNetworkAccessMode.outsideCampus;
+    }
+    return CampusNetworkAccessMode.unknown;
   }
 
   /// 默认探针只发起只读 GET 请求；任何非 5xx HTTP 响应都表示内网域名可达。

--- a/lib/widgets/campus_network_status_indicator.dart
+++ b/lib/widgets/campus_network_status_indicator.dart
@@ -1,5 +1,5 @@
 /*
- * 校园网状态徽标 — 在导航栏展示校园网 / VPN 检测结果
+ * 校园网状态徽标 — 展示校园网 / VPN 检测结果
  * @Project : SSPU-AllinOne
  * @File : campus_network_status_indicator.dart
  * @Author : Qintsg
@@ -12,15 +12,36 @@ import '../design/fluent_ui.dart';
 
 import '../models/campus_network_status.dart';
 import '../services/campus_network_status_service.dart';
-import '../theme/app_motion.dart';
-import '../theme/app_spacing.dart';
+
+/// 校园网 / VPN 状态徽标展示样式。
+enum CampusNetworkStatusIndicatorVariant {
+  /// 标准胶囊样式，用于侧边栏等常规区域。
+  standard,
+
+  /// 桌面自绘标题栏样式，固定宽度并显示语义图标。
+  titleBar,
+
+  /// 首页右上角小状态样式，使用状态灯和短文案。
+  home,
+}
 
 /// 应用级校园网 / VPN 状态徽标。
 class CampusNetworkStatusIndicator extends StatefulWidget {
-  const CampusNetworkStatusIndicator({super.key, this.service});
+  const CampusNetworkStatusIndicator({
+    super.key,
+    this.service,
+    this.variant = CampusNetworkStatusIndicatorVariant.standard,
+    this.indicatorKey = const Key('campus-network-status-indicator'),
+  });
 
   /// 检测服务；测试或后续平台差异化检测可注入自定义实现。
   final CampusNetworkStatusService? service;
+
+  /// 展示样式。
+  final CampusNetworkStatusIndicatorVariant variant;
+
+  /// 内部可点击区域 Key，便于不同入口分别测试。
+  final Key? indicatorKey;
 
   @override
   State<CampusNetworkStatusIndicator> createState() =>
@@ -29,195 +50,265 @@ class CampusNetworkStatusIndicator extends StatefulWidget {
 
 class _CampusNetworkStatusIndicatorState
     extends State<CampusNetworkStatusIndicator> {
-  late CampusNetworkStatus _status;
-
-  /// 当前自动检测间隔；0 表示只允许手动点击刷新。
-  int _detectionIntervalMinutes =
-      CampusNetworkStatusService.defaultDetectionIntervalMinutes;
-
-  /// 自动检测定时器，按设置页配置重排。
-  Timer? _refreshTimer;
-
-  /// 防止用户连续点击刷新造成重复探测。
-  bool _isChecking = false;
-
   CampusNetworkStatusService get _service {
     return widget.service ?? CampusNetworkStatusService.instance;
   }
 
+  CampusNetworkStatus get _status => _service.currentStatus;
+
+  int get _detectionIntervalMinutes => _service.detectionIntervalMinutes;
+
+  bool get _isChecking => _service.isChecking;
+
   @override
   void initState() {
     super.initState();
-    _status = CampusNetworkStatus.unknown(probeUri: _service.probeUri);
-    _service.addListener(_onServiceSettingsChanged);
-    unawaited(_loadIntervalAndRefresh());
+    _service.addListener(_onServiceChanged);
+    unawaited(_service.startStatusMonitoring());
   }
 
   @override
   void didUpdateWidget(CampusNetworkStatusIndicator oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.service != widget.service) {
-      final oldService = oldWidget.service ?? CampusNetworkStatusService.instance;
-      oldService.removeListener(_onServiceSettingsChanged);
-      _service.addListener(_onServiceSettingsChanged);
-      _status = CampusNetworkStatus.unknown(probeUri: _service.probeUri);
-      unawaited(_loadIntervalAndRefresh());
+      final oldService =
+          oldWidget.service ?? CampusNetworkStatusService.instance;
+      oldService.removeListener(_onServiceChanged);
+      oldService.stopStatusMonitoring();
+      _service.addListener(_onServiceChanged);
+      unawaited(_service.startStatusMonitoring());
     }
   }
 
   @override
   void dispose() {
-    _refreshTimer?.cancel();
-    _service.removeListener(_onServiceSettingsChanged);
+    _service.removeListener(_onServiceChanged);
+    _service.stopStatusMonitoring();
     super.dispose();
   }
 
-  /// 服务设置变化时重新加载检测间隔。
-  void _onServiceSettingsChanged() {
-    unawaited(_reloadDetectionInterval());
-  }
-
-  /// 加载检测间隔并立即刷新状态。
-  Future<void> _loadIntervalAndRefresh() async {
-    final interval = await _service.getDetectionIntervalMinutes();
-    if (!mounted) return;
-    setState(() => _detectionIntervalMinutes = interval);
-    await _refreshStatus();
-  }
-
-  /// 重新加载自动检测间隔。
-  Future<void> _reloadDetectionInterval() async {
-    final interval = await _service.getDetectionIntervalMinutes();
-    if (!mounted) return;
-    setState(() => _detectionIntervalMinutes = interval);
-    _scheduleNextRefresh();
+  /// 服务状态变化时刷新当前徽标视图。
+  void _onServiceChanged() {
+    if (mounted) setState(() {});
   }
 
   /// 刷新校园网状态。
   Future<void> _refreshStatus() async {
-    if (_isChecking) return;
-    _refreshTimer?.cancel();
-    setState(() => _isChecking = true);
-    final nextStatus = await _service.checkStatus();
-    if (!mounted) return;
-    setState(() {
-      _status = nextStatus;
-      _isChecking = false;
-    });
-    _scheduleNextRefresh();
-  }
-
-  /// 安排下一次自动检测。
-  void _scheduleNextRefresh() {
-    _refreshTimer?.cancel();
-    if (_detectionIntervalMinutes <= 0) return;
-
-    _refreshTimer = Timer(Duration(minutes: _detectionIntervalMinutes), () {
-      unawaited(_refreshStatus());
-    });
+    await _service.refreshStatus();
   }
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final foregroundColor = _foregroundColor(colorScheme);
-    final fillColor = _containerColor(colorScheme);
+    final palette = _palette(context);
+    final config = _variantConfig;
 
     return Tooltip(
       message: _tooltipMessage,
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          final showLabel = constraints.maxWidth >= 96;
-          return Semantics(
-            button: true,
-            label: '校园网状态，${_status.label}，点击重新检测',
-            child: GestureDetector(
-              key: const Key('campus-network-status-indicator'),
-              behavior: HitTestBehavior.opaque,
-              onTap: _isChecking ? null : _refreshStatus,
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(minWidth: 48, minHeight: 48),
-                child: AnimatedContainer(
-                  duration: AppMotion.short,
-                  padding: EdgeInsetsDirectional.symmetric(
-                    horizontal: showLabel ? AppSpacing.md : AppSpacing.sm,
-                    vertical: AppSpacing.sm,
-                  ),
-                  decoration: BoxDecoration(
-                    color: fillColor,
-                    border: Border.all(color: foregroundColor.withValues(alpha: 0.28)),
-                    borderRadius: const BorderRadius.all(Radius.circular(999)),
-                  ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      _buildStatusIcon(foregroundColor),
-                      if (showLabel) ...[
-                        const SizedBox(width: AppSpacing.sm),
-                        Flexible(
-                          child: Text(
-                            _isChecking ? '检测中' : _status.label,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: Theme.of(context).textTheme.labelMedium
-                                ?.copyWith(color: foregroundColor),
-                          ),
-                        ),
-                      ],
-                    ],
-                  ),
+      child: Semantics(
+        button: true,
+        label: '校园网状态，${_status.label}，点击重新检测',
+        child: FluentHoverButton(
+          onPressed: _isChecking ? null : _refreshStatus,
+          builder: (context, states) => _buildContent(
+            context,
+            palette: palette,
+            config: config,
+            hovered: states.isHovered,
+            pressed: states.isPressed,
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// 构建徽标主体。
+  Widget _buildContent(
+    BuildContext context, {
+    required _StatusPalette palette,
+    required _IndicatorVariantConfig config,
+    required bool hovered,
+    required bool pressed,
+  }) {
+    final colors = context.fluentColors;
+    final spacing = context.fluentSpacing;
+    final radii = context.fluentRadii;
+    final motion = context.fluentMotion;
+    final type = context.fluentType;
+    final background = pressed
+        ? palette.backgroundPressed
+        : hovered
+        ? palette.backgroundHover
+        : palette.background;
+    final label = _isChecking
+        ? '检测中'
+        : config.useShortLabel
+        ? _status.shortLabel
+        : _status.label;
+
+    return AnimatedContainer(
+      key: widget.indicatorKey,
+      duration: motion.durationFast,
+      curve: motion.curveDecelerateMid,
+      width: config.width,
+      height: config.height,
+      padding: EdgeInsetsDirectional.symmetric(
+        horizontal: config.horizontalPadding,
+        vertical: config.verticalPadding,
+      ),
+      decoration: BoxDecoration(
+        color: background,
+        border: Border.all(color: palette.border),
+        borderRadius: BorderRadius.circular(radii.circular),
+        boxShadow: config.elevated
+            ? [
+                BoxShadow(
+                  color: colors.neutralForeground1.withValues(alpha: 0.08),
+                  offset: const Offset(0, 6),
+                  blurRadius: 18,
                 ),
+              ]
+            : null,
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          config.useStatusLight
+              ? _buildStatusLight(palette.foreground)
+              : _buildStatusIcon(palette.foreground, config.iconSize),
+          SizedBox(width: spacing.s),
+          Flexible(
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: (config.compactText ? type.caption1 : type.body1).copyWith(
+                color: palette.foreground,
+                fontWeight: FontWeight.w600,
               ),
             ),
-          );
-        },
+          ),
+        ],
       ),
     );
   }
 
   /// 构建当前状态图标。
-  Widget _buildStatusIcon(Color foregroundColor) {
+  Widget _buildStatusIcon(Color foregroundColor, double size) {
     if (_isChecking) {
-      return SizedBox.square(
-        dimension: 20,
-        child: FluentProgressRing(
-          strokeWidth: 2,
-          activeColor: foregroundColor,
-        ),
+      return FluentProgressRing(
+        size: size,
+        strokeWidth: 2,
+        activeColor: foregroundColor,
       );
     }
 
-    return Icon(_statusIcon, size: 20, color: foregroundColor);
+    return Icon(_statusIcon, size: size, color: foregroundColor);
+  }
+
+  /// 构建首页使用的状态灯。
+  Widget _buildStatusLight(Color foregroundColor) {
+    if (_isChecking) {
+      return FluentProgressRing(
+        size: 12,
+        strokeWidth: 2,
+        activeColor: foregroundColor,
+      );
+    }
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: foregroundColor,
+        boxShadow: [
+          BoxShadow(
+            color: foregroundColor.withValues(alpha: 0.36),
+            blurRadius: 8,
+            spreadRadius: 1,
+          ),
+        ],
+      ),
+      child: const SizedBox.square(dimension: 9),
+    );
   }
 
   IconData get _statusIcon {
     return switch (_status.accessMode) {
-      CampusNetworkAccessMode.campus ||
-      CampusNetworkAccessMode.vpn ||
-      CampusNetworkAccessMode.campusOrVpn => Icons.power,
-      CampusNetworkAccessMode.unavailable => Icons.power_off,
-      CampusNetworkAccessMode.unknown => Icons.sync,
+      CampusNetworkAccessMode.campus => FluentIcons.plugConnected,
+      CampusNetworkAccessMode.vpn => FluentIcons.shield,
+      CampusNetworkAccessMode.outsideCampus => FluentIcons.globe,
+      CampusNetworkAccessMode.unknown => FluentIcons.syncStatus,
     };
   }
 
-  Color _foregroundColor(ColorScheme colorScheme) {
+  _StatusPalette _palette(BuildContext context) {
+    final colors = context.fluentColors;
     return switch (_status.accessMode) {
       CampusNetworkAccessMode.campus ||
-      CampusNetworkAccessMode.vpn ||
-      CampusNetworkAccessMode.campusOrVpn => colorScheme.primary,
-      CampusNetworkAccessMode.unavailable => colorScheme.error,
-      CampusNetworkAccessMode.unknown => colorScheme.onSurfaceVariant,
+      CampusNetworkAccessMode.vpn => _StatusPalette(
+        foreground: colors.statusSuccessForeground,
+        background: colors.statusSuccessBackground,
+        backgroundHover: colors.statusSuccessBackground.withValues(alpha: 0.86),
+        backgroundPressed: colors.statusSuccessBackground.withValues(
+          alpha: 0.72,
+        ),
+        border: colors.statusSuccessForeground.withValues(alpha: 0.22),
+      ),
+      CampusNetworkAccessMode.outsideCampus => _StatusPalette(
+        foreground: widget.variant == CampusNetworkStatusIndicatorVariant.home
+            ? colors.neutralForeground3
+            : colors.statusWarningForeground,
+        background: widget.variant == CampusNetworkStatusIndicatorVariant.home
+            ? colors.neutralBackground3
+            : colors.statusWarningBackground,
+        backgroundHover:
+            widget.variant == CampusNetworkStatusIndicatorVariant.home
+            ? colors.neutralBackground2
+            : colors.statusWarningBackground.withValues(alpha: 0.86),
+        backgroundPressed:
+            widget.variant == CampusNetworkStatusIndicatorVariant.home
+            ? colors.neutralBackground1Pressed
+            : colors.statusWarningBackground.withValues(alpha: 0.72),
+        border: colors.neutralStroke2,
+      ),
+      CampusNetworkAccessMode.unknown => _StatusPalette(
+        foreground: colors.neutralForeground3,
+        background: colors.neutralBackground3,
+        backgroundHover: colors.neutralBackground2,
+        backgroundPressed: colors.neutralBackground1Pressed,
+        border: colors.neutralStroke2,
+      ),
     };
   }
 
-  Color _containerColor(ColorScheme colorScheme) {
-    return switch (_status.accessMode) {
-      CampusNetworkAccessMode.campus ||
-      CampusNetworkAccessMode.vpn ||
-      CampusNetworkAccessMode.campusOrVpn => colorScheme.primaryContainer,
-      CampusNetworkAccessMode.unavailable => colorScheme.errorContainer,
-      CampusNetworkAccessMode.unknown => colorScheme.surfaceContainerHighest,
+  _IndicatorVariantConfig get _variantConfig {
+    return switch (widget.variant) {
+      CampusNetworkStatusIndicatorVariant.standard =>
+        const _IndicatorVariantConfig(
+          height: 44,
+          horizontalPadding: 14,
+          verticalPadding: 8,
+          iconSize: 18,
+        ),
+      CampusNetworkStatusIndicatorVariant.titleBar =>
+        const _IndicatorVariantConfig(
+          width: 152,
+          height: 30,
+          horizontalPadding: 12,
+          verticalPadding: 4,
+          iconSize: 16,
+          compactText: true,
+        ),
+      CampusNetworkStatusIndicatorVariant.home => const _IndicatorVariantConfig(
+        height: 32,
+        horizontalPadding: 12,
+        verticalPadding: 5,
+        iconSize: 14,
+        compactText: true,
+        useShortLabel: true,
+        useStatusLight: true,
+        elevated: true,
+      ),
     };
   }
 
@@ -235,4 +326,44 @@ class _CampusNetworkStatusIndicatorState
 
     return '${_status.description}\n${_status.detail}\n$checkedAtLabel\n$intervalLabel\n点击可重新检测';
   }
+}
+
+class _StatusPalette {
+  const _StatusPalette({
+    required this.foreground,
+    required this.background,
+    required this.backgroundHover,
+    required this.backgroundPressed,
+    required this.border,
+  });
+
+  final Color foreground;
+  final Color background;
+  final Color backgroundHover;
+  final Color backgroundPressed;
+  final Color border;
+}
+
+class _IndicatorVariantConfig {
+  const _IndicatorVariantConfig({
+    this.width,
+    required this.height,
+    required this.horizontalPadding,
+    required this.verticalPadding,
+    required this.iconSize,
+    this.compactText = false,
+    this.useShortLabel = false,
+    this.useStatusLight = false,
+    this.elevated = false,
+  });
+
+  final double? width;
+  final double height;
+  final double horizontalPadding;
+  final double verticalPadding;
+  final double iconSize;
+  final bool compactText;
+  final bool useShortLabel;
+  final bool useStatusLight;
+  final bool elevated;
 }

--- a/lib/widgets/desktop_window_frame.dart
+++ b/lib/widgets/desktop_window_frame.dart
@@ -1,0 +1,188 @@
+/*
+ * 桌面窗口框架 — 自绘标题栏并承载校园网状态入口
+ * @Project : SSPU-AllinOne
+ * @File : desktop_window_frame.dart
+ * @Author : Qintsg
+ * @Date : 2026-05-31
+ */
+
+import 'dart:async';
+
+import 'package:window_manager/window_manager.dart';
+
+import '../design/fluent_ui.dart';
+import '../services/campus_network_status_service.dart';
+import 'campus_network_status_indicator.dart';
+
+/// 桌面端自绘窗口框架。
+///
+/// 原生标题栏被隐藏后，使用该组件提供拖拽区域、窗口按钮和网络状态入口。
+class DesktopWindowFrame extends StatefulWidget {
+  const DesktopWindowFrame({
+    super.key,
+    required this.child,
+    this.campusNetworkStatusService,
+  });
+
+  /// 主内容。
+  final Widget child;
+
+  /// 校园网 / VPN 状态检测服务；为空时不展示状态入口。
+  final CampusNetworkStatusService? campusNetworkStatusService;
+
+  @override
+  State<DesktopWindowFrame> createState() => _DesktopWindowFrameState();
+}
+
+class _DesktopWindowFrameState extends State<DesktopWindowFrame>
+    with WindowListener {
+  bool _isMaximized = false;
+
+  @override
+  void initState() {
+    super.initState();
+    windowManager.addListener(this);
+    unawaited(_loadWindowState());
+  }
+
+  @override
+  void dispose() {
+    windowManager.removeListener(this);
+    super.dispose();
+  }
+
+  /// 读取初始最大化状态，保证窗口按钮图标与真实窗口一致。
+  Future<void> _loadWindowState() async {
+    final isMaximized = await windowManager.isMaximized();
+    if (!mounted) return;
+    setState(() => _isMaximized = isMaximized);
+  }
+
+  @override
+  void onWindowMaximize() {
+    if (mounted) setState(() => _isMaximized = true);
+  }
+
+  @override
+  void onWindowUnmaximize() {
+    if (mounted) setState(() => _isMaximized = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.fluentColors;
+
+    return VirtualWindowFrame(
+      child: ColoredBox(
+        color: colors.neutralBackground1,
+        child: Column(
+          children: [
+            _DesktopWindowTitleBar(
+              isMaximized: _isMaximized,
+              campusNetworkStatusService: widget.campusNetworkStatusService,
+              onToggleMaximized: _toggleMaximized,
+            ),
+            Expanded(child: widget.child),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 切换最大化 / 还原。
+  void _toggleMaximized() {
+    unawaited(_setMaximized(!_isMaximized));
+  }
+
+  Future<void> _setMaximized(bool maximized) async {
+    if (maximized) {
+      await windowManager.maximize();
+      return;
+    }
+    await windowManager.unmaximize();
+  }
+}
+
+class _DesktopWindowTitleBar extends StatelessWidget {
+  const _DesktopWindowTitleBar({
+    required this.isMaximized,
+    required this.campusNetworkStatusService,
+    required this.onToggleMaximized,
+  });
+
+  final bool isMaximized;
+  final CampusNetworkStatusService? campusNetworkStatusService;
+  final VoidCallback onToggleMaximized;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.fluentColors;
+    final spacing = context.fluentSpacing;
+    final type = context.fluentType;
+    final brightness = Theme.of(context).brightness;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: colors.neutralBackground2,
+        border: Border(bottom: BorderSide(color: colors.neutralStrokeDivider)),
+      ),
+      child: SizedBox(
+        height: 40,
+        child: Row(
+          children: [
+            Expanded(
+              child: DragToMoveArea(
+                child: Padding(
+                  padding: EdgeInsetsDirectional.only(start: spacing.l),
+                  child: Row(
+                    children: [
+                      Icon(
+                        FluentIcons.home,
+                        size: 16,
+                        color: colors.brandForeground1,
+                      ),
+                      SizedBox(width: spacing.s),
+                      Text(
+                        'SSPU-AllinOne',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: type.caption1Strong.copyWith(
+                          color: colors.neutralForeground1,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            if (campusNetworkStatusService != null) ...[
+              CampusNetworkStatusIndicator(
+                service: campusNetworkStatusService,
+                variant: CampusNetworkStatusIndicatorVariant.titleBar,
+                indicatorKey: const Key('campus-network-status-titlebar'),
+              ),
+              SizedBox(width: spacing.xs),
+            ],
+            WindowCaptionButton.minimize(
+              brightness: brightness,
+              onPressed: () => unawaited(windowManager.minimize()),
+            ),
+            isMaximized
+                ? WindowCaptionButton.unmaximize(
+                    brightness: brightness,
+                    onPressed: onToggleMaximized,
+                  )
+                : WindowCaptionButton.maximize(
+                    brightness: brightness,
+                    onPressed: onToggleMaximized,
+                  ),
+            WindowCaptionButton.close(
+              brightness: brightness,
+              onPressed: () => unawaited(windowManager.close()),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/campus_network_status_service_test.dart
+++ b/test/campus_network_status_service_test.dart
@@ -13,7 +13,8 @@ import 'package:sspu_allinone/services/campus_network_status_service.dart';
 import 'package:sspu_allinone/services/storage_service.dart';
 
 void main() {
-  final probeUri = Uri.parse('https://tygl.sspu.edu.cn/');
+  final campusProbeUri = Uri.parse('https://tygl.sspu.edu.cn/');
+  final vpnProbeUri = Uri.parse('https://vpn.sspu.edu.cn/');
 
   setUp(() {
     SharedPreferences.setMockInitialValues({});
@@ -25,10 +26,72 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
 
-  test('探针可达时返回校园网或 VPN 可用状态', () async {
+  test('VPN 入口和校园站点均可达时返回 VPN 环境', () async {
+    final service = _buildService(
+      campusProbeUri: campusProbeUri,
+      vpnProbeUri: vpnProbeUri,
+      vpnReachable: true,
+      campusReachable: true,
+    );
+
+    final status = await service.checkStatus();
+
+    expect(status.accessMode, CampusNetworkAccessMode.vpn);
+    expect(status.canAccessRestrictedServices, isTrue);
+    expect(status.probeUri, campusProbeUri);
+    expect(status.vpnProbeUri, vpnProbeUri);
+    expect(status.checkedAt, isNotNull);
+  });
+
+  test('仅校园站点可达时返回校园网环境', () async {
+    final service = _buildService(
+      campusProbeUri: campusProbeUri,
+      vpnProbeUri: vpnProbeUri,
+      vpnReachable: false,
+      campusReachable: true,
+    );
+
+    final status = await service.checkStatus();
+
+    expect(status.accessMode, CampusNetworkAccessMode.campus);
+    expect(status.canAccessRestrictedServices, isTrue);
+  });
+
+  test('仅 VPN 入口可达时返回非校园网环境', () async {
+    final service = _buildService(
+      campusProbeUri: campusProbeUri,
+      vpnProbeUri: vpnProbeUri,
+      vpnReachable: true,
+      campusReachable: false,
+    );
+
+    final status = await service.checkStatus();
+
+    expect(status.accessMode, CampusNetworkAccessMode.outsideCampus);
+    expect(status.canAccessRestrictedServices, isFalse);
+    expect(status.description, contains('连接校园网或学校 VPN'));
+  });
+
+  test('双探针均不可达时返回网络环境未知', () async {
+    final service = _buildService(
+      campusProbeUri: campusProbeUri,
+      vpnProbeUri: vpnProbeUri,
+      vpnReachable: false,
+      campusReachable: false,
+    );
+
+    final status = await service.checkStatus();
+
+    expect(status.accessMode, CampusNetworkAccessMode.unknown);
+    expect(status.canAccessRestrictedServices, isFalse);
+  });
+
+  test('单个探针抛出异常时不影响另一个探针判定', () async {
     final service = CampusNetworkStatusService(
-      probeUri: probeUri,
+      probeUri: campusProbeUri,
+      vpnProbeUri: vpnProbeUri,
       probe: (uri, timeout) async {
+        if (uri.host == vpnProbeUri.host) throw StateError('probe failed');
         return CampusNetworkProbeResult(
           reachable: true,
           statusCode: 200,
@@ -39,46 +102,12 @@ void main() {
 
     final status = await service.checkStatus();
 
-    expect(status.accessMode, CampusNetworkAccessMode.campusOrVpn);
-    expect(status.canAccessRestrictedServices, isTrue);
-    expect(status.probeUri, probeUri);
-    expect(status.checkedAt, isNotNull);
-  });
-
-  test('探针不可达时返回受限入口不可用状态', () async {
-    final service = CampusNetworkStatusService(
-      probeUri: probeUri,
-      probe: (uri, timeout) async {
-        return CampusNetworkProbeResult(
-          reachable: false,
-          detail: '访问 ${uri.host} 超时',
-        );
-      },
-    );
-
-    final status = await service.checkStatus();
-
-    expect(status.accessMode, CampusNetworkAccessMode.unavailable);
-    expect(status.canAccessRestrictedServices, isFalse);
-    expect(status.description, contains('连接校园网或学校 VPN'));
-  });
-
-  test('探针抛出异常时返回失败说明而不是继续向外抛出', () async {
-    final service = CampusNetworkStatusService(
-      probeUri: probeUri,
-      probe: (uri, timeout) async {
-        throw StateError('probe failed');
-      },
-    );
-
-    final status = await service.checkStatus();
-
-    expect(status.accessMode, CampusNetworkAccessMode.unavailable);
+    expect(status.accessMode, CampusNetworkAccessMode.campus);
     expect(status.detail, contains('probe failed'));
   });
 
   test('检测间隔默认 15 分钟并支持关闭自动检测', () async {
-    final service = CampusNetworkStatusService(probeUri: probeUri);
+    final service = CampusNetworkStatusService(probeUri: campusProbeUri);
 
     expect(
       await service.getDetectionIntervalMinutes(),
@@ -91,4 +120,53 @@ void main() {
     await service.setDetectionIntervalMinutes(-1);
     expect(await service.getDetectionIntervalMinutes(), 0);
   });
+
+  test('共享刷新会合并同时触发的检测请求', () async {
+    var probeCount = 0;
+    final service = CampusNetworkStatusService(
+      probeUri: campusProbeUri,
+      vpnProbeUri: vpnProbeUri,
+      probe: (uri, timeout) async {
+        probeCount++;
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        return CampusNetworkProbeResult(
+          reachable: true,
+          statusCode: 200,
+          detail: '已访问 ${uri.host}，HTTP 200',
+        );
+      },
+    );
+
+    final firstRefresh = service.refreshStatus();
+    final secondRefresh = service.refreshStatus();
+    final statuses = await Future.wait([firstRefresh, secondRefresh]);
+
+    expect(statuses.first.accessMode, CampusNetworkAccessMode.vpn);
+    expect(statuses.last.accessMode, CampusNetworkAccessMode.vpn);
+    expect(service.currentStatus.accessMode, CampusNetworkAccessMode.vpn);
+    expect(service.isChecking, isFalse);
+    expect(probeCount, 2);
+  });
+}
+
+CampusNetworkStatusService _buildService({
+  required Uri campusProbeUri,
+  required Uri vpnProbeUri,
+  required bool vpnReachable,
+  required bool campusReachable,
+}) {
+  return CampusNetworkStatusService(
+    probeUri: campusProbeUri,
+    vpnProbeUri: vpnProbeUri,
+    probe: (uri, timeout) async {
+      final reachable = uri.host == vpnProbeUri.host
+          ? vpnReachable
+          : campusReachable;
+      return CampusNetworkProbeResult(
+        reachable: reachable,
+        statusCode: reachable ? 200 : null,
+        detail: reachable ? '已访问 ${uri.host}，HTTP 200' : '访问 ${uri.host} 超时',
+      );
+    },
+  );
 }

--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -12,6 +12,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sspu_allinone/models/campus_card.dart';
 import 'package:sspu_allinone/pages/home_page.dart';
 import 'package:sspu_allinone/services/campus_card_service.dart';
+import 'package:sspu_allinone/services/campus_network_status_service.dart';
 import 'package:sspu_allinone/services/storage_service.dart';
 
 /// 等待目标组件出现，避免页面异步加载尚未完成时提前断言。
@@ -42,10 +43,12 @@ void main() {
 
   testWidgets('首页校园卡卡片可手动刷新并进入详情页', (tester) async {
     final service = _FakeCampusCardClient(result: _successResult);
+    final campusNetworkStatusService = _buildCampusNetworkStatusService();
     await tester.pumpWidget(
       MaterialApp(
         home: HomePage(
           campusCardService: service,
+          campusNetworkStatusService: campusNetworkStatusService,
           campusCardAutoRefreshEnabledOverride: false,
           campusCardAutoRefreshIntervalOverride: 30,
         ),
@@ -75,10 +78,12 @@ void main() {
 
   testWidgets('校园卡自动刷新开启时会主动读取余额', (tester) async {
     final service = _FakeCampusCardClient(result: _successResult);
+    final campusNetworkStatusService = _buildCampusNetworkStatusService();
     await tester.pumpWidget(
       MaterialApp(
         home: HomePage(
           campusCardService: service,
+          campusNetworkStatusService: campusNetworkStatusService,
           campusCardAutoRefreshEnabledOverride: true,
           campusCardAutoRefreshIntervalOverride: 30,
         ),
@@ -90,6 +95,40 @@ void main() {
     expect(service.fetchCount, 1);
     await disposeHomePage(tester);
   });
+
+  testWidgets('首页右上角显示小型网络状态指示', (tester) async {
+    final campusNetworkStatusService = _buildCampusNetworkStatusService();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: HomePage(
+          campusNetworkStatusService: campusNetworkStatusService,
+          campusCardAutoRefreshEnabledOverride: false,
+          campusCardAutoRefreshIntervalOverride: 30,
+        ),
+      ),
+    );
+
+    await pumpUntilFound(
+      tester,
+      find.byKey(const Key('campus-network-status-home')),
+    );
+
+    expect(find.byKey(const Key('campus-network-status-home')), findsOneWidget);
+    expect(find.text('VPN'), findsOneWidget);
+    await disposeHomePage(tester);
+  });
+}
+
+CampusNetworkStatusService _buildCampusNetworkStatusService() {
+  return CampusNetworkStatusService(
+    probe: (uri, timeout) async {
+      return CampusNetworkProbeResult(
+        reachable: true,
+        statusCode: 200,
+        detail: '已访问 ${uri.host}，HTTP 200',
+      );
+    },
+  );
 }
 
 class _FakeCampusCardClient implements CampusCardBalanceClient {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -17,6 +17,7 @@ import 'package:sspu_allinone/pages/webview_page.dart';
 import 'package:sspu_allinone/services/campus_network_status_service.dart';
 import 'package:sspu_allinone/services/storage_service.dart';
 import 'package:sspu_allinone/services/wxmp_config_service.dart';
+import 'package:sspu_allinone/widgets/campus_network_status_indicator.dart';
 import 'package:sspu_allinone/widgets/settings_auto_refresh_section.dart';
 import 'package:sspu_allinone/widgets/settings_wechat_section.dart';
 
@@ -60,7 +61,12 @@ void main() {
     await configureMobileView(tester);
 
     try {
-      await tester.pumpWidget(const MaterialApp(home: AppShell()));
+      SharedPreferences.setMockInitialValues({});
+      StorageService.debugUseSharedPreferencesStorageForTesting(true);
+      final service = _buildCampusNetworkStatusService();
+      await tester.pumpWidget(
+        MaterialApp(home: AppShell(campusNetworkStatusService: service)),
+      );
       await tester.pump(const Duration(milliseconds: 100));
 
       final bottomNavigation = find.byKey(
@@ -99,23 +105,19 @@ void main() {
       await tester.pump(const Duration(milliseconds: 300));
     } finally {
       debugDefaultTargetPlatformOverride = previousTargetPlatform;
+      StorageService.debugUseSharedPreferencesStorageForTesting(null);
+      SharedPreferences.setMockInitialValues({});
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
       await resetMobileView(tester);
     }
   });
 
-  testWidgets('桌面导航在设置上方显示校园网状态徽标', (WidgetTester tester) async {
+  testWidgets('桌面首页右上角显示校园网状态小徽标', (WidgetTester tester) async {
     SharedPreferences.setMockInitialValues({});
     StorageService.debugUseSharedPreferencesStorageForTesting(true);
     final previousTargetPlatform = debugDefaultTargetPlatformOverride;
-    final service = CampusNetworkStatusService(
-      probe: (uri, timeout) async {
-        return CampusNetworkProbeResult(
-          reachable: true,
-          statusCode: 200,
-          detail: '已访问 ${uri.host}，HTTP 200',
-        );
-      },
-    );
+    final service = _buildCampusNetworkStatusService();
     debugDefaultTargetPlatformOverride = TargetPlatform.windows;
     tester.view.physicalSize = const Size(1280, 800);
     tester.view.devicePixelRatio = 1.0;
@@ -126,13 +128,18 @@ void main() {
         MaterialApp(home: AppShell(campusNetworkStatusService: service)),
       );
       await tester.pump(const Duration(milliseconds: 100));
+      await pumpUntilFound(tester, find.text('VPN'));
 
       // 校园网徽标由可注入服务驱动，避免组件测试依赖真实校园网环境。
       expect(
-        find.byKey(const Key('campus-network-status-indicator')),
+        find.byKey(const Key('campus-network-status-home')),
         findsOneWidget,
       );
-      expect(find.text('校园网/VPN'), findsOneWidget);
+      expect(find.text('VPN'), findsOneWidget);
+      expect(
+        find.byKey(const Key('campus-network-status-pane-item')),
+        findsNothing,
+      );
 
       // 首页入场动画会保留短计时器，测试结束前推进时间以清理动画状态。
       await tester.pump(const Duration(milliseconds: 300));
@@ -140,9 +147,65 @@ void main() {
       debugDefaultTargetPlatformOverride = previousTargetPlatform;
       StorageService.debugUseSharedPreferencesStorageForTesting(null);
       SharedPreferences.setMockInitialValues({});
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
       tester.view.resetPhysicalSize();
       tester.view.resetDevicePixelRatio();
       await tester.binding.setSurfaceSize(null);
+    }
+  });
+
+  testWidgets('多个校园网状态入口共享同一次检测结果', (WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues({});
+    StorageService.debugUseSharedPreferencesStorageForTesting(true);
+    var probeCount = 0;
+    final service = CampusNetworkStatusService(
+      probe: (uri, timeout) async {
+        probeCount++;
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        return CampusNetworkProbeResult(
+          reachable: true,
+          statusCode: 200,
+          detail: '已访问 ${uri.host}，HTTP 200',
+        );
+      },
+    );
+
+    try {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Row(
+            children: [
+              CampusNetworkStatusIndicator(
+                service: service,
+                indicatorKey: const Key('campus-network-status-first'),
+              ),
+              CampusNetworkStatusIndicator(
+                service: service,
+                indicatorKey: const Key('campus-network-status-second'),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      await pumpUntilFound(tester, find.text('VPN 环境'));
+
+      expect(
+        find.byKey(const Key('campus-network-status-first')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('campus-network-status-second')),
+        findsOneWidget,
+      );
+      expect(find.text('VPN 环境'), findsNWidgets(2));
+      expect(probeCount, 2);
+    } finally {
+      StorageService.debugUseSharedPreferencesStorageForTesting(null);
+      SharedPreferences.setMockInitialValues({});
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
     }
   });
 
@@ -295,6 +358,18 @@ void main() {
       await tester.binding.setSurfaceSize(null);
     }
   });
+}
+
+CampusNetworkStatusService _buildCampusNetworkStatusService() {
+  return CampusNetworkStatusService(
+    probe: (uri, timeout) async {
+      return CampusNetworkProbeResult(
+        reachable: true,
+        statusCode: 200,
+        detail: '已访问 ${uri.host}，HTTP 200',
+      );
+    },
+  );
 }
 
 class _SettingsNavigationLayoutHarness extends StatelessWidget {


### PR DESCRIPTION
## 变更说明
- 新增桌面自绘标题栏，展示校园网 / VPN 状态入口并保留窗口拖拽与最小化/最大化/关闭按钮
- 将校园网状态检测服务改为共享状态，支持多入口共用同一次刷新结果
- 首页右上角新增小型网络状态徽标，并补充相关服务和 Widget 测试

## 验证记录
- flutter analyze --no-fatal-infos
- flutter test test/campus_network_status_service_test.dart test/home_page_test.dart test/widget_test.dart

## 影响范围
- 桌面端窗口标题栏与校园网 / VPN 状态展示
- 首页标题栏命令区
- 校园网状态检测定时刷新与手动刷新逻辑

## 回滚方式
- Revert 本 PR 对应提交