### PR TITLE
fix(auth): 优化鉴权数据缓存刷新

### DIFF
--- a/lib/models/academic_eams/course_offerings.dart
+++ b/lib/models/academic_eams/course_offerings.dart
@@ -30,6 +30,30 @@ class AcademicCourseOfferingSearchCriteria {
 
   /// 开课院系。
   final String? department;
+
+  /// 从 JSON 恢复开课检索条件。
+  factory AcademicCourseOfferingSearchCriteria.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return AcademicCourseOfferingSearchCriteria(
+      termName: json['termName'] as String?,
+      courseCode: json['courseCode'] as String?,
+      courseName: json['courseName'] as String?,
+      teacher: json['teacher'] as String?,
+      department: json['department'] as String?,
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'termName': termName,
+      'courseCode': courseCode,
+      'courseName': courseName,
+      'teacher': teacher,
+      'department': department,
+    };
+  }
 }
 
 /// 单条开课记录。
@@ -76,6 +100,38 @@ class AcademicCourseOfferingRecord {
 
   /// 原始单元格文本。
   final List<String> rawCells;
+
+  /// 从 JSON 恢复开课记录。
+  factory AcademicCourseOfferingRecord.fromJson(Map<String, dynamic> json) {
+    return AcademicCourseOfferingRecord(
+      courseName: json['courseName'] as String? ?? '',
+      rawCells: (json['rawCells'] as List<dynamic>? ?? const []).cast<String>(),
+      courseCode: json['courseCode'] as String?,
+      teacher: json['teacher'] as String?,
+      credit: (json['credit'] as num?)?.toDouble(),
+      capacity: (json['capacity'] as num?)?.toInt(),
+      department: json['department'] as String?,
+      scheduleText: json['scheduleText'] as String?,
+      locationText: json['locationText'] as String?,
+      termName: json['termName'] as String?,
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'courseName': courseName,
+      'rawCells': rawCells,
+      'courseCode': courseCode,
+      'teacher': teacher,
+      'credit': credit,
+      'capacity': capacity,
+      'department': department,
+      'scheduleText': scheduleText,
+      'locationText': locationText,
+      'termName': termName,
+    };
+  }
 }
 
 /// 开课检索结果。
@@ -98,4 +154,33 @@ class AcademicCourseOfferingSearchResult {
 
   /// 来源页面地址。
   final Uri sourceUri;
+
+  /// 从 JSON 恢复开课检索结果。
+  factory AcademicCourseOfferingSearchResult.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return AcademicCourseOfferingSearchResult(
+      criteria: AcademicCourseOfferingSearchCriteria.fromJson(
+        json['criteria'] as Map<String, dynamic>? ?? const {},
+      ),
+      records: (json['records'] as List<dynamic>? ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(AcademicCourseOfferingRecord.fromJson)
+          .toList(),
+      fetchedAt:
+          DateTime.tryParse(json['fetchedAt'] as String? ?? '')?.toLocal() ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+      sourceUri: Uri.parse(json['sourceUri'] as String? ?? ''),
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'criteria': criteria.toJson(),
+      'records': records.map((record) => record.toJson()).toList(),
+      'fetchedAt': fetchedAt.toUtc().toIso8601String(),
+      'sourceUri': sourceUri.toString(),
+    };
+  }
 }

--- a/lib/models/academic_eams/course_table.dart
+++ b/lib/models/academic_eams/course_table.dart
@@ -47,6 +47,36 @@ class AcademicCourseTableEntry {
   /// 单元格原始文本，供解析降级展示。
   final String rawText;
 
+  /// 从 JSON 恢复课表课程记录。
+  factory AcademicCourseTableEntry.fromJson(Map<String, dynamic> json) {
+    return AcademicCourseTableEntry(
+      courseName: json['courseName'] as String? ?? '',
+      weekday: (json['weekday'] as num?)?.toInt() ?? 0,
+      startUnit: (json['startUnit'] as num?)?.toInt() ?? 0,
+      endUnit: (json['endUnit'] as num?)?.toInt() ?? 0,
+      timeText: json['timeText'] as String? ?? '',
+      rawText: json['rawText'] as String? ?? '',
+      teacher: json['teacher'] as String?,
+      location: json['location'] as String?,
+      weekDescription: json['weekDescription'] as String?,
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'courseName': courseName,
+      'weekday': weekday,
+      'startUnit': startUnit,
+      'endUnit': endUnit,
+      'timeText': timeText,
+      'rawText': rawText,
+      'teacher': teacher,
+      'location': location,
+      'weekDescription': weekDescription,
+    };
+  }
+
   /// 友好的星期文案。
   String get weekdayLabel {
     return switch (weekday) {
@@ -82,4 +112,29 @@ class AcademicCourseTableSnapshot {
 
   /// 产生该快照的业务页面地址。
   final Uri sourceUri;
+
+  /// 从 JSON 恢复课表快照。
+  factory AcademicCourseTableSnapshot.fromJson(Map<String, dynamic> json) {
+    return AcademicCourseTableSnapshot(
+      entries: (json['entries'] as List<dynamic>? ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(AcademicCourseTableEntry.fromJson)
+          .toList(),
+      fetchedAt:
+          DateTime.tryParse(json['fetchedAt'] as String? ?? '')?.toLocal() ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+      sourceUri: Uri.parse(json['sourceUri'] as String? ?? ''),
+      termName: json['termName'] as String?,
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'entries': entries.map((entry) => entry.toJson()).toList(),
+      'fetchedAt': fetchedAt.toUtc().toIso8601String(),
+      'sourceUri': sourceUri.toString(),
+      'termName': termName,
+    };
+  }
 }

--- a/lib/models/academic_eams/exams.dart
+++ b/lib/models/academic_eams/exams.dart
@@ -34,6 +34,30 @@ class AcademicExamRecord {
 
   /// 原始单元格文本。
   final List<String> rawCells;
+
+  /// 从 JSON 恢复考试安排。
+  factory AcademicExamRecord.fromJson(Map<String, dynamic> json) {
+    return AcademicExamRecord(
+      courseName: json['courseName'] as String? ?? '',
+      rawCells: (json['rawCells'] as List<dynamic>? ?? const []).cast<String>(),
+      examTime: json['examTime'] as String?,
+      location: json['location'] as String?,
+      seatNumber: json['seatNumber'] as String?,
+      status: json['status'] as String?,
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'courseName': courseName,
+      'rawCells': rawCells,
+      'examTime': examTime,
+      'location': location,
+      'seatNumber': seatNumber,
+      'status': status,
+    };
+  }
 }
 
 /// 考试安排快照。
@@ -52,4 +76,27 @@ class AcademicExamSnapshot {
 
   /// 来源页面地址。
   final Uri sourceUri;
+
+  /// 从 JSON 恢复考试安排快照。
+  factory AcademicExamSnapshot.fromJson(Map<String, dynamic> json) {
+    return AcademicExamSnapshot(
+      records: (json['records'] as List<dynamic>? ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(AcademicExamRecord.fromJson)
+          .toList(),
+      fetchedAt:
+          DateTime.tryParse(json['fetchedAt'] as String? ?? '')?.toLocal() ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+      sourceUri: Uri.parse(json['sourceUri'] as String? ?? ''),
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'records': records.map((record) => record.toJson()).toList(),
+      'fetchedAt': fetchedAt.toUtc().toIso8601String(),
+      'sourceUri': sourceUri.toString(),
+    };
+  }
 }

--- a/lib/models/academic_eams/free_classrooms.dart
+++ b/lib/models/academic_eams/free_classrooms.dart
@@ -30,6 +30,30 @@ class AcademicFreeClassroomSearchCriteria {
 
   /// 结束节次。
   final int? lessonTo;
+
+  /// 从 JSON 恢复空闲教室查询条件。
+  factory AcademicFreeClassroomSearchCriteria.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return AcademicFreeClassroomSearchCriteria(
+      campus: json['campus'] as String?,
+      building: json['building'] as String?,
+      dateText: json['dateText'] as String?,
+      lessonFrom: (json['lessonFrom'] as num?)?.toInt(),
+      lessonTo: (json['lessonTo'] as num?)?.toInt(),
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'campus': campus,
+      'building': building,
+      'dateText': dateText,
+      'lessonFrom': lessonFrom,
+      'lessonTo': lessonTo,
+    };
+  }
 }
 
 /// 单条空闲教室记录。
@@ -68,6 +92,34 @@ class AcademicFreeClassroomRecord {
 
   /// 原始单元格文本。
   final List<String> rawCells;
+
+  /// 从 JSON 恢复空闲教室记录。
+  factory AcademicFreeClassroomRecord.fromJson(Map<String, dynamic> json) {
+    return AcademicFreeClassroomRecord(
+      roomName: json['roomName'] as String? ?? '',
+      rawCells: (json['rawCells'] as List<dynamic>? ?? const []).cast<String>(),
+      campus: json['campus'] as String?,
+      building: json['building'] as String?,
+      location: json['location'] as String?,
+      capacity: (json['capacity'] as num?)?.toInt(),
+      dateText: json['dateText'] as String?,
+      lessonText: json['lessonText'] as String?,
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'roomName': roomName,
+      'rawCells': rawCells,
+      'campus': campus,
+      'building': building,
+      'location': location,
+      'capacity': capacity,
+      'dateText': dateText,
+      'lessonText': lessonText,
+    };
+  }
 }
 
 /// 空闲教室查询结果。
@@ -90,4 +142,33 @@ class AcademicFreeClassroomSearchResult {
 
   /// 来源页面地址。
   final Uri sourceUri;
+
+  /// 从 JSON 恢复空闲教室查询结果。
+  factory AcademicFreeClassroomSearchResult.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return AcademicFreeClassroomSearchResult(
+      criteria: AcademicFreeClassroomSearchCriteria.fromJson(
+        json['criteria'] as Map<String, dynamic>? ?? const {},
+      ),
+      records: (json['records'] as List<dynamic>? ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(AcademicFreeClassroomRecord.fromJson)
+          .toList(),
+      fetchedAt:
+          DateTime.tryParse(json['fetchedAt'] as String? ?? '')?.toLocal() ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+      sourceUri: Uri.parse(json['sourceUri'] as String? ?? ''),
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'criteria': criteria.toJson(),
+      'records': records.map((record) => record.toJson()).toList(),
+      'fetchedAt': fetchedAt.toUtc().toIso8601String(),
+      'sourceUri': sourceUri.toString(),
+    };
+  }
 }

--- a/lib/models/academic_eams/grades.dart
+++ b/lib/models/academic_eams/grades.dart
@@ -47,6 +47,36 @@ class AcademicGradeRecord {
   /// 原始单元格文本。
   final List<String> rawCells;
 
+  /// 从 JSON 恢复成绩记录。
+  factory AcademicGradeRecord.fromJson(Map<String, dynamic> json) {
+    return AcademicGradeRecord(
+      courseName: json['courseName'] as String? ?? '',
+      scoreText: json['scoreText'] as String? ?? '',
+      rawCells: (json['rawCells'] as List<dynamic>? ?? const []).cast<String>(),
+      courseCode: json['courseCode'] as String?,
+      termName: json['termName'] as String?,
+      credit: (json['credit'] as num?)?.toDouble(),
+      gradePoint: (json['gradePoint'] as num?)?.toDouble(),
+      processScoreText: json['processScoreText'] as String?,
+      totalScoreText: json['totalScoreText'] as String?,
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'courseName': courseName,
+      'scoreText': scoreText,
+      'rawCells': rawCells,
+      'courseCode': courseCode,
+      'termName': termName,
+      'credit': credit,
+      'gradePoint': gradePoint,
+      'processScoreText': processScoreText,
+      'totalScoreText': totalScoreText,
+    };
+  }
+
   /// 是否可视为通过，用于培养计划完成情况的保守统计。
   bool get isPassed {
     final normalized = scoreText.replaceAll(RegExp(r'\s+'), '').toLowerCase();
@@ -80,4 +110,37 @@ class AcademicGradeSnapshot {
 
   /// 产生该快照的最后页面地址。
   final Uri sourceUri;
+
+  /// 从 JSON 恢复成绩快照。
+  factory AcademicGradeSnapshot.fromJson(Map<String, dynamic> json) {
+    return AcademicGradeSnapshot(
+      currentTermRecords:
+          (json['currentTermRecords'] as List<dynamic>? ?? const [])
+              .whereType<Map<String, dynamic>>()
+              .map(AcademicGradeRecord.fromJson)
+              .toList(),
+      historyRecords: (json['historyRecords'] as List<dynamic>? ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(AcademicGradeRecord.fromJson)
+          .toList(),
+      fetchedAt:
+          DateTime.tryParse(json['fetchedAt'] as String? ?? '')?.toLocal() ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+      sourceUri: Uri.parse(json['sourceUri'] as String? ?? ''),
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'currentTermRecords': currentTermRecords
+          .map((record) => record.toJson())
+          .toList(),
+      'historyRecords': historyRecords
+          .map((record) => record.toJson())
+          .toList(),
+      'fetchedAt': fetchedAt.toUtc().toIso8601String(),
+      'sourceUri': sourceUri.toString(),
+    };
+  }
 }

--- a/lib/models/academic_eams/profile.dart
+++ b/lib/models/academic_eams/profile.dart
@@ -35,6 +35,28 @@ class AcademicEamsProfile {
   /// 原始字段集合，供页面结构变化时回退展示。
   final Map<String, String> rawFields;
 
+  /// 从 JSON 恢复个人基本信息。
+  factory AcademicEamsProfile.fromJson(Map<String, dynamic> json) {
+    return AcademicEamsProfile(
+      name: json['name'] as String?,
+      studentId: null,
+      department: json['department'] as String?,
+      major: json['major'] as String?,
+      className: json['className'] as String?,
+      rawFields: const {},
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'name': name,
+      'department': department,
+      'major': major,
+      'className': className,
+    };
+  }
+
   /// 是否至少解析出一个核心字段。
   bool get hasAnyValue {
     return [

--- a/lib/models/academic_eams/program_plan.dart
+++ b/lib/models/academic_eams/program_plan.dart
@@ -38,6 +38,32 @@ class AcademicProgramPlanCourse {
 
   /// 原始单元格文本。
   final List<String> rawCells;
+
+  /// 从 JSON 恢复培养计划课程。
+  factory AcademicProgramPlanCourse.fromJson(Map<String, dynamic> json) {
+    return AcademicProgramPlanCourse(
+      courseName: json['courseName'] as String? ?? '',
+      rawCells: (json['rawCells'] as List<dynamic>? ?? const []).cast<String>(),
+      courseCode: json['courseCode'] as String?,
+      credit: (json['credit'] as num?)?.toDouble(),
+      moduleName: json['moduleName'] as String?,
+      category: json['category'] as String?,
+      suggestedTerm: json['suggestedTerm'] as String?,
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'courseName': courseName,
+      'rawCells': rawCells,
+      'courseCode': courseCode,
+      'credit': credit,
+      'moduleName': moduleName,
+      'category': category,
+      'suggestedTerm': suggestedTerm,
+    };
+  }
 }
 
 /// 培养计划快照。
@@ -60,6 +86,31 @@ class AcademicProgramPlanSnapshot {
 
   /// 来源页面地址。
   final Uri sourceUri;
+
+  /// 从 JSON 恢复培养计划快照。
+  factory AcademicProgramPlanSnapshot.fromJson(Map<String, dynamic> json) {
+    return AcademicProgramPlanSnapshot(
+      courses: (json['courses'] as List<dynamic>? ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(AcademicProgramPlanCourse.fromJson)
+          .toList(),
+      fetchedAt:
+          DateTime.tryParse(json['fetchedAt'] as String? ?? '')?.toLocal() ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+      sourceUri: Uri.parse(json['sourceUri'] as String? ?? ''),
+      planName: json['planName'] as String?,
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'courses': courses.map((course) => course.toJson()).toList(),
+      'fetchedAt': fetchedAt.toUtc().toIso8601String(),
+      'sourceUri': sourceUri.toString(),
+      'planName': planName,
+    };
+  }
 }
 
 /// 单个培养计划模块的完成进度。
@@ -94,6 +145,33 @@ class AcademicProgramModuleProgress {
 
   /// 模块未修学分。
   final double pendingCredits;
+
+  /// 从 JSON 恢复模块完成进度。
+  factory AcademicProgramModuleProgress.fromJson(Map<String, dynamic> json) {
+    return AcademicProgramModuleProgress(
+      moduleName: json['moduleName'] as String? ?? '',
+      totalCourseCount: (json['totalCourseCount'] as num?)?.toInt() ?? 0,
+      completedCourseCount:
+          (json['completedCourseCount'] as num?)?.toInt() ?? 0,
+      pendingCourseCount: (json['pendingCourseCount'] as num?)?.toInt() ?? 0,
+      totalCredits: (json['totalCredits'] as num?)?.toDouble() ?? 0,
+      completedCredits: (json['completedCredits'] as num?)?.toDouble() ?? 0,
+      pendingCredits: (json['pendingCredits'] as num?)?.toDouble() ?? 0,
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'moduleName': moduleName,
+      'totalCourseCount': totalCourseCount,
+      'completedCourseCount': completedCourseCount,
+      'pendingCourseCount': pendingCourseCount,
+      'totalCredits': totalCredits,
+      'completedCredits': completedCredits,
+      'pendingCredits': pendingCredits,
+    };
+  }
 }
 
 /// 培养计划完成情况快照。
@@ -120,4 +198,34 @@ class AcademicProgramCompletionSnapshot {
 
   /// 按模块聚合的完成进度。
   final List<AcademicProgramModuleProgress> moduleProgress;
+
+  /// 从 JSON 恢复培养计划完成情况。
+  factory AcademicProgramCompletionSnapshot.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return AcademicProgramCompletionSnapshot(
+      completedCourseCount:
+          (json['completedCourseCount'] as num?)?.toInt() ?? 0,
+      pendingCourseCount: (json['pendingCourseCount'] as num?)?.toInt() ?? 0,
+      completedCredits: (json['completedCredits'] as num?)?.toDouble() ?? 0,
+      pendingCredits: (json['pendingCredits'] as num?)?.toDouble() ?? 0,
+      moduleProgress: (json['moduleProgress'] as List<dynamic>? ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(AcademicProgramModuleProgress.fromJson)
+          .toList(),
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'completedCourseCount': completedCourseCount,
+      'pendingCourseCount': pendingCourseCount,
+      'completedCredits': completedCredits,
+      'pendingCredits': pendingCredits,
+      'moduleProgress': moduleProgress
+          .map((progress) => progress.toJson())
+          .toList(),
+    };
+  }
 }

--- a/lib/models/academic_eams/snapshot.dart
+++ b/lib/models/academic_eams/snapshot.dart
@@ -71,6 +71,61 @@ class AcademicEamsSnapshot {
   /// 空闲教室预览结果；仅在首页探测出结果表格时返回。
   final AcademicFreeClassroomSearchResult? freeClassroomsPreview;
 
+  /// 从 JSON 恢复本专科教务摘要快照。
+  factory AcademicEamsSnapshot.fromJson(Map<String, dynamic> json) {
+    return AcademicEamsSnapshot(
+      fetchedAt:
+          DateTime.tryParse(json['fetchedAt'] as String? ?? '')?.toLocal() ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+      sourceUri: Uri.parse(json['sourceUri'] as String? ?? ''),
+      warnings: (json['warnings'] as List<dynamic>? ?? const []).cast<String>(),
+      hasCourseOfferingEntry: json['hasCourseOfferingEntry'] as bool? ?? false,
+      hasFreeClassroomEntry: json['hasFreeClassroomEntry'] as bool? ?? false,
+      profile: _readObject(json['profile'], AcademicEamsProfile.fromJson),
+      courseTable: _readObject(
+        json['courseTable'],
+        AcademicCourseTableSnapshot.fromJson,
+      ),
+      grades: _readObject(json['grades'], AcademicGradeSnapshot.fromJson),
+      programPlan: _readObject(
+        json['programPlan'],
+        AcademicProgramPlanSnapshot.fromJson,
+      ),
+      programCompletion: _readObject(
+        json['programCompletion'],
+        AcademicProgramCompletionSnapshot.fromJson,
+      ),
+      exams: _readObject(json['exams'], AcademicExamSnapshot.fromJson),
+      courseOfferingsPreview: _readObject(
+        json['courseOfferingsPreview'],
+        AcademicCourseOfferingSearchResult.fromJson,
+      ),
+      freeClassroomsPreview: _readObject(
+        json['freeClassroomsPreview'],
+        AcademicFreeClassroomSearchResult.fromJson,
+      ),
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'fetchedAt': fetchedAt.toUtc().toIso8601String(),
+      'sourceUri': sourceUri.toString(),
+      'warnings': warnings,
+      'hasCourseOfferingEntry': hasCourseOfferingEntry,
+      'hasFreeClassroomEntry': hasFreeClassroomEntry,
+      'profile': profile?.toJson(),
+      'courseTable': courseTable?.toJson(),
+      'grades': grades?.toJson(),
+      'programPlan': programPlan?.toJson(),
+      'programCompletion': programCompletion?.toJson(),
+      'exams': exams?.toJson(),
+      'courseOfferingsPreview': courseOfferingsPreview?.toJson(),
+      'freeClassroomsPreview': freeClassroomsPreview?.toJson(),
+    };
+  }
+
   /// 是否至少解析出一个核心模块。
   bool get hasAnyData {
     return profile?.hasAnyValue == true ||
@@ -82,4 +137,9 @@ class AcademicEamsSnapshot {
         (courseOfferingsPreview?.records.isNotEmpty ?? false) ||
         (freeClassroomsPreview?.records.isNotEmpty ?? false);
   }
+}
+
+T? _readObject<T>(Object? value, T Function(Map<String, dynamic>) fromJson) {
+  if (value is Map<String, dynamic>) return fromJson(value);
+  return null;
 }

--- a/lib/models/academic_login_validation.dart
+++ b/lib/models/academic_login_validation.dart
@@ -15,6 +15,8 @@ class AcademicLoginSessionSnapshot {
     required this.authenticatedAt,
     required this.entranceUri,
     required this.finalUri,
+    this.ownerAccount = '',
+    this.ownerCredentialHash = '',
   });
 
   /// 按 Cookie 作用域保存的请求头；值不可展示给用户。
@@ -28,6 +30,12 @@ class AcademicLoginSessionSnapshot {
 
   /// 登录成功后最终停留地址。
   final Uri finalUri;
+
+  /// 产生该登录会话的 OA 账号；用于避免切换账号后复用旧 Cookie。
+  final String ownerAccount;
+
+  /// 产生该登录会话时的 OA 密码指纹；用于避免同账号换密后复用旧 Cookie。
+  final String ownerCredentialHash;
 
   /// 是否获得了后续网页请求可复用的 Cookie。
   bool get hasCookies {
@@ -52,6 +60,21 @@ class AcademicLoginSessionSnapshot {
     return matchingCookieHeaders.join('; ');
   }
 
+  /// 复制会话快照并绑定到指定 OA 账号。
+  AcademicLoginSessionSnapshot withOwnerAccount(
+    String ownerAccount, {
+    String ownerCredentialHash = '',
+  }) {
+    return AcademicLoginSessionSnapshot(
+      cookieHeadersByHost: cookieHeadersByHost,
+      authenticatedAt: authenticatedAt,
+      entranceUri: entranceUri,
+      finalUri: finalUri,
+      ownerAccount: ownerAccount.trim().toLowerCase(),
+      ownerCredentialHash: ownerCredentialHash,
+    );
+  }
+
   /// 序列化为安全存储中的 JSON 结构。
   Map<String, Object> toJson() {
     return {
@@ -59,6 +82,8 @@ class AcademicLoginSessionSnapshot {
       'authenticatedAt': authenticatedAt.toIso8601String(),
       'entranceUri': entranceUri.toString(),
       'finalUri': finalUri.toString(),
+      'ownerAccount': ownerAccount,
+      'ownerCredentialHash': ownerCredentialHash,
     };
   }
 
@@ -85,6 +110,9 @@ class AcademicLoginSessionSnapshot {
       authenticatedAt: authenticatedAt,
       entranceUri: Uri.parse(payload['entranceUri']?.toString() ?? ''),
       finalUri: Uri.parse(payload['finalUri']?.toString() ?? ''),
+      ownerAccount:
+          payload['ownerAccount']?.toString().trim().toLowerCase() ?? '',
+      ownerCredentialHash: payload['ownerCredentialHash']?.toString() ?? '',
     );
   }
 }

--- a/lib/models/campus_card.dart
+++ b/lib/models/campus_card.dart
@@ -66,6 +66,30 @@ class CampusCardTransactionRecord {
 
   /// 原始表格单元格文本，页面结构变化时用于兜底展示。
   final List<String> rawCells;
+
+  /// 从 JSON 恢复校园卡交易记录。
+  factory CampusCardTransactionRecord.fromJson(Map<String, dynamic> json) {
+    return CampusCardTransactionRecord(
+      occurredAt: json['occurredAt'] as String? ?? '',
+      amount: (json['amount'] as num?)?.toDouble() ?? 0,
+      merchant: json['merchant'] as String?,
+      type: json['type'] as String?,
+      balanceAfter: (json['balanceAfter'] as num?)?.toDouble(),
+      rawCells: (json['rawCells'] as List<dynamic>? ?? const []).cast<String>(),
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'occurredAt': occurredAt,
+      'amount': amount,
+      'merchant': merchant,
+      'type': type,
+      'balanceAfter': balanceAfter,
+      'rawCells': rawCells,
+    };
+  }
 }
 
 /// 校园卡余额与交易记录快照。
@@ -92,6 +116,33 @@ class CampusCardSnapshot {
 
   /// 产生该快照的最后一个业务页面地址。
   final Uri sourceUri;
+
+  /// 从 JSON 恢复校园卡快照。
+  factory CampusCardSnapshot.fromJson(Map<String, dynamic> json) {
+    return CampusCardSnapshot(
+      balance: (json['balance'] as num?)?.toDouble(),
+      status: json['status'] as String? ?? '',
+      records: (json['records'] as List<dynamic>? ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(CampusCardTransactionRecord.fromJson)
+          .toList(),
+      fetchedAt:
+          DateTime.tryParse(json['fetchedAt'] as String? ?? '')?.toLocal() ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+      sourceUri: Uri.parse(json['sourceUri'] as String? ?? ''),
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'balance': balance,
+      'status': status,
+      'records': records.map((record) => record.toJson()).toList(),
+      'fetchedAt': fetchedAt.toUtc().toIso8601String(),
+      'sourceUri': sourceUri.toString(),
+    };
+  }
 
   /// 页面是否明确显示非正常状态。
   bool get hasAbnormalStatus {

--- a/lib/models/email_mailbox.dart
+++ b/lib/models/email_mailbox.dart
@@ -70,6 +70,20 @@ class EmailServerEndpoint {
 
   /// 是否从连接建立时即使用 TLS。
   final bool isSecure;
+
+  /// 从 JSON 恢复邮箱服务端点。
+  factory EmailServerEndpoint.fromJson(Map<String, dynamic> json) {
+    return EmailServerEndpoint(
+      host: json['host'] as String? ?? '',
+      port: (json['port'] as num?)?.toInt() ?? 0,
+      isSecure: json['isSecure'] as bool? ?? true,
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {'host': host, 'port': port, 'isSecure': isSecure};
+  }
 }
 
 /// 单封邮件的只读展示快照。
@@ -104,6 +118,34 @@ class EmailMessageSnapshot {
 
   /// 邮件头中的发送时间。
   final DateTime? receivedAt;
+
+  /// 从 JSON 恢复邮件快照。
+  factory EmailMessageSnapshot.fromJson(Map<String, dynamic> json) {
+    return EmailMessageSnapshot(
+      id: json['id'] as String? ?? '',
+      subject: json['subject'] as String? ?? '',
+      senderName: json['senderName'] as String? ?? '',
+      senderAddress: json['senderAddress'] as String? ?? '',
+      preview: json['preview'] as String? ?? '',
+      body: json['body'] as String? ?? '',
+      receivedAt: DateTime.tryParse(
+        json['receivedAt'] as String? ?? '',
+      )?.toLocal(),
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'subject': subject,
+      'senderName': senderName,
+      'senderAddress': senderAddress,
+      'preview': preview,
+      'body': body,
+      'receivedAt': receivedAt?.toUtc().toIso8601String(),
+    };
+  }
 }
 
 /// 邮箱一次只读收信快照。
@@ -130,6 +172,39 @@ class EmailMailboxSnapshot {
 
   /// 本次读取使用的服务端点。
   final EmailServerEndpoint endpoint;
+
+  /// 从 JSON 恢复邮箱快照。
+  factory EmailMailboxSnapshot.fromJson(Map<String, dynamic> json) {
+    final protocolName = json['protocol'] as String?;
+    final protocol = EmailProtocol.values.firstWhere(
+      (value) => value.name == protocolName,
+      orElse: () => EmailProtocol.imap,
+    );
+    return EmailMailboxSnapshot(
+      protocol: protocol,
+      account: '',
+      messages: (json['messages'] as List<dynamic>? ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(EmailMessageSnapshot.fromJson)
+          .toList(),
+      fetchedAt:
+          DateTime.tryParse(json['fetchedAt'] as String? ?? '')?.toLocal() ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+      endpoint: EmailServerEndpoint.fromJson(
+        json['endpoint'] as Map<String, dynamic>? ?? const {},
+      ),
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'protocol': protocol.name,
+      'messages': messages.map((message) => message.toJson()).toList(),
+      'fetchedAt': fetchedAt.toUtc().toIso8601String(),
+      'endpoint': endpoint.toJson(),
+    };
+  }
 }
 
 /// 邮箱只读收信结果。

--- a/lib/models/sports_attendance.dart
+++ b/lib/models/sports_attendance.dart
@@ -29,6 +29,14 @@ enum SportsAttendanceCategory {
 
   /// 页面展示名称。
   final String label;
+
+  /// 从持久化名称恢复分类。
+  static SportsAttendanceCategory fromName(String? name) {
+    return SportsAttendanceCategory.values.firstWhere(
+      (category) => category.name == name,
+      orElse: () => SportsAttendanceCategory.unknown,
+    );
+  }
 }
 
 /// 体育部考勤查询状态。
@@ -96,6 +104,32 @@ class SportsAttendanceRecord {
 
   /// 备注或状态。
   final String? remark;
+
+  /// 从 JSON 恢复考勤记录。
+  factory SportsAttendanceRecord.fromJson(Map<String, dynamic> json) {
+    return SportsAttendanceRecord(
+      category: SportsAttendanceCategory.fromName(json['category'] as String?),
+      count: (json['count'] as num?)?.toInt() ?? 0,
+      cells: (json['cells'] as List<dynamic>? ?? const []).cast<String>(),
+      occurredAt: json['occurredAt'] as String?,
+      project: json['project'] as String?,
+      location: json['location'] as String?,
+      remark: json['remark'] as String?,
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'category': category.name,
+      'count': count,
+      'cells': cells,
+      'occurredAt': occurredAt,
+      'project': project,
+      'location': location,
+      'remark': remark,
+    };
+  }
 }
 
 /// 体育部课外活动考勤汇总。
@@ -130,6 +164,40 @@ class SportsAttendanceSummary {
 
   /// 明细页来源地址。
   final Uri sourceUri;
+
+  /// 从 JSON 恢复体育部考勤汇总。
+  factory SportsAttendanceSummary.fromJson(Map<String, dynamic> json) {
+    return SportsAttendanceSummary(
+      morningExerciseCount:
+          (json['morningExerciseCount'] as num?)?.toInt() ?? 0,
+      extracurricularActivityCount:
+          (json['extracurricularActivityCount'] as num?)?.toInt() ?? 0,
+      countAdjustmentCount:
+          (json['countAdjustmentCount'] as num?)?.toInt() ?? 0,
+      sportsCorridorCount: (json['sportsCorridorCount'] as num?)?.toInt() ?? 0,
+      records: (json['records'] as List<dynamic>? ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(SportsAttendanceRecord.fromJson)
+          .toList(),
+      fetchedAt:
+          DateTime.tryParse(json['fetchedAt'] as String? ?? '')?.toLocal() ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+      sourceUri: Uri.parse(json['sourceUri'] as String? ?? ''),
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'morningExerciseCount': morningExerciseCount,
+      'extracurricularActivityCount': extracurricularActivityCount,
+      'countAdjustmentCount': countAdjustmentCount,
+      'sportsCorridorCount': sportsCorridorCount,
+      'records': records.map((record) => record.toJson()).toList(),
+      'fetchedAt': fetchedAt.toUtc().toIso8601String(),
+      'sourceUri': sourceUri.toString(),
+    };
+  }
 
   /// issue #112 要求展示的总次数。
   int get totalCount {

--- a/lib/models/student_report.dart
+++ b/lib/models/student_report.dart
@@ -73,6 +73,32 @@ class SecondClassroomCreditRecord {
 
   /// 原始表格单元格，页面变化时用于兜底展示。
   final List<String> rawCells;
+
+  /// 从 JSON 恢复第二课堂学分记录。
+  factory SecondClassroomCreditRecord.fromJson(Map<String, dynamic> json) {
+    return SecondClassroomCreditRecord(
+      category: json['category'] as String? ?? '',
+      itemName: json['itemName'] as String? ?? '',
+      credit: (json['credit'] as num?)?.toDouble() ?? 0,
+      rawCells: (json['rawCells'] as List<dynamic>? ?? const []).cast<String>(),
+      semester: json['semester'] as String?,
+      occurredAt: json['occurredAt'] as String?,
+      status: json['status'] as String?,
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'category': category,
+      'itemName': itemName,
+      'credit': credit,
+      'rawCells': rawCells,
+      'semester': semester,
+      'occurredAt': occurredAt,
+      'status': status,
+    };
+  }
 }
 
 /// 第二课堂学分统计快照。
@@ -91,6 +117,29 @@ class SecondClassroomCreditSummary {
 
   /// 产生该快照的最后一个业务页面地址。
   final Uri sourceUri;
+
+  /// 从 JSON 恢复第二课堂学分统计。
+  factory SecondClassroomCreditSummary.fromJson(Map<String, dynamic> json) {
+    return SecondClassroomCreditSummary(
+      records: (json['records'] as List<dynamic>? ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(SecondClassroomCreditRecord.fromJson)
+          .toList(),
+      fetchedAt:
+          DateTime.tryParse(json['fetchedAt'] as String? ?? '')?.toLocal() ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+      sourceUri: Uri.parse(json['sourceUri'] as String? ?? ''),
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'records': records.map((record) => record.toJson()).toList(),
+      'fetchedAt': fetchedAt.toUtc().toIso8601String(),
+      'sourceUri': sourceUri.toString(),
+    };
+  }
 }
 
 /// 学工报表只读查询或登录校验结果。

--- a/lib/pages/academic_page.dart
+++ b/lib/pages/academic_page.dart
@@ -14,6 +14,7 @@ import 'package:flutter_animate/flutter_animate.dart';
 import '../models/academic_eams.dart';
 import '../models/sports_attendance.dart';
 import '../models/student_report.dart';
+import '../services/academic_credentials_service.dart';
 import '../services/academic_eams_service.dart';
 import '../services/sports_attendance_service.dart';
 import '../services/student_report_service.dart';
@@ -83,16 +84,13 @@ class _AcademicPageState extends State<AcademicPage> {
   SportsAttendanceQueryResult? _sportsAttendanceResult;
   bool _isLoadingSportsAttendance = false;
   bool _sportsAttendanceAutoRefreshEnabled = false;
-  int _sportsAttendanceAutoRefreshIntervalMinutes =
-      SportsAttendanceService.defaultAutoRefreshIntervalMinutes;
   Timer? _sportsAttendanceAutoRefreshTimer;
 
   StudentReportQueryResult? _studentReportResult;
   bool _isLoadingStudentReport = false;
   bool _studentReportAutoRefreshEnabled = false;
-  int _studentReportAutoRefreshIntervalMinutes =
-      StudentReportService.defaultAutoRefreshIntervalMinutes;
   Timer? _studentReportAutoRefreshTimer;
+  StreamSubscription<int>? _credentialChangeSubscription;
 
   SportsAttendanceClient get _sportsAttendanceService {
     return widget.sportsAttendanceService ?? SportsAttendanceService.instance;
@@ -109,17 +107,23 @@ class _AcademicPageState extends State<AcademicPage> {
   @override
   void initState() {
     super.initState();
-    _loadAcademicEamsAutoRefreshSettings();
-    _loadSportsAttendanceAutoRefreshSettings();
-    _loadStudentReportAutoRefreshSettings();
+    _credentialChangeSubscription = AcademicCredentialsService.instance.changes
+        .listen((_) => _clearAuthenticatedState());
+    _loadAcademicEamsCacheAndSettings();
+    _loadSportsAttendanceCacheAndSettings();
+    _loadStudentReportCacheAndSettings();
   }
 
-  @override
-  void dispose() {
-    _academicEamsAutoRefreshTimer?.cancel();
-    _sportsAttendanceAutoRefreshTimer?.cancel();
-    _studentReportAutoRefreshTimer?.cancel();
-    super.dispose();
+  void _clearAuthenticatedState() {
+    if (!mounted) return;
+    setState(() {
+      _academicEamsResult = null;
+      _sportsAttendanceResult = null;
+      _studentReportResult = null;
+      _isLoadingAcademicEams = false;
+      _isLoadingSportsAttendance = false;
+      _isLoadingStudentReport = false;
+    });
   }
 
   /// 读取本专科教务自动刷新设置；未启用时不主动访问教务系统。
@@ -138,34 +142,51 @@ class _AcademicPageState extends State<AcademicPage> {
       _academicEamsAutoRefreshEnabled = enabled;
       _academicEamsAutoRefreshIntervalMinutes = interval;
     });
-    _restartAcademicEamsAutoRefreshTimer();
-    if (enabled) unawaited(_loadAcademicEamsOverview());
+    _restartAcademicEamsAutoRefreshTimer(enabled, interval);
+    if (enabled &&
+        _shouldAutoRefresh(_academicEamsResult?.checkedAt, interval)) {
+      unawaited(_loadAcademicEamsOverview(silent: true));
+    }
+  }
+
+  void _restartAcademicEamsAutoRefreshTimer(bool enabled, int intervalMinutes) {
+    _academicEamsAutoRefreshTimer?.cancel();
+    _academicEamsAutoRefreshTimer = null;
+    if (!enabled || intervalMinutes <= 0) return;
+    _academicEamsAutoRefreshTimer = Timer.periodic(
+      Duration(minutes: intervalMinutes),
+      (_) {
+        if (_shouldAutoRefresh(
+          _academicEamsResult?.checkedAt,
+          intervalMinutes,
+        )) {
+          unawaited(_loadAcademicEamsOverview(silent: true));
+        }
+      },
+    );
+  }
+
+  /// 先显示本地本专科教务缓存，再按间隔决定是否静默刷新。
+  Future<void> _loadAcademicEamsCacheAndSettings() async {
+    final cachedResult = await _academicEamsService.readLatestCachedOverview();
+    if (mounted && cachedResult != null) {
+      setState(() => _academicEamsResult = cachedResult);
+    }
+    await _loadAcademicEamsAutoRefreshSettings();
   }
 
   /// 读取本专科教务摘要；失败时在卡片中展示明确状态。
-  Future<void> _loadAcademicEamsOverview() async {
+  Future<void> _loadAcademicEamsOverview({bool silent = false}) async {
     if (_isLoadingAcademicEams) return;
-    setState(() => _isLoadingAcademicEams = true);
+    if (!silent) setState(() => _isLoadingAcademicEams = true);
 
     final result = await _academicEamsService.fetchOverview();
     if (!mounted) return;
+    if (silent && !result.isSuccess) return;
     setState(() {
       _academicEamsResult = result;
-      _isLoadingAcademicEams = false;
+      if (!silent) _isLoadingAcademicEams = false;
     });
-  }
-
-  /// 根据设置重建本专科教务自动刷新定时器。
-  void _restartAcademicEamsAutoRefreshTimer() {
-    _academicEamsAutoRefreshTimer?.cancel();
-    _academicEamsAutoRefreshTimer = null;
-    if (!_academicEamsAutoRefreshEnabled) return;
-    final intervalMinutes = _academicEamsAutoRefreshIntervalMinutes;
-    if (intervalMinutes <= 0) return;
-    _academicEamsAutoRefreshTimer = Timer.periodic(
-      Duration(minutes: intervalMinutes),
-      (_) => _loadAcademicEamsOverview(),
-    );
   }
 
   /// 读取体育部自动刷新设置；未启用时不主动访问体育部系统。
@@ -177,38 +198,56 @@ class _AcademicPageState extends State<AcademicPage> {
         widget.sportsAttendanceAutoRefreshIntervalOverride ??
         await SportsAttendanceService.instance.getAutoRefreshIntervalMinutes();
     if (!mounted) return;
-    setState(() {
-      _sportsAttendanceAutoRefreshEnabled = enabled;
-      _sportsAttendanceAutoRefreshIntervalMinutes = interval;
-    });
-    _restartSportsAttendanceAutoRefreshTimer();
-    if (enabled) unawaited(_loadSportsAttendance());
+    setState(() => _sportsAttendanceAutoRefreshEnabled = enabled);
+    _restartSportsAttendanceAutoRefreshTimer(enabled, interval);
+    if (enabled &&
+        _shouldAutoRefresh(_sportsAttendanceResult?.checkedAt, interval)) {
+      unawaited(_loadSportsAttendance(silent: true));
+    }
+  }
+
+  void _restartSportsAttendanceAutoRefreshTimer(
+    bool enabled,
+    int intervalMinutes,
+  ) {
+    _sportsAttendanceAutoRefreshTimer?.cancel();
+    _sportsAttendanceAutoRefreshTimer = null;
+    if (!enabled || intervalMinutes <= 0) return;
+    _sportsAttendanceAutoRefreshTimer = Timer.periodic(
+      Duration(minutes: intervalMinutes),
+      (_) {
+        if (_shouldAutoRefresh(
+          _sportsAttendanceResult?.checkedAt,
+          intervalMinutes,
+        )) {
+          unawaited(_loadSportsAttendance(silent: true));
+        }
+      },
+    );
+  }
+
+  /// 先显示本地体育部考勤缓存，再按间隔决定是否静默刷新。
+  Future<void> _loadSportsAttendanceCacheAndSettings() async {
+    final cachedResult = await _sportsAttendanceService
+        .readLatestCachedAttendanceSummary();
+    if (mounted && cachedResult != null) {
+      setState(() => _sportsAttendanceResult = cachedResult);
+    }
+    await _loadSportsAttendanceAutoRefreshSettings();
   }
 
   /// 读取体育部课外活动考勤；失败时在卡片内展示明确状态。
-  Future<void> _loadSportsAttendance() async {
+  Future<void> _loadSportsAttendance({bool silent = false}) async {
     if (_isLoadingSportsAttendance) return;
-    setState(() => _isLoadingSportsAttendance = true);
+    if (!silent) setState(() => _isLoadingSportsAttendance = true);
 
     final result = await _sportsAttendanceService.fetchAttendanceSummary();
     if (!mounted) return;
+    if (silent && !result.isSuccess) return;
     setState(() {
       _sportsAttendanceResult = result;
-      _isLoadingSportsAttendance = false;
+      if (!silent) _isLoadingSportsAttendance = false;
     });
-  }
-
-  /// 根据设置重建体育部考勤自动刷新定时器。
-  void _restartSportsAttendanceAutoRefreshTimer() {
-    _sportsAttendanceAutoRefreshTimer?.cancel();
-    _sportsAttendanceAutoRefreshTimer = null;
-    if (!_sportsAttendanceAutoRefreshEnabled) return;
-    final intervalMinutes = _sportsAttendanceAutoRefreshIntervalMinutes;
-    if (intervalMinutes <= 0) return;
-    _sportsAttendanceAutoRefreshTimer = Timer.periodic(
-      Duration(minutes: intervalMinutes),
-      (_) => _loadSportsAttendance(),
-    );
   }
 
   /// 读取第二课堂学分自动刷新设置；未启用时不主动访问学工报表。
@@ -220,38 +259,72 @@ class _AcademicPageState extends State<AcademicPage> {
         widget.studentReportAutoRefreshIntervalOverride ??
         await StudentReportService.instance.getAutoRefreshIntervalMinutes();
     if (!mounted) return;
-    setState(() {
-      _studentReportAutoRefreshEnabled = enabled;
-      _studentReportAutoRefreshIntervalMinutes = interval;
-    });
-    _restartStudentReportAutoRefreshTimer();
-    if (enabled) unawaited(_loadStudentReport());
+    setState(() => _studentReportAutoRefreshEnabled = enabled);
+    _restartStudentReportAutoRefreshTimer(enabled, interval);
+    if (enabled &&
+        _shouldAutoRefresh(_studentReportResult?.checkedAt, interval)) {
+      unawaited(_loadStudentReport(silent: true));
+    }
+  }
+
+  void _restartStudentReportAutoRefreshTimer(
+    bool enabled,
+    int intervalMinutes,
+  ) {
+    _studentReportAutoRefreshTimer?.cancel();
+    _studentReportAutoRefreshTimer = null;
+    if (!enabled || intervalMinutes <= 0) return;
+    _studentReportAutoRefreshTimer = Timer.periodic(
+      Duration(minutes: intervalMinutes),
+      (_) {
+        if (_shouldAutoRefresh(
+          _studentReportResult?.checkedAt,
+          intervalMinutes,
+        )) {
+          unawaited(_loadStudentReport(silent: true));
+        }
+      },
+    );
+  }
+
+  /// 先显示本地第二课堂学分缓存，再按间隔决定是否静默刷新。
+  Future<void> _loadStudentReportCacheAndSettings() async {
+    final cachedResult = await _studentReportService
+        .readLatestCachedSecondClassroomCredits();
+    if (mounted && cachedResult != null) {
+      setState(() => _studentReportResult = cachedResult);
+    }
+    await _loadStudentReportAutoRefreshSettings();
   }
 
   /// 读取第二课堂学分；失败时在卡片内展示明确状态。
-  Future<void> _loadStudentReport() async {
+  Future<void> _loadStudentReport({bool silent = false}) async {
     if (_isLoadingStudentReport) return;
-    setState(() => _isLoadingStudentReport = true);
+    if (!silent) setState(() => _isLoadingStudentReport = true);
 
     final result = await _studentReportService.fetchSecondClassroomCredits();
     if (!mounted) return;
+    if (silent && !result.isSuccess) return;
     setState(() {
       _studentReportResult = result;
-      _isLoadingStudentReport = false;
+      if (!silent) _isLoadingStudentReport = false;
     });
   }
 
-  /// 根据设置重建第二课堂学分自动刷新定时器。
-  void _restartStudentReportAutoRefreshTimer() {
+  bool _shouldAutoRefresh(DateTime? fetchedAt, int intervalMinutes) {
+    if (intervalMinutes <= 0) return false;
+    if (fetchedAt == null) return true;
+    return DateTime.now().difference(fetchedAt) >=
+        Duration(minutes: intervalMinutes);
+  }
+
+  @override
+  void dispose() {
+    _credentialChangeSubscription?.cancel();
+    _academicEamsAutoRefreshTimer?.cancel();
+    _sportsAttendanceAutoRefreshTimer?.cancel();
     _studentReportAutoRefreshTimer?.cancel();
-    _studentReportAutoRefreshTimer = null;
-    if (!_studentReportAutoRefreshEnabled) return;
-    final intervalMinutes = _studentReportAutoRefreshIntervalMinutes;
-    if (intervalMinutes <= 0) return;
-    _studentReportAutoRefreshTimer = Timer.periodic(
-      Duration(minutes: intervalMinutes),
-      (_) => _loadStudentReport(),
-    );
+    super.dispose();
   }
 
   @override

--- a/lib/pages/course_schedule_page.dart
+++ b/lib/pages/course_schedule_page.dart
@@ -11,6 +11,7 @@ import 'dart:async';
 import '../design/fluent_ui.dart';
 
 import '../models/academic_eams.dart';
+import '../services/academic_credentials_service.dart';
 import '../services/academic_eams_service.dart';
 import '../theme/fluent_tokens.dart';
 
@@ -47,6 +48,7 @@ class _CourseSchedulePageState extends State<CourseSchedulePage> {
   int _autoRefreshIntervalMinutes =
       AcademicEamsService.defaultAutoRefreshIntervalMinutes;
   Timer? _autoRefreshTimer;
+  StreamSubscription<int>? _credentialChangeSubscription;
 
   AcademicEamsClient get _academicEamsService {
     return widget.academicEamsService ?? AcademicEamsService.instance;
@@ -55,14 +57,18 @@ class _CourseSchedulePageState extends State<CourseSchedulePage> {
   @override
   void initState() {
     super.initState();
+    _credentialChangeSubscription = AcademicCredentialsService.instance.changes
+        .listen((_) => _clearAuthenticatedState());
     _result = widget.initialResult;
-    _loadAutoRefreshSettings();
+    _loadCacheAndAutoRefreshSettings();
   }
 
-  @override
-  void dispose() {
-    _autoRefreshTimer?.cancel();
-    super.dispose();
+  void _clearAuthenticatedState() {
+    if (!mounted) return;
+    setState(() {
+      _result = null;
+      _isLoading = false;
+    });
   }
 
   Future<void> _loadAutoRefreshSettings() async {
@@ -80,32 +86,62 @@ class _CourseSchedulePageState extends State<CourseSchedulePage> {
       _autoRefreshEnabled = enabled;
       _autoRefreshIntervalMinutes = interval;
     });
-    _restartAutoRefreshTimer();
-    if (enabled) unawaited(_loadCourseTable());
+    _restartAutoRefreshTimer(enabled, interval);
+    if (enabled && _shouldAutoRefresh(_result?.checkedAt, interval)) {
+      unawaited(_loadCourseTable(silent: true));
+    }
   }
 
-  Future<void> _loadCourseTable() async {
-    if (_isLoading) return;
-    setState(() => _isLoading = true);
-
-    final result = await _academicEamsService.fetchCourseTable();
-    if (!mounted) return;
-    setState(() {
-      _result = result;
-      _isLoading = false;
+  void _restartAutoRefreshTimer(bool enabled, int intervalMinutes) {
+    _autoRefreshTimer?.cancel();
+    _autoRefreshTimer = null;
+    if (!enabled || intervalMinutes <= 0) return;
+    _autoRefreshTimer = Timer.periodic(Duration(minutes: intervalMinutes), (_) {
+      if (_shouldAutoRefresh(_result?.checkedAt, intervalMinutes)) {
+        unawaited(_loadCourseTable(silent: true));
+      }
     });
   }
 
-  void _restartAutoRefreshTimer() {
+  Future<void> _loadCacheAndAutoRefreshSettings() async {
+    final cachedResult = await _academicEamsService
+        .readLatestCachedCourseTable();
+    if (mounted && cachedResult != null && !_hasUsableCourseTable(_result)) {
+      setState(() => _result = cachedResult);
+    }
+    await _loadAutoRefreshSettings();
+  }
+
+  bool _hasUsableCourseTable(AcademicEamsQueryResult? result) {
+    final entries = result?.snapshot?.courseTable?.entries;
+    return result?.isSuccess == true && entries != null && entries.isNotEmpty;
+  }
+
+  Future<void> _loadCourseTable({bool silent = false}) async {
+    if (_isLoading) return;
+    if (!silent) setState(() => _isLoading = true);
+
+    final result = await _academicEamsService.fetchCourseTable();
+    if (!mounted) return;
+    if (silent && !result.isSuccess) return;
+    setState(() {
+      _result = result;
+      if (!silent) _isLoading = false;
+    });
+  }
+
+  bool _shouldAutoRefresh(DateTime? fetchedAt, int intervalMinutes) {
+    if (intervalMinutes <= 0) return false;
+    if (fetchedAt == null) return true;
+    return DateTime.now().difference(fetchedAt) >=
+        Duration(minutes: intervalMinutes);
+  }
+
+  @override
+  void dispose() {
+    _credentialChangeSubscription?.cancel();
     _autoRefreshTimer?.cancel();
-    _autoRefreshTimer = null;
-    if (!_autoRefreshEnabled) return;
-    final intervalMinutes = _autoRefreshIntervalMinutes;
-    if (intervalMinutes <= 0) return;
-    _autoRefreshTimer = Timer.periodic(
-      Duration(minutes: intervalMinutes),
-      (_) => _loadCourseTable(),
-    );
+    super.dispose();
   }
 
   @override

--- a/lib/pages/email_page.dart
+++ b/lib/pages/email_page.dart
@@ -12,6 +12,7 @@ import '../design/fluent_ui.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 
 import '../models/email_mailbox.dart';
+import '../services/academic_credentials_service.dart';
 import '../services/email_service.dart';
 import '../theme/fluent_tokens.dart';
 
@@ -46,9 +47,8 @@ class _EmailPageState extends State<EmailPage> {
   EmailLoginValidationResult? _validationResult;
   bool _isFetchingMessages = false;
   bool _emailAutoRefreshEnabled = false;
-  int _emailAutoRefreshIntervalMinutes =
-      EmailService.defaultAutoRefreshIntervalMinutes;
   Timer? _emailAutoRefreshTimer;
+  StreamSubscription<int>? _credentialChangeSubscription;
 
   EmailMailboxClient get _emailService {
     return widget.emailService ?? EmailService.instance;
@@ -57,13 +57,19 @@ class _EmailPageState extends State<EmailPage> {
   @override
   void initState() {
     super.initState();
-    _loadEmailAutoRefreshSettings();
+    _credentialChangeSubscription = AcademicCredentialsService.instance.changes
+        .listen((_) => _clearAuthenticatedState());
+    _loadMailboxCacheAndSettings();
   }
 
-  @override
-  void dispose() {
-    _emailAutoRefreshTimer?.cancel();
-    super.dispose();
+  void _clearAuthenticatedState() {
+    if (!mounted) return;
+    setState(() {
+      _mailboxResult = null;
+      _validationResult = null;
+      _isFetchingMessages = false;
+      _validatingProtocol = null;
+    });
   }
 
   /// 读取邮箱自动刷新设置；默认不主动访问邮箱系统。
@@ -75,41 +81,70 @@ class _EmailPageState extends State<EmailPage> {
         widget.emailAutoRefreshIntervalOverride ??
         await EmailService.instance.getAutoRefreshIntervalMinutes();
     if (!mounted) return;
-    setState(() {
-      _emailAutoRefreshEnabled = enabled;
-      _emailAutoRefreshIntervalMinutes = interval;
-    });
-    _restartEmailAutoRefreshTimer();
-    if (enabled) unawaited(_fetchMessages());
+    setState(() => _emailAutoRefreshEnabled = enabled);
+    _restartEmailAutoRefreshTimer(enabled, interval);
+    if (enabled && _shouldAutoRefresh(_mailboxResult?.checkedAt, interval)) {
+      unawaited(_fetchMessages(silent: true));
+    }
+  }
+
+  void _restartEmailAutoRefreshTimer(bool enabled, int intervalMinutes) {
+    _emailAutoRefreshTimer?.cancel();
+    _emailAutoRefreshTimer = null;
+    if (!enabled || intervalMinutes <= 0) return;
+    _emailAutoRefreshTimer = Timer.periodic(
+      Duration(minutes: intervalMinutes),
+      (_) {
+        if (_shouldAutoRefresh(_mailboxResult?.checkedAt, intervalMinutes)) {
+          unawaited(_fetchMessages(silent: true));
+        }
+      },
+    );
+  }
+
+  /// 先显示当前协议的本地邮箱缓存，再按间隔决定是否静默刷新。
+  Future<void> _loadMailboxCacheAndSettings() async {
+    await _loadCachedMessagesForSelectedProtocol();
+    await _loadEmailAutoRefreshSettings();
+  }
+
+  Future<void> _loadCachedMessagesForSelectedProtocol() async {
+    final cachedResult = await _emailService.readLatestCachedMessages(
+      _selectedProtocol,
+    );
+    if (!mounted) return;
+    setState(() => _mailboxResult = cachedResult);
   }
 
   /// 使用当前选择的只读协议读取最近邮件。
-  Future<void> _fetchMessages() async {
+  Future<void> _fetchMessages({bool silent = false}) async {
     if (_isFetchingMessages || _selectedProtocol == EmailProtocol.smtp) return;
-    setState(() => _isFetchingMessages = true);
+    if (!silent) setState(() => _isFetchingMessages = true);
 
     final result = await _emailService.fetchMessages(
       protocol: _selectedProtocol,
       messageCount: 10,
     );
     if (!mounted) return;
+    if (silent && !result.isSuccess) return;
     setState(() {
       _mailboxResult = result;
-      _isFetchingMessages = false;
+      if (!silent) _isFetchingMessages = false;
     });
   }
 
-  /// 根据设置重建邮箱自动刷新定时器。
-  void _restartEmailAutoRefreshTimer() {
+  bool _shouldAutoRefresh(DateTime? fetchedAt, int intervalMinutes) {
+    if (intervalMinutes <= 0) return false;
+    if (fetchedAt == null) return true;
+    return DateTime.now().difference(fetchedAt) >=
+        Duration(minutes: intervalMinutes);
+  }
+
+  @override
+  void dispose() {
+    _credentialChangeSubscription?.cancel();
     _emailAutoRefreshTimer?.cancel();
-    _emailAutoRefreshTimer = null;
-    if (!_emailAutoRefreshEnabled) return;
-    final intervalMinutes = _emailAutoRefreshIntervalMinutes;
-    if (intervalMinutes <= 0) return;
-    _emailAutoRefreshTimer = Timer.periodic(
-      Duration(minutes: intervalMinutes),
-      (_) => _fetchMessages(),
-    );
+    super.dispose();
   }
 
   /// 校验指定协议登录状态；SMTP 只认证，不发送邮件。
@@ -219,6 +254,7 @@ class _EmailPageState extends State<EmailPage> {
                       : (protocol) {
                           if (protocol == null) return;
                           setState(() => _selectedProtocol = protocol);
+                          unawaited(_loadCachedMessagesForSelectedProtocol());
                         },
                 ),
               ),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -12,6 +12,7 @@ import '../design/fluent_ui.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import '../models/campus_card.dart';
 import '../models/message_item.dart';
+import '../services/academic_credentials_service.dart';
 import '../services/campus_card_service.dart';
 import '../services/campus_network_status_service.dart';
 import '../services/message_state_service.dart';
@@ -58,9 +59,8 @@ class _HomePageState extends State<HomePage> {
   CampusCardQueryResult? _campusCardResult;
   bool _isLoadingCampusCard = false;
   bool _campusCardAutoRefreshEnabled = false;
-  int _campusCardAutoRefreshIntervalMinutes =
-      CampusCardService.defaultAutoRefreshIntervalMinutes;
   Timer? _campusCardAutoRefreshTimer;
+  StreamSubscription<int>? _credentialChangeSubscription;
 
   CampusCardBalanceClient get _campusCardService {
     return widget.campusCardService ?? CampusCardService.instance;
@@ -69,14 +69,18 @@ class _HomePageState extends State<HomePage> {
   @override
   void initState() {
     super.initState();
+    _credentialChangeSubscription = AcademicCredentialsService.instance.changes
+        .listen((_) => _clearAuthenticatedState());
     _loadLatestMessages();
-    _loadCampusCardAutoRefreshSettings();
+    _loadCampusCardCacheAndSettings();
   }
 
-  @override
-  void dispose() {
-    _campusCardAutoRefreshTimer?.cancel();
-    super.dispose();
+  void _clearAuthenticatedState() {
+    if (!mounted) return;
+    setState(() {
+      _campusCardResult = null;
+      _isLoadingCampusCard = false;
+    });
   }
 
   /// 从本地存储加载消息并取前 5 条
@@ -98,41 +102,69 @@ class _HomePageState extends State<HomePage> {
         widget.campusCardAutoRefreshIntervalOverride ??
         await CampusCardService.instance.getAutoRefreshIntervalMinutes();
     if (!mounted) return;
-    setState(() {
-      _campusCardAutoRefreshEnabled = enabled;
-      _campusCardAutoRefreshIntervalMinutes = interval;
-    });
-    _restartCampusCardAutoRefreshTimer();
-    if (enabled) unawaited(_loadCampusCard());
+    setState(() => _campusCardAutoRefreshEnabled = enabled);
+    _restartCampusCardAutoRefreshTimer(enabled, interval);
+    if (enabled && _shouldAutoRefresh(_campusCardResult?.checkedAt, interval)) {
+      unawaited(_loadCampusCard(silent: true));
+    }
+  }
+
+  void _restartCampusCardAutoRefreshTimer(bool enabled, int intervalMinutes) {
+    _campusCardAutoRefreshTimer?.cancel();
+    _campusCardAutoRefreshTimer = null;
+    if (!enabled || intervalMinutes <= 0) return;
+    _campusCardAutoRefreshTimer = Timer.periodic(
+      Duration(minutes: intervalMinutes),
+      (_) {
+        if (_shouldAutoRefresh(_campusCardResult?.checkedAt, intervalMinutes)) {
+          unawaited(_loadCampusCard(silent: true));
+        }
+      },
+    );
+  }
+
+  /// 先显示本地校园卡缓存，再根据设置决定是否静默刷新。
+  Future<void> _loadCampusCardCacheAndSettings() async {
+    final cachedResult = await _campusCardService.readLatestCachedCampusCard();
+    if (mounted && cachedResult != null) {
+      setState(() => _campusCardResult = cachedResult);
+    }
+    await _loadCampusCardAutoRefreshSettings();
   }
 
   /// 读取校园卡余额、状态和交易记录。
-  Future<void> _loadCampusCard({DateTime? startDate, DateTime? endDate}) async {
+  Future<void> _loadCampusCard({
+    DateTime? startDate,
+    DateTime? endDate,
+    bool silent = false,
+  }) async {
     if (_isLoadingCampusCard) return;
-    setState(() => _isLoadingCampusCard = true);
+    if (!silent) setState(() => _isLoadingCampusCard = true);
 
     final result = await _campusCardService.fetchCampusCard(
       startDate: startDate,
       endDate: endDate,
     );
     if (!mounted) return;
+    if (silent && !result.isSuccess) return;
     setState(() {
       _campusCardResult = result;
-      _isLoadingCampusCard = false;
+      if (!silent) _isLoadingCampusCard = false;
     });
   }
 
-  /// 根据设置重建校园卡余额自动刷新定时器。
-  void _restartCampusCardAutoRefreshTimer() {
+  bool _shouldAutoRefresh(DateTime? fetchedAt, int intervalMinutes) {
+    if (intervalMinutes <= 0) return false;
+    if (fetchedAt == null) return true;
+    return DateTime.now().difference(fetchedAt) >=
+        Duration(minutes: intervalMinutes);
+  }
+
+  @override
+  void dispose() {
+    _credentialChangeSubscription?.cancel();
     _campusCardAutoRefreshTimer?.cancel();
-    _campusCardAutoRefreshTimer = null;
-    if (!_campusCardAutoRefreshEnabled) return;
-    final intervalMinutes = _campusCardAutoRefreshIntervalMinutes;
-    if (intervalMinutes <= 0) return;
-    _campusCardAutoRefreshTimer = Timer.periodic(
-      Duration(minutes: intervalMinutes),
-      (_) => _loadCampusCard(),
-    );
+    super.dispose();
   }
 
   @override

--- a/lib/services/academic_credentials_service.dart
+++ b/lib/services/academic_credentials_service.dart
@@ -6,12 +6,15 @@
  * @Date : 2026-04-24
  */
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import '../models/academic_credentials.dart';
 import '../models/academic_login_validation.dart';
+import 'authenticated_data_cache_service.dart';
+import 'storage_service.dart';
 
 /// 教务凭据安全存储服务。
 /// 使用系统安全存储保存可解密凭据，供后续外部网站登录流程读取。
@@ -46,6 +49,13 @@ class AcademicCredentialsService {
   /// Android 端由 flutter_secure_storage 使用当前默认加密实现托管密钥。
   static const FlutterSecureStorage _secureStorage = FlutterSecureStorage();
 
+  final StreamController<int> _changeController =
+      StreamController<int>.broadcast();
+  int _changeVersion = 0;
+
+  /// 凭据变化通知；页面据此丢弃已挂载的旧账号业务状态。
+  Stream<int> get changes => _changeController.stream;
+
   /// 获取设置页展示所需的凭据状态。
   Future<AcademicCredentialsStatus> getStatus() async {
     final oaAccount = await _readValue(_oaAccountKey);
@@ -73,16 +83,28 @@ class AcademicCredentialsService {
   }) async {
     final normalizedOaAccount = oaAccount.trim();
     final previousOaAccount = await _readValue(_oaAccountKey) ?? '';
+    final shouldClearForSecretUpdate =
+        (oaPassword != null && oaPassword.isNotEmpty) ||
+        (sportsQueryPassword != null && sportsQueryPassword.isNotEmpty) ||
+        (emailPassword != null && emailPassword.isNotEmpty);
+    final shouldClearAuthenticatedCache =
+        (previousOaAccount.isNotEmpty &&
+            previousOaAccount != normalizedOaAccount) ||
+        shouldClearForSecretUpdate;
     final shouldClearOaSession =
         previousOaAccount != normalizedOaAccount ||
         (oaPassword != null && oaPassword.isNotEmpty);
 
+    if (shouldClearOaSession) await clearOaLoginSession();
     await _writeOrDeleteWhenBlank(_oaAccountKey, normalizedOaAccount);
     await _secureStorage.delete(key: _legacyEmailAccountKey);
     await _writeWhenPresent(_oaPasswordKey, oaPassword);
     await _writeWhenPresent(_sportsQueryPasswordKey, sportsQueryPassword);
     await _writeWhenPresent(_emailPasswordKey, emailPassword);
-    if (shouldClearOaSession) await clearOaLoginSession();
+    if (shouldClearAuthenticatedCache) {
+      await AuthenticatedDataCacheService.clearAll();
+      _notifyChanged();
+    }
   }
 
   /// 读取指定密码字段原文，供后续登录外部网站使用。
@@ -92,12 +114,29 @@ class AcademicCredentialsService {
 
   /// 保存 OA 登录后返回的会话身份信息。
   Future<void> saveOaLoginSession(
-    AcademicLoginSessionSnapshot sessionSnapshot,
-  ) async {
+    AcademicLoginSessionSnapshot sessionSnapshot, {
+    String? ownerAccount,
+  }) async {
     if (!sessionSnapshot.hasCookies) return;
+    final normalizedOwnerAccount = _normalizeAccount(
+      ownerAccount ?? await _readValue(_oaAccountKey) ?? '',
+    );
+    if (normalizedOwnerAccount.isEmpty) return;
+    final ownerCredentialHash = _ownerCredentialHash(
+      normalizedOwnerAccount,
+      await _readValue(_oaPasswordKey) ?? '',
+    );
+    if (ownerCredentialHash.isEmpty) return;
     await _secureStorage.write(
       key: _oaLoginSessionKey,
-      value: jsonEncode(sessionSnapshot.toJson()),
+      value: jsonEncode(
+        sessionSnapshot
+            .withOwnerAccount(
+              normalizedOwnerAccount,
+              ownerCredentialHash: ownerCredentialHash,
+            )
+            .toJson(),
+      ),
     );
   }
 
@@ -107,7 +146,24 @@ class AcademicCredentialsService {
     if (sessionPayload == null || sessionPayload.trim().isEmpty) return null;
     try {
       final decodedPayload = jsonDecode(sessionPayload) as Map<String, dynamic>;
-      return AcademicLoginSessionSnapshot.fromJson(decodedPayload);
+      final sessionSnapshot = AcademicLoginSessionSnapshot.fromJson(
+        decodedPayload,
+      );
+      final currentAccount = _normalizeAccount(
+        await _readValue(_oaAccountKey) ?? '',
+      );
+      final currentCredentialHash = _ownerCredentialHash(
+        currentAccount,
+        await _readValue(_oaPasswordKey) ?? '',
+      );
+      if (currentAccount.isEmpty ||
+          currentCredentialHash.isEmpty ||
+          sessionSnapshot.ownerAccount != currentAccount ||
+          sessionSnapshot.ownerCredentialHash != currentCredentialHash) {
+        await clearOaLoginSession();
+        return null;
+      }
+      return sessionSnapshot;
     } catch (_) {
       await clearOaLoginSession();
       return null;
@@ -129,9 +185,11 @@ class AcademicCredentialsService {
   /// 清除指定密码字段。
   Future<void> clearSecret(AcademicCredentialSecret secret) async {
     await _secureStorage.delete(key: _keyOf(secret));
+    await AuthenticatedDataCacheService.clearAll();
     if (secret == AcademicCredentialSecret.oaPassword) {
       await clearOaLoginSession();
     }
+    _notifyChanged();
   }
 
   /// 清除本服务管理的所有教务凭据。
@@ -139,6 +197,8 @@ class AcademicCredentialsService {
     for (final key in _allKeys) {
       await _secureStorage.delete(key: key);
     }
+    await AuthenticatedDataCacheService.clearAll();
+    _notifyChanged();
   }
 
   /// 当前服务管理的全部安全存储键。
@@ -185,5 +245,22 @@ class AcademicCredentialsService {
     final normalizedOaAccount = oaAccount.trim();
     if (normalizedOaAccount.isEmpty) return '';
     return '$normalizedOaAccount@sspu.edu.cn';
+  }
+
+  String _normalizeAccount(String value) {
+    return value.trim().toLowerCase();
+  }
+
+  String _ownerCredentialHash(String ownerAccount, String oaPassword) {
+    final normalizedOwnerAccount = _normalizeAccount(ownerAccount);
+    if (normalizedOwnerAccount.isEmpty || oaPassword.isEmpty) return '';
+    return StorageService.hashPassword(
+      'academic-login-session:$normalizedOwnerAccount:$oaPassword',
+    );
+  }
+
+  void _notifyChanged() {
+    _changeVersion++;
+    _changeController.add(_changeVersion);
   }
 }

--- a/lib/services/academic_eams_discovery.dart
+++ b/lib/services/academic_eams_discovery.dart
@@ -201,6 +201,7 @@ extension _AcademicEamsDiscovery on AcademicEamsService {
     AcademicEamsQueryStatus status, {
     required String message,
     required String detail,
+    DateTime? checkedAt,
     Uri? finalUri,
     CampusNetworkStatus? campusNetworkStatus,
     AcademicEamsSnapshot? snapshot,
@@ -211,7 +212,7 @@ extension _AcademicEamsDiscovery on AcademicEamsService {
       status: status,
       message: message,
       detail: detail,
-      checkedAt: DateTime.now(),
+      checkedAt: checkedAt ?? DateTime.now(),
       entranceUri: entranceUri,
       finalUri: finalUri,
       campusNetworkStatus: campusNetworkStatus,

--- a/lib/services/academic_eams_overview_flow.dart
+++ b/lib/services/academic_eams_overview_flow.dart
@@ -45,7 +45,18 @@ extension _AcademicEamsOverviewFlow on AcademicEamsService {
         );
       }
 
-      return await _fetchWithOaSession(scope, campusStatus);
+      final result = await _fetchWithOaSession(scope, campusStatus);
+      if (result.isSuccess && result.snapshot != null) {
+        if (!await _hasSameOaCredentials(oaAccount, oaPassword)) {
+          return _credentialsChangedResult(campusStatus, result.finalUri);
+        }
+        await _saveAcademicEamsCache(
+          scope: scope,
+          accountKey: oaAccount,
+          snapshot: result.snapshot!,
+        );
+      }
+      return result;
     } on TimeoutException {
       return _buildResult(
         AcademicEamsQueryStatus.networkError,
@@ -71,13 +82,53 @@ extension _AcademicEamsOverviewFlow on AcademicEamsService {
     }
   }
 
+  Future<void> _saveAcademicEamsCache({
+    required _AcademicFetchScope scope,
+    required String accountKey,
+    required AcademicEamsSnapshot snapshot,
+  }) async {
+    await AuthenticatedDataCacheService.saveLatest(
+      collection: scope == _AcademicFetchScope.courseTableOnly
+          ? StorageKeys.academicEamsCourseTableCacheCollection
+          : StorageKeys.academicEamsOverviewCacheCollection,
+      accountKey: accountKey,
+      fetchedAt: snapshot.fetchedAt,
+      data: snapshot.toJson(),
+    );
+  }
+
+  Future<bool> _hasSameOaCredentials(
+    String accountKey,
+    String oaPassword,
+  ) async {
+    final currentAccountKey = (await _credentialsService.getStatus()).oaAccount
+        .trim();
+    final currentOaPassword = await _credentialsService.readSecret(
+      AcademicCredentialSecret.oaPassword,
+    );
+    return currentAccountKey == accountKey && currentOaPassword == oaPassword;
+  }
+
+  AcademicEamsQueryResult _credentialsChangedResult(
+    CampusNetworkStatus? campusStatus,
+    Uri? finalUri,
+  ) {
+    return _buildResult(
+      AcademicEamsQueryStatus.unexpectedError,
+      message: '本专科教务查询已取消',
+      detail: '教务凭据已在查询过程中变更，已丢弃本次教务结果。',
+      finalUri: finalUri,
+      campusNetworkStatus: campusStatus,
+    );
+  }
+
   Future<AcademicEamsQueryResult> _fetchWithOaSession(
     _AcademicFetchScope scope,
     CampusNetworkStatus campusNetworkStatus,
   ) async {
     var sessionSnapshot = await _credentialsService.readOaLoginSession();
-    var entrySnapshot = await _openEntryWithSession(sessionSnapshot);
-    if (_isAuthenticationRequired(entrySnapshot)) {
+    var refreshedBeforeEntry = false;
+    if (sessionSnapshot == null || !sessionSnapshot.hasCookies) {
       final loginResult = await _refreshOaLogin();
       if (!loginResult.isSuccess) {
         return _buildResult(
@@ -91,6 +142,25 @@ extension _AcademicEamsOverviewFlow on AcademicEamsService {
       sessionSnapshot =
           await _credentialsService.readOaLoginSession() ??
           loginResult.sessionSnapshot;
+      refreshedBeforeEntry = true;
+    }
+    var entrySnapshot = await _openEntryWithSession(sessionSnapshot);
+    if (_isAuthenticationRequired(entrySnapshot)) {
+      if (!refreshedBeforeEntry) {
+        final loginResult = await _refreshOaLogin();
+        if (!loginResult.isSuccess) {
+          return _buildResult(
+            AcademicEamsQueryStatus.oaLoginRequired,
+            message: 'OA 登录状态不可用，无法访问本专科教务',
+            detail: loginResult.message,
+            finalUri: loginResult.finalUri,
+            campusNetworkStatus: campusNetworkStatus,
+          );
+        }
+        sessionSnapshot =
+            await _credentialsService.readOaLoginSession() ??
+            loginResult.sessionSnapshot;
+      }
       entrySnapshot = await _openEntryWithSession(sessionSnapshot);
     }
 
@@ -99,7 +169,7 @@ extension _AcademicEamsOverviewFlow on AcademicEamsService {
       return _buildResult(
         AcademicEamsQueryStatus.oaLoginRequired,
         message: '本专科教务登录状态不可用',
-        detail: 'EAMS 入口仍返回 CAS 或教务登录页，请先在安全设置中验证 OA 登录。',
+        detail: 'EAMS 入口仍返回 CAS 或教务登录页，已无法自动刷新 OA 登录会话。',
         finalUri: homeSnapshot.finalUri,
         campusNetworkStatus: campusNetworkStatus,
       );

--- a/lib/services/academic_eams_search_flow.dart
+++ b/lib/services/academic_eams_search_flow.dart
@@ -57,8 +57,8 @@ extension _AcademicEamsSearchFlow on AcademicEamsService {
       }
 
       var sessionSnapshot = await _credentialsService.readOaLoginSession();
-      var entrySnapshot = await _openEntryWithSession(sessionSnapshot);
-      if (_isAuthenticationRequired(entrySnapshot)) {
+      var refreshedBeforeEntry = false;
+      if (sessionSnapshot == null || !sessionSnapshot.hasCookies) {
         final loginResult = await _refreshOaLogin();
         if (!loginResult.isSuccess) {
           return _buildResult(
@@ -72,6 +72,25 @@ extension _AcademicEamsSearchFlow on AcademicEamsService {
         sessionSnapshot =
             await _credentialsService.readOaLoginSession() ??
             loginResult.sessionSnapshot;
+        refreshedBeforeEntry = true;
+      }
+      var entrySnapshot = await _openEntryWithSession(sessionSnapshot);
+      if (_isAuthenticationRequired(entrySnapshot)) {
+        if (!refreshedBeforeEntry) {
+          final loginResult = await _refreshOaLogin();
+          if (!loginResult.isSuccess) {
+            return _buildResult(
+              AcademicEamsQueryStatus.oaLoginRequired,
+              message: 'OA 登录状态不可用，无法访问本专科教务',
+              detail: loginResult.message,
+              finalUri: loginResult.finalUri,
+              campusNetworkStatus: campusStatus,
+            );
+          }
+          sessionSnapshot =
+              await _credentialsService.readOaLoginSession() ??
+              loginResult.sessionSnapshot;
+        }
         entrySnapshot = await _openEntryWithSession(sessionSnapshot);
       }
 
@@ -80,7 +99,7 @@ extension _AcademicEamsSearchFlow on AcademicEamsService {
         return _buildResult(
           AcademicEamsQueryStatus.oaLoginRequired,
           message: '本专科教务登录状态不可用',
-          detail: 'EAMS 入口仍返回 CAS 或教务登录页，请先在安全设置中验证 OA 登录。',
+          detail: 'EAMS 入口仍返回 CAS 或教务登录页，已无法自动刷新 OA 登录会话。',
           finalUri: homeSnapshot.finalUri,
           campusNetworkStatus: campusStatus,
         );
@@ -112,7 +131,7 @@ extension _AcademicEamsSearchFlow on AcademicEamsService {
         return _buildResult(
           AcademicEamsQueryStatus.oaLoginRequired,
           message: '本专科教务登录状态已失效',
-          detail: '进入只读查询页时返回了教务登录页，请先重新验证 OA 登录。',
+          detail: '进入只读查询页时返回了教务登录页，已无法自动刷新 OA 登录会话。',
           finalUri: searchEntrySnapshot.finalUri,
           campusNetworkStatus: campusStatus,
         );
@@ -143,7 +162,7 @@ extension _AcademicEamsSearchFlow on AcademicEamsService {
         return _buildResult(
           AcademicEamsQueryStatus.oaLoginRequired,
           message: '本专科教务登录状态已失效',
-          detail: '只读查询提交后返回了教务登录页，请重新验证 OA 登录。',
+          detail: '只读查询提交后返回了教务登录页，已无法自动刷新 OA 登录会话。',
           finalUri: resultSnapshot.finalUri,
           campusNetworkStatus: campusStatus,
         );
@@ -156,6 +175,9 @@ extension _AcademicEamsSearchFlow on AcademicEamsService {
           finalUri: resultSnapshot.finalUri,
           campusNetworkStatus: campusStatus,
         );
+      }
+      if (!await _hasSameOaCredentials(oaAccount, oaPassword)) {
+        return _credentialsChangedResult(campusStatus, resultSnapshot.finalUri);
       }
       return resultBuilder(resultSnapshot, campusStatus);
     } on TimeoutException {

--- a/lib/services/academic_eams_service.dart
+++ b/lib/services/academic_eams_service.dart
@@ -20,6 +20,7 @@ import '../models/academic_login_validation.dart';
 import '../models/campus_network_status.dart';
 import 'academic_credentials_service.dart';
 import 'academic_login_validation_service.dart';
+import 'authenticated_data_cache_service.dart';
 import 'campus_network_status_service.dart';
 import 'http_service.dart';
 import 'storage_service.dart';
@@ -37,6 +38,12 @@ part 'academic_eams_shell_followups.dart';
 
 /// 教务中心与课程表页可依赖的只读接口。
 abstract class AcademicEamsClient {
+  /// 读取最近一次本地本专科教务摘要缓存。
+  Future<AcademicEamsQueryResult?> readLatestCachedOverview();
+
+  /// 读取最近一次本地课表缓存。
+  Future<AcademicEamsQueryResult?> readLatestCachedCourseTable();
+
   /// 读取教务摘要，尽量覆盖个人信息、课表、成绩、考试和培养计划。
   Future<AcademicEamsQueryResult> fetchOverview();
 
@@ -118,7 +125,9 @@ class AcademicEamsService implements AcademicEamsClient {
        _gateway = gateway ?? DioAcademicEamsGateway(),
        _refreshOaLogin =
            refreshOaLogin ??
-           AcademicLoginValidationService.instance.validateSavedCredentials,
+           (() => AcademicLoginValidationService.instance.ensureSavedSession(
+             forceRefresh: true,
+           )),
        entranceUri = entranceUri ?? defaultEntranceUri,
        homeUri = homeUri ?? defaultHomeUri,
        submenuBaseUri = submenuBaseUri ?? defaultSubmenuBaseUri,
@@ -282,6 +291,49 @@ class AcademicEamsService implements AcademicEamsClient {
           freeClassrooms: records,
         );
       },
+    );
+  }
+
+  /// 读取最近一次本地本专科教务摘要缓存。
+  @override
+  Future<AcademicEamsQueryResult?> readLatestCachedOverview() async {
+    return _readLatestCachedResult(
+      collection: StorageKeys.academicEamsOverviewCacheCollection,
+      message: '已显示本地本专科教务缓存',
+      detail: '显示最近一次成功读取并保存的本专科教务摘要。',
+    );
+  }
+
+  /// 读取最近一次本地课表缓存。
+  @override
+  Future<AcademicEamsQueryResult?> readLatestCachedCourseTable() async {
+    return _readLatestCachedResult(
+      collection: StorageKeys.academicEamsCourseTableCacheCollection,
+      message: '已显示本地课表缓存',
+      detail: '显示最近一次成功读取并保存的本专科教务课表。',
+    );
+  }
+
+  Future<AcademicEamsQueryResult?> _readLatestCachedResult({
+    required String collection,
+    required String message,
+    required String detail,
+  }) async {
+    final accountKey = (await _credentialsService.getStatus()).oaAccount.trim();
+    if (accountKey.isEmpty) return null;
+    final entry = await AuthenticatedDataCacheService.readLatest(
+      collection,
+      accountKey: accountKey,
+    );
+    if (entry == null) return null;
+    final snapshot = AcademicEamsSnapshot.fromJson(entry.data);
+    return _buildResult(
+      AcademicEamsQueryStatus.success,
+      message: message,
+      detail: detail,
+      checkedAt: snapshot.fetchedAt,
+      finalUri: snapshot.sourceUri,
+      snapshot: snapshot,
     );
   }
 }

--- a/lib/services/academic_login_validation_service.dart
+++ b/lib/services/academic_login_validation_service.dart
@@ -107,6 +107,50 @@ class AcademicLoginValidationService {
   /// 单次网络步骤超时时间。
   final Duration timeout;
 
+  Future<AcademicLoginValidationResult>? _ensureSessionFuture;
+  String? _ensureSessionAccountKey;
+  int? _ensureSessionCredentialMarker;
+
+  /// 确保本地已有可复用 OA 登录会话；缺失或强制刷新时自动执行 OA/CAS 登录。
+  Future<AcademicLoginValidationResult> ensureSavedSession({
+    bool forceRefresh = false,
+  }) async {
+    final accountKey = (await _credentialsService.getStatus()).oaAccount
+        .trim()
+        .toLowerCase();
+    final oaPassword = await _credentialsService.readSecret(
+      AcademicCredentialSecret.oaPassword,
+    );
+    final credentialMarker = Object.hash(accountKey, oaPassword ?? '', forceRefresh);
+    while (true) {
+      final activeFuture = _ensureSessionFuture;
+      if (activeFuture == null) break;
+      if (_ensureSessionAccountKey == accountKey &&
+          _ensureSessionCredentialMarker == credentialMarker) {
+        return activeFuture;
+      }
+      try {
+        await activeFuture;
+      } catch (_) {
+        // Ignore the other account's result; this call will start its own flow.
+      }
+    }
+    final future = _ensureSavedSession(
+      forceRefresh: forceRefresh,
+      accountKey: accountKey,
+    );
+    _ensureSessionFuture = future;
+    _ensureSessionAccountKey = accountKey;
+    _ensureSessionCredentialMarker = credentialMarker;
+    return future.whenComplete(() {
+      if (identical(_ensureSessionFuture, future)) {
+        _ensureSessionFuture = null;
+        _ensureSessionAccountKey = null;
+        _ensureSessionCredentialMarker = null;
+      }
+    });
+  }
+
   /// 使用本地已保存 OA 账号密码执行只读登录校验。
   Future<AcademicLoginValidationResult> validateSavedCredentials() async {
     CampusNetworkStatus? campusStatus;
@@ -149,12 +193,47 @@ class AcademicLoginValidationService {
       );
       if (validationResult.isSuccess &&
           validationResult.sessionSnapshot != null) {
+        final currentStatus = await _credentialsService.getStatus();
+        final currentOaPassword = await _credentialsService.readSecret(
+          AcademicCredentialSecret.oaPassword,
+        );
+        if (currentStatus.oaAccount.trim().toLowerCase() !=
+                oaAccount.toLowerCase() ||
+            currentOaPassword != oaPassword) {
+          return _buildResult(
+            AcademicLoginValidationStatus.unexpectedError,
+            message: 'OA 登录校验已取消',
+            detail: '教务凭据已在校验过程中变更，已丢弃本次登录会话。',
+            finalUri: validationResult.finalUri,
+            campusNetworkStatus: campusStatus,
+          );
+        }
+        final sessionSnapshot = validationResult.sessionSnapshot!
+            .withOwnerAccount(oaAccount);
         await _credentialsService.saveOaLoginSession(
-          validationResult.sessionSnapshot!,
+          sessionSnapshot,
+          ownerAccount: oaAccount,
+        );
+        return _buildResult(
+          AcademicLoginValidationStatus.success,
+          message: validationResult.message,
+          detail: validationResult.detail,
+          finalUri: validationResult.finalUri,
+          campusNetworkStatus: campusStatus,
+          sessionSnapshot: sessionSnapshot,
         );
       } else if (validationResult.status ==
           AcademicLoginValidationStatus.credentialsRejected) {
-        await _credentialsService.clearOaLoginSession();
+        final currentAccount = (await _credentialsService.getStatus()).oaAccount
+            .trim()
+            .toLowerCase();
+        final currentOaPassword = await _credentialsService.readSecret(
+          AcademicCredentialSecret.oaPassword,
+        );
+        if (currentAccount == oaAccount.toLowerCase() &&
+            currentOaPassword == oaPassword) {
+          await _credentialsService.clearOaLoginSession();
+        }
       }
       return validationResult;
     } on TimeoutException {
@@ -180,6 +259,28 @@ class AcademicLoginValidationService {
         campusNetworkStatus: campusStatus,
       );
     }
+  }
+
+  Future<AcademicLoginValidationResult> _ensureSavedSession({
+    required bool forceRefresh,
+    required String accountKey,
+  }) async {
+    if (accountKey.isEmpty) return validateSavedCredentials();
+    if (!forceRefresh) {
+      final sessionSnapshot = await _credentialsService.readOaLoginSession();
+      if (sessionSnapshot != null &&
+          sessionSnapshot.hasCookies &&
+          sessionSnapshot.ownerAccount == accountKey) {
+        return _buildResult(
+          AcademicLoginValidationStatus.success,
+          message: 'OA 登录会话已就绪',
+          detail: '本地已有可复用 OA/CAS Cookie，会在业务读取时自动使用。',
+          finalUri: sessionSnapshot.finalUri,
+          sessionSnapshot: sessionSnapshot,
+        );
+      }
+    }
+    return validateSavedCredentials();
   }
 
   Future<AcademicLoginValidationResult> _validateCredentials({

--- a/lib/services/authenticated_data_cache_service.dart
+++ b/lib/services/authenticated_data_cache_service.dart
@@ -1,0 +1,203 @@
+/*
+ * 鉴权业务数据缓存服务 — 保存只读业务快照并保留最近记录
+ * @Project : SSPU-AllinOne
+ * @File : authenticated_data_cache_service.dart
+ * @Author : Qintsg
+ * @Date : 2026-05-31
+ */
+
+import 'storage_service.dart';
+
+/// 鉴权业务数据缓存条目。
+/// 仅包含业务解析结果和读取时间，不保存凭据、Cookie 或其它身份材料。
+class AuthenticatedDataCacheEntry {
+  const AuthenticatedDataCacheEntry({
+    required this.key,
+    required this.fetchedAt,
+    required this.data,
+  });
+
+  /// 存储集合内的记录键。
+  final String key;
+
+  /// 业务数据获取时间。
+  final DateTime fetchedAt;
+
+  /// 业务快照 JSON。
+  final Map<String, dynamic> data;
+
+  /// 是否已经超过指定自动刷新间隔。
+  bool isStaleFor(int intervalMinutes) {
+    if (intervalMinutes <= 0) return false;
+    return DateTime.now().difference(fetchedAt) >=
+        Duration(minutes: intervalMinutes);
+  }
+}
+
+/// 鉴权业务数据缓存服务。
+class AuthenticatedDataCacheService {
+  AuthenticatedDataCacheService._();
+
+  static const String _ownerAccountKey = 'ownerAccount';
+
+  /// 每类业务数据最多保留的历史记录数。
+  static const int maxRecordsPerType = 3;
+
+  /// 保存一条业务快照，并清理同集合中更旧的记录。
+  static Future<void> saveLatest({
+    required String collection,
+    required String accountKey,
+    required DateTime fetchedAt,
+    required Map<String, dynamic> data,
+  }) async {
+    final ownerAccount = _ownerKeyForAccount(accountKey);
+    if (ownerAccount.isEmpty) return;
+    final normalizedFetchedAt = fetchedAt.toUtc();
+    final key = [
+      ownerAccount,
+      normalizedFetchedAt.microsecondsSinceEpoch,
+      DateTime.now().toUtc().microsecondsSinceEpoch,
+    ].join('_');
+    final payload = _sanitizeCachePayload(data);
+    payload[_ownerAccountKey] = ownerAccount;
+    payload['fetchedAt'] = normalizedFetchedAt.toIso8601String();
+
+    await StorageService.saveData(collection, key, payload);
+    await _trimCollection(collection, ownerAccount);
+  }
+
+  /// 读取指定集合中最新一条业务快照。
+  static Future<AuthenticatedDataCacheEntry?> readLatest(
+    String collection, {
+    String? accountKey,
+  }) async {
+    final entries = await readLatestRecords(collection, accountKey: accountKey);
+    return entries.isEmpty ? null : entries.first;
+  }
+
+  /// 读取指定集合中按时间倒序排列的业务快照。
+  static Future<List<AuthenticatedDataCacheEntry>> readLatestRecords(
+    String collection, {
+    String? accountKey,
+  }) async {
+    final expectedOwner = accountKey == null
+        ? null
+        : _ownerKeyForAccount(accountKey);
+    final records = await StorageService.getAllData(collection);
+    final entries = <AuthenticatedDataCacheEntry>[];
+    for (final item in records.entries) {
+      final fetchedAt = _parseFetchedAt(item.value);
+      if (fetchedAt == null) continue;
+      if (expectedOwner != null &&
+          item.value[_ownerAccountKey] != expectedOwner) {
+        continue;
+      }
+      entries.add(
+        AuthenticatedDataCacheEntry(
+          key: item.key,
+          fetchedAt: fetchedAt,
+          data: item.value,
+        ),
+      );
+    }
+    entries.sort((a, b) => b.fetchedAt.compareTo(a.fetchedAt));
+    return entries;
+  }
+
+  /// 清理全部鉴权业务数据缓存。
+  static Future<void> clearAll() async {
+    for (final collection in _authenticatedCollections) {
+      await StorageService.clearCollection(collection);
+    }
+  }
+
+  static Future<void> _trimCollection(
+    String collection,
+    String ownerAccount,
+  ) async {
+    final entries = (await readLatestRecords(
+      collection,
+    )).where((entry) => entry.data[_ownerAccountKey] == ownerAccount).toList();
+    if (entries.length <= maxRecordsPerType) return;
+    for (final entry in entries.skip(maxRecordsPerType)) {
+      await StorageService.removeData(collection, entry.key);
+    }
+  }
+
+  static DateTime? _parseFetchedAt(Map<String, dynamic> data) {
+    final value = data['fetchedAt'];
+    if (value is String) return DateTime.tryParse(value)?.toLocal();
+    return null;
+  }
+
+  static Map<String, dynamic> _sanitizeCachePayload(Map<String, dynamic> data) {
+    return Map<String, dynamic>.fromEntries(
+      data.entries.map(
+        (entry) =>
+            MapEntry(entry.key, _sanitizeCacheValue(entry.key, entry.value)),
+      ),
+    );
+  }
+
+  static Object? _sanitizeCacheValue(String key, Object? value) {
+    if (value is Map<String, dynamic>) return _sanitizeCachePayload(value);
+    if (value is Map) {
+      return Map<String, dynamic>.fromEntries(
+        value.entries.map(
+          (entry) => MapEntry(
+            entry.key.toString(),
+            _sanitizeCacheValue(entry.key.toString(), entry.value),
+          ),
+        ),
+      );
+    }
+    if (value is List) {
+      return value.map((item) => _sanitizeCacheValue(key, item)).toList();
+    }
+    if (value is String && _isUriField(key)) return _sanitizeUriString(value);
+    return value;
+  }
+
+  static bool _isUriField(String key) {
+    return key.toLowerCase().endsWith('uri');
+  }
+
+  static String _sanitizeUriString(String value) {
+    final uri = Uri.tryParse(value);
+    if (uri == null || !uri.hasScheme) return value;
+    final sanitizedUri = StringBuffer('${uri.scheme}:');
+    if (uri.hasAuthority) {
+      sanitizedUri.write('//');
+      if (uri.userInfo.isNotEmpty) sanitizedUri.write('${uri.userInfo}@');
+      sanitizedUri.write(uri.host);
+      if (uri.hasPort) sanitizedUri.write(':${uri.port}');
+    }
+    sanitizedUri.write(uri.path);
+    return sanitizedUri.toString();
+  }
+
+  static String _normalizeAccountKey(Object? value) {
+    if (value is! String) return '';
+    return value.trim().toLowerCase();
+  }
+
+  static String _ownerKeyForAccount(Object? value) {
+    final normalizedAccount = _normalizeAccountKey(value);
+    if (normalizedAccount.isEmpty) return '';
+    return StorageService.hashPassword(
+      'authenticated-cache:$normalizedAccount',
+    );
+  }
+
+  static List<String> get _authenticatedCollections => [
+    StorageKeys.campusCardCacheCollection,
+    StorageKeys.sportsAttendanceCacheCollection,
+    StorageKeys.studentReportCacheCollection,
+    StorageKeys.academicEamsOverviewCacheCollection,
+    StorageKeys.academicEamsCourseTableCacheCollection,
+    StorageKeys.emailMailboxCacheCollection,
+    '${StorageKeys.emailMailboxCacheCollection}_imap',
+    '${StorageKeys.emailMailboxCacheCollection}_pop',
+    '${StorageKeys.emailMailboxCacheCollection}_smtp',
+  ];
+}

--- a/lib/services/campus_card_flow.dart
+++ b/lib/services/campus_card_flow.dart
@@ -177,6 +177,7 @@ extension _CampusCardFlow on CampusCardService {
     CampusCardQueryStatus status, {
     required String message,
     required String detail,
+    DateTime? checkedAt,
     Uri? finalUri,
     CampusNetworkStatus? campusNetworkStatus,
     CampusCardSnapshot? snapshot,
@@ -185,7 +186,7 @@ extension _CampusCardFlow on CampusCardService {
       status: status,
       message: message,
       detail: detail,
-      checkedAt: DateTime.now(),
+      checkedAt: checkedAt ?? DateTime.now(),
       entranceUri: entranceUri,
       finalUri: finalUri,
       campusNetworkStatus: campusNetworkStatus,

--- a/lib/services/campus_card_service.dart
+++ b/lib/services/campus_card_service.dart
@@ -20,6 +20,7 @@ import '../models/campus_card.dart';
 import '../models/campus_network_status.dart';
 import 'academic_credentials_service.dart';
 import 'academic_login_validation_service.dart';
+import 'authenticated_data_cache_service.dart';
 import 'campus_network_status_service.dart';
 import 'http_service.dart';
 import 'storage_service.dart';
@@ -30,6 +31,9 @@ part 'campus_card_page_parser.dart';
 
 /// 教务首页依赖的校园卡查询接口，便于 widget 测试替换。
 abstract class CampusCardBalanceClient {
+  /// 读取最近一次本地校园卡业务快照。
+  Future<CampusCardQueryResult?> readLatestCachedCampusCard();
+
   /// 读取校园卡余额、卡状态和交易记录。
   Future<CampusCardQueryResult> fetchCampusCard({
     DateTime? startDate,
@@ -99,7 +103,9 @@ class CampusCardService implements CampusCardBalanceClient {
        _gateway = gateway ?? DioCampusCardGateway(),
        _refreshOaLogin =
            refreshOaLogin ??
-           AcademicLoginValidationService.instance.validateSavedCredentials,
+           (() => AcademicLoginValidationService.instance.ensureSavedSession(
+             forceRefresh: true,
+           )),
        entranceUri = entranceUri ?? defaultEntranceUri,
        homeUri = homeUri ?? defaultHomeUri,
        transactionIndexUri = transactionIndexUri ?? defaultTransactionIndexUri,
@@ -183,6 +189,27 @@ class CampusCardService implements CampusCardBalanceClient {
     );
   }
 
+  /// 读取最近一次本地校园卡业务快照。
+  @override
+  Future<CampusCardQueryResult?> readLatestCachedCampusCard() async {
+    final accountKey = (await _credentialsService.getStatus()).oaAccount.trim();
+    if (accountKey.isEmpty) return null;
+    final entry = await AuthenticatedDataCacheService.readLatest(
+      StorageKeys.campusCardCacheCollection,
+      accountKey: accountKey,
+    );
+    if (entry == null) return null;
+    final snapshot = CampusCardSnapshot.fromJson(entry.data);
+    return _buildResult(
+      CampusCardQueryStatus.success,
+      message: '已显示本地校园卡缓存',
+      detail: '显示最近一次成功读取并保存的校园卡余额、状态和交易记录。',
+      checkedAt: snapshot.fetchedAt,
+      finalUri: snapshot.sourceUri,
+      snapshot: snapshot,
+    );
+  }
+
   @override
   Future<CampusCardQueryResult> fetchCampusCard({
     DateTime? startDate,
@@ -221,11 +248,21 @@ class CampusCardService implements CampusCardBalanceClient {
         );
       }
 
-      return await _fetchWithOaSession(
+      final result = await _fetchWithOaSession(
         startDate: startDate,
         endDate: endDate,
         campusNetworkStatus: campusStatus,
       );
+      if (result.isSuccess && result.snapshot != null) {
+        if (!await _hasSameOaCredentials(studentId, oaPassword)) {
+          return _credentialsChangedResult(campusStatus, result.finalUri);
+        }
+        await _saveCampusCardCache(
+          accountKey: studentId,
+          snapshot: result.snapshot!,
+        );
+      }
+      return result;
     } on TimeoutException {
       return _buildResult(
         CampusCardQueryStatus.networkError,
@@ -251,14 +288,51 @@ class CampusCardService implements CampusCardBalanceClient {
     }
   }
 
+  Future<void> _saveCampusCardCache({
+    required String accountKey,
+    required CampusCardSnapshot snapshot,
+  }) async {
+    await AuthenticatedDataCacheService.saveLatest(
+      collection: StorageKeys.campusCardCacheCollection,
+      accountKey: accountKey,
+      fetchedAt: snapshot.fetchedAt,
+      data: snapshot.toJson(),
+    );
+  }
+
+  Future<bool> _hasSameOaCredentials(
+    String accountKey,
+    String oaPassword,
+  ) async {
+    final currentAccountKey = (await _credentialsService.getStatus()).oaAccount
+        .trim();
+    final currentOaPassword = await _credentialsService.readSecret(
+      AcademicCredentialSecret.oaPassword,
+    );
+    return currentAccountKey == accountKey && currentOaPassword == oaPassword;
+  }
+
+  CampusCardQueryResult _credentialsChangedResult(
+    CampusNetworkStatus? campusStatus,
+    Uri? finalUri,
+  ) {
+    return _buildResult(
+      CampusCardQueryStatus.unexpectedError,
+      message: '校园卡查询已取消',
+      detail: '教务凭据已在查询过程中变更，已丢弃本次校园卡结果。',
+      finalUri: finalUri,
+      campusNetworkStatus: campusStatus,
+    );
+  }
+
   Future<CampusCardQueryResult> _fetchWithOaSession({
     DateTime? startDate,
     DateTime? endDate,
     required CampusNetworkStatus campusNetworkStatus,
   }) async {
     var sessionSnapshot = await _credentialsService.readOaLoginSession();
-    var entrySnapshot = await _openEntryWithSession(sessionSnapshot);
-    if (_isAuthenticationRequired(entrySnapshot)) {
+    var refreshedBeforeEntry = false;
+    if (sessionSnapshot == null || !sessionSnapshot.hasCookies) {
       final loginResult = await _refreshOaLogin();
       if (!loginResult.isSuccess) {
         return _buildResult(
@@ -272,6 +346,25 @@ class CampusCardService implements CampusCardBalanceClient {
       sessionSnapshot =
           await _credentialsService.readOaLoginSession() ??
           loginResult.sessionSnapshot;
+      refreshedBeforeEntry = true;
+    }
+    var entrySnapshot = await _openEntryWithSession(sessionSnapshot);
+    if (_isAuthenticationRequired(entrySnapshot)) {
+      if (!refreshedBeforeEntry) {
+        final loginResult = await _refreshOaLogin();
+        if (!loginResult.isSuccess) {
+          return _buildResult(
+            CampusCardQueryStatus.oaLoginRequired,
+            message: 'OA 登录状态不可用，无法查询校园卡',
+            detail: loginResult.message,
+            finalUri: loginResult.finalUri,
+            campusNetworkStatus: campusNetworkStatus,
+          );
+        }
+        sessionSnapshot =
+            await _credentialsService.readOaLoginSession() ??
+            loginResult.sessionSnapshot;
+      }
       entrySnapshot = await _openEntryWithSession(sessionSnapshot);
     }
     entrySnapshot = await _resolveBusinessEntrySnapshot(entrySnapshot);
@@ -280,7 +373,7 @@ class CampusCardService implements CampusCardBalanceClient {
       return _buildResult(
         CampusCardQueryStatus.oaLoginRequired,
         message: 'OA 登录状态不可用，无法进入校园卡系统',
-        detail: '校园卡入口仍返回 CAS 登录页，请先在安全设置中验证 OA 登录。',
+        detail: '校园卡入口仍返回 CAS 登录页，已无法自动刷新 OA 登录会话。',
         finalUri: entrySnapshot.finalUri,
         campusNetworkStatus: campusNetworkStatus,
       );

--- a/lib/services/email_service.dart
+++ b/lib/services/email_service.dart
@@ -15,6 +15,7 @@ import 'package:html/parser.dart' as html_parser;
 import '../models/academic_credentials.dart';
 import '../models/email_mailbox.dart';
 import 'academic_credentials_service.dart';
+import 'authenticated_data_cache_service.dart';
 import 'storage_service.dart';
 
 part 'email_gateway.dart';
@@ -22,6 +23,11 @@ part 'email_support.dart';
 
 /// 邮箱页面依赖的只读查询接口，便于 widget 测试替换。
 abstract class EmailMailboxClient {
+  /// 读取最近一次指定协议的本地邮箱缓存。
+  Future<EmailMailboxQueryResult?> readLatestCachedMessages(
+    EmailProtocol protocol,
+  );
+
   /// 通过 IMAP 或 POP 读取最近邮件；SMTP 不允许用于收信。
   Future<EmailMailboxQueryResult> fetchMessages({
     required EmailProtocol protocol,
@@ -167,6 +173,32 @@ class EmailService implements EmailMailboxClient {
     );
   }
 
+  /// 读取最近一次指定协议的本地邮箱缓存。
+  @override
+  Future<EmailMailboxQueryResult?> readLatestCachedMessages(
+    EmailProtocol protocol,
+  ) async {
+    final accountKey = normalizeEmailAccount(
+      (await _credentialsService.getStatus()).oaAccount,
+    );
+    if (accountKey.isEmpty) return null;
+    final entry = await AuthenticatedDataCacheService.readLatest(
+      _mailboxCacheCollection(protocol),
+      accountKey: accountKey,
+    );
+    if (entry == null) return null;
+    final snapshot = EmailMailboxSnapshot.fromJson(entry.data);
+    return _buildMailboxResult(
+      status: EmailQueryStatus.success,
+      protocol: snapshot.protocol,
+      endpoint: snapshot.endpoint,
+      message: '已显示本地邮箱缓存',
+      detail: '显示最近一次成功读取并保存的 ${snapshot.protocol.label} 邮件快照。',
+      checkedAt: snapshot.fetchedAt,
+      snapshot: snapshot,
+    );
+  }
+
   /// 将学工号规范化为固定学校邮箱地址。
   static String normalizeEmailAccount(String studentId) {
     final trimmedStudentId = studentId.trim();
@@ -224,21 +256,45 @@ class EmailService implements EmailMailboxClient {
         EmailProtocol.smtp => const <EmailMessageSnapshot>[],
       };
       final fetchedAt = DateTime.now();
-      return _buildMailboxResult(
+      final snapshot = EmailMailboxSnapshot(
+        protocol: protocol,
+        account: credentials.account,
+        messages: messages,
+        fetchedAt: fetchedAt,
+        endpoint: endpoint,
+      );
+      final result = _buildMailboxResult(
         status: EmailQueryStatus.success,
         protocol: protocol,
         endpoint: endpoint,
         message: '${protocol.label} 邮件读取完成',
         detail: '已通过只读协议读取最近 ${messages.length} 封邮件。',
         checkedAt: fetchedAt,
-        snapshot: EmailMailboxSnapshot(
-          protocol: protocol,
-          account: credentials.account,
-          messages: messages,
-          fetchedAt: fetchedAt,
-          endpoint: endpoint,
-        ),
+        snapshot: snapshot,
       );
+      final currentAccount = normalizeEmailAccount(
+        (await _credentialsService.getStatus()).oaAccount,
+      );
+      final currentPassword = await _credentialsService.readSecret(
+        AcademicCredentialSecret.emailPassword,
+      );
+      if (currentAccount != credentials.account ||
+          currentPassword != credentials.password) {
+        return _buildMailboxResult(
+          status: EmailQueryStatus.unexpectedError,
+          protocol: protocol,
+          endpoint: endpoint,
+          message: '邮箱读取已取消',
+          detail: '邮箱凭据已在读取过程中变更，已丢弃本次邮箱结果。',
+        );
+      }
+      await AuthenticatedDataCacheService.saveLatest(
+        collection: _mailboxCacheCollection(protocol),
+        accountKey: credentials.account,
+        fetchedAt: snapshot.fetchedAt,
+        data: snapshot.toJson(),
+      );
+      return result;
     } on TimeoutException {
       return _networkFailure(protocol, endpoint, '邮箱服务器响应超时');
     } on SocketException {
@@ -355,6 +411,10 @@ class EmailService implements EmailMailboxClient {
 
   int _normalizeAutoRefreshInterval(int minutes) {
     return minutes <= 0 ? defaultAutoRefreshIntervalMinutes : minutes;
+  }
+
+  String _mailboxCacheCollection(EmailProtocol protocol) {
+    return '${StorageKeys.emailMailboxCacheCollection}_${protocol.name}';
   }
 
   Future<_EmailCredentials> _readCredentials() async {

--- a/lib/services/sports_attendance_service.dart
+++ b/lib/services/sports_attendance_service.dart
@@ -18,6 +18,7 @@ import '../models/academic_credentials.dart';
 import '../models/campus_network_status.dart';
 import '../models/sports_attendance.dart';
 import 'academic_credentials_service.dart';
+import 'authenticated_data_cache_service.dart';
 import 'campus_network_status_service.dart';
 import 'http_service.dart';
 import 'storage_service.dart';
@@ -28,6 +29,9 @@ part 'sports_attendance_support.dart';
 
 /// 教务页依赖的体育部考勤读取接口，便于测试中替换实现。
 abstract class SportsAttendanceClient {
+  /// 读取最近一次本地体育部考勤缓存。
+  Future<SportsAttendanceQueryResult?> readLatestCachedAttendanceSummary();
+
   /// 登录体育部查询系统并读取课外活动考勤。
   Future<SportsAttendanceQueryResult> fetchAttendanceSummary();
 }
@@ -155,6 +159,28 @@ class SportsAttendanceService implements SportsAttendanceClient {
     );
   }
 
+  /// 读取最近一次本地体育部考勤缓存。
+  @override
+  Future<SportsAttendanceQueryResult?>
+  readLatestCachedAttendanceSummary() async {
+    final accountKey = (await _credentialsService.getStatus()).oaAccount.trim();
+    if (accountKey.isEmpty) return null;
+    final entry = await AuthenticatedDataCacheService.readLatest(
+      StorageKeys.sportsAttendanceCacheCollection,
+      accountKey: accountKey,
+    );
+    if (entry == null) return null;
+    final summary = SportsAttendanceSummary.fromJson(entry.data);
+    return _buildResult(
+      SportsAttendanceQueryStatus.success,
+      message: '已显示本地体育部考勤缓存',
+      detail: '显示最近一次成功读取并保存的体育部考勤总次数与明细记录。',
+      checkedAt: summary.fetchedAt,
+      finalUri: summary.sourceUri,
+      summary: summary,
+    );
+  }
+
   @override
   Future<SportsAttendanceQueryResult> fetchAttendanceSummary() async {
     CampusNetworkStatus? campusStatus;
@@ -190,11 +216,30 @@ class SportsAttendanceService implements SportsAttendanceClient {
         );
       }
 
-      return await _fetchWithCredentials(
+      final result = await _fetchWithCredentials(
         studentId: studentId,
         sportsPassword: sportsPassword,
         campusNetworkStatus: campusStatus,
       );
+      if (result.isSuccess && result.summary != null) {
+        final currentStudentId = (await _credentialsService.getStatus())
+            .oaAccount
+            .trim();
+        final currentSportsPassword = await _credentialsService.readSecret(
+          AcademicCredentialSecret.sportsQueryPassword,
+        );
+        if (currentStudentId != studentId ||
+            currentSportsPassword != sportsPassword) {
+          return _credentialsChangedResult(campusStatus, result.finalUri);
+        }
+        await AuthenticatedDataCacheService.saveLatest(
+          collection: StorageKeys.sportsAttendanceCacheCollection,
+          accountKey: studentId,
+          fetchedAt: result.summary!.fetchedAt,
+          data: result.summary!.toJson(),
+        );
+      }
+      return result;
     } on TimeoutException {
       return _buildResult(
         SportsAttendanceQueryStatus.networkError,
@@ -218,6 +263,19 @@ class SportsAttendanceService implements SportsAttendanceClient {
         campusNetworkStatus: campusStatus,
       );
     }
+  }
+
+  SportsAttendanceQueryResult _credentialsChangedResult(
+    CampusNetworkStatus? campusStatus,
+    Uri? finalUri,
+  ) {
+    return _buildResult(
+      SportsAttendanceQueryStatus.unexpectedError,
+      message: '体育部考勤查询已取消',
+      detail: '体育部查询凭据已在查询过程中变更，已丢弃本次考勤结果。',
+      finalUri: finalUri,
+      campusNetworkStatus: campusStatus,
+    );
   }
 
   Future<SportsAttendanceQueryResult> _fetchWithCredentials({
@@ -352,6 +410,7 @@ class SportsAttendanceService implements SportsAttendanceClient {
     SportsAttendanceQueryStatus status, {
     required String message,
     required String detail,
+    DateTime? checkedAt,
     Uri? finalUri,
     CampusNetworkStatus? campusNetworkStatus,
     SportsAttendanceSummary? summary,
@@ -360,7 +419,7 @@ class SportsAttendanceService implements SportsAttendanceClient {
       status: status,
       message: message,
       detail: detail,
-      checkedAt: DateTime.now(),
+      checkedAt: checkedAt ?? DateTime.now(),
       entranceUri: entranceUri,
       finalUri: finalUri,
       campusNetworkStatus: campusNetworkStatus,

--- a/lib/services/storage_keys.dart
+++ b/lib/services/storage_keys.dart
@@ -74,4 +74,25 @@ class StorageKeys {
 
   /// 结构化数据前缀（JSON 序列化存储）。
   static const String dataPrefix = 'data_';
+
+  /// 校园卡业务快照缓存集合。
+  static const String campusCardCacheCollection = 'cache_campus_card';
+
+  /// 体育部考勤业务快照缓存集合。
+  static const String sportsAttendanceCacheCollection =
+      'cache_sports_attendance';
+
+  /// 第二课堂学分业务快照缓存集合。
+  static const String studentReportCacheCollection = 'cache_student_report';
+
+  /// 本专科教务摘要业务快照缓存集合。
+  static const String academicEamsOverviewCacheCollection =
+      'cache_academic_eams_overview';
+
+  /// 本专科教务课表业务快照缓存集合。
+  static const String academicEamsCourseTableCacheCollection =
+      'cache_academic_eams_course_table';
+
+  /// 学校邮箱业务快照缓存集合。
+  static const String emailMailboxCacheCollection = 'cache_email_mailbox';
 }

--- a/lib/services/student_report_service.dart
+++ b/lib/services/student_report_service.dart
@@ -20,6 +20,7 @@ import '../models/campus_network_status.dart';
 import '../models/student_report.dart';
 import 'academic_credentials_service.dart';
 import 'academic_login_validation_service.dart';
+import 'authenticated_data_cache_service.dart';
 import 'campus_network_status_service.dart';
 import 'http_service.dart';
 import 'storage_service.dart';
@@ -30,6 +31,9 @@ part 'student_report_page_parser.dart';
 
 /// 教务页依赖的学工报表接口，便于 widget 测试替换。
 abstract class StudentReportClient {
+  /// 读取最近一次本地第二课堂学分缓存。
+  Future<StudentReportQueryResult?> readLatestCachedSecondClassroomCredits();
+
   /// 校验学工报表系统登录状态，不读取学分明细。
   Future<StudentReportQueryResult> validateLoginStatus();
 
@@ -90,7 +94,9 @@ class StudentReportService implements StudentReportClient {
        _gateway = gateway ?? DioStudentReportGateway(),
        _refreshOaLogin =
            refreshOaLogin ??
-           AcademicLoginValidationService.instance.validateSavedCredentials,
+           (() => AcademicLoginValidationService.instance.ensureSavedSession(
+             forceRefresh: true,
+           )),
        entranceUri = entranceUri ?? defaultEntranceUri,
        homeUri = homeUri ?? defaultHomeUri,
        timeout = timeout ?? const Duration(seconds: 15);
@@ -156,6 +162,28 @@ class StudentReportService implements StudentReportClient {
     );
   }
 
+  /// 读取最近一次本地第二课堂学分缓存。
+  @override
+  Future<StudentReportQueryResult?>
+  readLatestCachedSecondClassroomCredits() async {
+    final accountKey = (await _credentialsService.getStatus()).oaAccount.trim();
+    if (accountKey.isEmpty) return null;
+    final entry = await AuthenticatedDataCacheService.readLatest(
+      StorageKeys.studentReportCacheCollection,
+      accountKey: accountKey,
+    );
+    if (entry == null) return null;
+    final summary = SecondClassroomCreditSummary.fromJson(entry.data);
+    return _buildResult(
+      StudentReportQueryStatus.success,
+      message: '已显示本地第二课堂学分缓存',
+      detail: '显示最近一次成功读取并保存的第二课堂逐项得分明细。',
+      checkedAt: summary.fetchedAt,
+      finalUri: summary.sourceUri,
+      summary: summary,
+    );
+  }
+
   @override
   Future<StudentReportQueryResult> validateLoginStatus() async {
     return _fetchReport(requireCredits: false);
@@ -202,10 +230,28 @@ class StudentReportService implements StudentReportClient {
         );
       }
 
-      return await _fetchWithOaSession(
+      final result = await _fetchWithOaSession(
         requireCredits: requireCredits,
         campusNetworkStatus: campusStatus,
       );
+      if (requireCredits && result.isSuccess && result.summary != null) {
+        final currentStudentId = (await _credentialsService.getStatus())
+            .oaAccount
+            .trim();
+        final currentOaPassword = await _credentialsService.readSecret(
+          AcademicCredentialSecret.oaPassword,
+        );
+        if (currentStudentId != studentId || currentOaPassword != oaPassword) {
+          return _credentialsChangedResult(campusStatus, result.finalUri);
+        }
+        await AuthenticatedDataCacheService.saveLatest(
+          collection: StorageKeys.studentReportCacheCollection,
+          accountKey: studentId,
+          fetchedAt: result.summary!.fetchedAt,
+          data: result.summary!.toJson(),
+        );
+      }
+      return result;
     } on TimeoutException {
       return _buildResult(
         StudentReportQueryStatus.networkError,
@@ -231,22 +277,26 @@ class StudentReportService implements StudentReportClient {
     }
   }
 
+  StudentReportQueryResult _credentialsChangedResult(
+    CampusNetworkStatus? campusStatus,
+    Uri? finalUri,
+  ) {
+    return _buildResult(
+      StudentReportQueryStatus.unexpectedError,
+      message: '学工报表查询已取消',
+      detail: '教务凭据已在查询过程中变更，已丢弃本次学工报表结果。',
+      finalUri: finalUri,
+      campusNetworkStatus: campusStatus,
+    );
+  }
+
   Future<StudentReportQueryResult> _fetchWithOaSession({
     required bool requireCredits,
     required CampusNetworkStatus campusNetworkStatus,
   }) async {
     var sessionSnapshot = await _credentialsService.readOaLoginSession();
-    for (var attempt = 0; attempt < 2; attempt++) {
-      final result = await _fetchWithSessionSnapshot(
-        sessionSnapshot: sessionSnapshot,
-        requireCredits: requireCredits,
-        campusNetworkStatus: campusNetworkStatus,
-      );
-      if (result.status != StudentReportQueryStatus.oaLoginRequired ||
-          attempt == 1) {
-        return result;
-      }
-
+    var refreshedBeforeFetch = false;
+    if (sessionSnapshot == null || !sessionSnapshot.hasCookies) {
       final loginResult = await _refreshOaLogin();
       if (!loginResult.isSuccess) {
         return _buildResult(
@@ -260,6 +310,34 @@ class StudentReportService implements StudentReportClient {
       sessionSnapshot =
           await _credentialsService.readOaLoginSession() ??
           loginResult.sessionSnapshot;
+      refreshedBeforeFetch = true;
+    }
+    for (var attempt = 0; attempt < 2; attempt++) {
+      final result = await _fetchWithSessionSnapshot(
+        sessionSnapshot: sessionSnapshot,
+        requireCredits: requireCredits,
+        campusNetworkStatus: campusNetworkStatus,
+      );
+      if (result.status != StudentReportQueryStatus.oaLoginRequired ||
+          attempt == 1) {
+        return result;
+      }
+
+      if (refreshedBeforeFetch) continue;
+      final loginResult = await _refreshOaLogin();
+      if (!loginResult.isSuccess) {
+        return _buildResult(
+          StudentReportQueryStatus.oaLoginRequired,
+          message: 'OA 登录状态不可用，无法查询学工报表',
+          detail: loginResult.message,
+          finalUri: loginResult.finalUri,
+          campusNetworkStatus: campusNetworkStatus,
+        );
+      }
+      sessionSnapshot =
+          await _credentialsService.readOaLoginSession() ??
+          loginResult.sessionSnapshot;
+      refreshedBeforeFetch = true;
     }
 
     return _buildResult(
@@ -280,7 +358,7 @@ class StudentReportService implements StudentReportClient {
       return _buildResult(
         StudentReportQueryStatus.oaLoginRequired,
         message: 'OA 登录状态不可用，无法进入学工报表系统',
-        detail: '学工报表入口仍返回 CAS 或本地登录页，请先在安全设置中验证 OA 登录。',
+        detail: '学工报表入口仍返回 CAS 或本地登录页，已无法自动刷新 OA 登录会话。',
         finalUri: entrySnapshot.finalUri,
         campusNetworkStatus: campusNetworkStatus,
       );
@@ -452,6 +530,7 @@ class StudentReportService implements StudentReportClient {
     StudentReportQueryStatus status, {
     required String message,
     required String detail,
+    DateTime? checkedAt,
     Uri? finalUri,
     CampusNetworkStatus? campusNetworkStatus,
     SecondClassroomCreditSummary? summary,
@@ -460,7 +539,7 @@ class StudentReportService implements StudentReportClient {
       status: status,
       message: message,
       detail: detail,
-      checkedAt: DateTime.now(),
+      checkedAt: checkedAt ?? DateTime.now(),
       entranceUri: entranceUri,
       finalUri: finalUri,
       campusNetworkStatus: campusNetworkStatus,

--- a/test/academic_credentials_service_test.dart
+++ b/test/academic_credentials_service_test.dart
@@ -8,15 +8,25 @@
 
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sspu_allinone/models/academic_credentials.dart';
 import 'package:sspu_allinone/models/academic_login_validation.dart';
 import 'package:sspu_allinone/services/academic_credentials_service.dart';
+import 'package:sspu_allinone/services/authenticated_data_cache_service.dart';
+import 'package:sspu_allinone/services/storage_service.dart';
 
 void main() {
   final service = AcademicCredentialsService.instance;
 
   setUp(() {
     FlutterSecureStorage.setMockInitialValues({});
+    SharedPreferences.setMockInitialValues({});
+    StorageService.debugUseSharedPreferencesStorageForTesting(true);
+  });
+
+  tearDown(() {
+    StorageService.debugUseSharedPreferencesStorageForTesting(null);
+    SharedPreferences.setMockInitialValues({});
   });
 
   test('保存教务凭据后返回账号与密码填写状态', () async {
@@ -117,6 +127,34 @@ void main() {
     expect(await service.readOaLoginSession(), isNull);
   });
 
+  test('同账号更新 OA 密码后旧登录会话不可复用', () async {
+    await service.saveCredentials(
+      oaAccount: '20260001',
+      oaPassword: 'old-pass',
+    );
+    await service.saveOaLoginSession(
+      AcademicLoginSessionSnapshot(
+        cookieHeadersByHost: const {
+          'oa.sspu.edu.cn': 'ecology_JSessionid=fake-session',
+        },
+        authenticatedAt: DateTime(2026, 4, 27),
+        entranceUri: Uri.parse(
+          'https://oa.sspu.edu.cn/interface/Entrance.jsp?id=bzkjw',
+        ),
+        finalUri: Uri.parse(
+          'https://oa.sspu.edu.cn/interface/Entrance.jsp?id=bzkjw',
+        ),
+      ),
+    );
+
+    await service.saveCredentials(
+      oaAccount: '20260001',
+      oaPassword: 'new-pass',
+    );
+
+    expect(await service.readOaLoginSession(), isNull);
+  });
+
   test('清除所有教务凭据时逐项删除安全存储键', () async {
     await service.saveCredentials(
       oaAccount: '20260001',
@@ -134,5 +172,53 @@ void main() {
     expect(status.hasOaPassword, isFalse);
     expect(status.hasSportsQueryPassword, isFalse);
     expect(status.hasEmailPassword, isFalse);
+  });
+
+  test('切换账号时清理鉴权业务缓存', () async {
+    await service.saveCredentials(oaAccount: '20260001');
+    await AuthenticatedDataCacheService.saveLatest(
+      collection: StorageKeys.campusCardCacheCollection,
+      accountKey: '20260001',
+      fetchedAt: DateTime(2026, 5, 1, 8),
+      data: const {'balance': 23.45},
+    );
+
+    await service.saveCredentials(oaAccount: '20260002');
+
+    expect(
+      await AuthenticatedDataCacheService.readLatest(
+        StorageKeys.campusCardCacheCollection,
+        accountKey: '20260001',
+      ),
+      isNull,
+    );
+  });
+
+  test('同账号更新任一密码时清理鉴权业务缓存', () async {
+    await service.saveCredentials(
+      oaAccount: '20260001',
+      oaPassword: 'oa-pass',
+      sportsQueryPassword: 'sports-pass',
+      emailPassword: 'mail-pass',
+    );
+    await AuthenticatedDataCacheService.saveLatest(
+      collection: StorageKeys.emailMailboxCacheCollection,
+      accountKey: '20260001@sspu.edu.cn',
+      fetchedAt: DateTime(2026, 5, 1, 8),
+      data: const {'subject': '旧邮件'},
+    );
+
+    await service.saveCredentials(
+      oaAccount: '20260001',
+      emailPassword: 'new-mail-pass',
+    );
+
+    expect(
+      await AuthenticatedDataCacheService.readLatest(
+        StorageKeys.emailMailboxCacheCollection,
+        accountKey: '20260001@sspu.edu.cn',
+      ),
+      isNull,
+    );
   });
 }

--- a/test/academic_eams_service_test.dart
+++ b/test/academic_eams_service_test.dart
@@ -120,6 +120,32 @@ void main() {
     expect(result.snapshot?.hasFreeClassroomEntry, isTrue);
   });
 
+  test('本专科教务缓存不持久化明文学号或原始个人字段', () async {
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      oaPassword: 'oa-pass',
+    );
+    await AcademicCredentialsService.instance.saveOaLoginSession(
+      academicEamsSessionSnapshot,
+    );
+    final service = buildAcademicEamsServiceForTest(
+      gateway: FakeAcademicEamsGateway(),
+      campusReachable: true,
+    );
+
+    await service.fetchOverview();
+    final storedPayload = (await StorageService.getAllData(
+      StorageKeys.academicEamsOverviewCacheCollection,
+    )).values.single;
+    final cachedResult = await service.readLatestCachedOverview();
+
+    expect(storedPayload.toString(), isNot(contains('20260001')));
+    expect(storedPayload.toString(), isNot(contains('学号')));
+    expect(cachedResult?.snapshot?.profile?.name, '张三');
+    expect(cachedResult?.snapshot?.profile?.studentId, isNull);
+    expect(cachedResult?.snapshot?.profile?.rawFields, isEmpty);
+  });
+
   test('独立课表读取只解析当前学期课表', () async {
     await AcademicCredentialsService.instance.saveCredentials(
       oaAccount: '20260001',
@@ -244,5 +270,45 @@ void main() {
 
     expect(firstResult.snapshot?.hasFreeClassroomEntry, isFalse);
     expect(secondResult.snapshot?.hasFreeClassroomEntry, isTrue);
+  });
+
+  test('查询过程中切换账号时不会把旧账号教务摘要写入新账号缓存', () async {
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      oaPassword: 'oa-pass',
+    );
+    final service = buildAcademicEamsServiceForTest(
+      gateway: FakeAcademicEamsGateway(),
+      campusReachable: true,
+      refreshOaLogin: () async {
+        await AcademicCredentialsService.instance.saveCredentials(
+          oaAccount: '20260002',
+          oaPassword: 'oa-pass',
+        );
+        await AcademicCredentialsService.instance.saveOaLoginSession(
+          academicEamsSessionSnapshot,
+        );
+        return AcademicLoginValidationResult(
+          status: AcademicLoginValidationStatus.success,
+          message: 'OA 登录校验通过',
+          detail: '已刷新 OA 会话',
+          checkedAt: DateTime(2026, 5, 2),
+          entranceUri: academicEamsOaEntranceUri,
+          finalUri: academicEamsOaEntranceUri,
+          sessionSnapshot: academicEamsSessionSnapshot,
+        );
+      },
+    );
+
+    final result = await service.fetchOverview();
+    final cachedResult = await service.readLatestCachedOverview();
+
+    expect(result.status, AcademicEamsQueryStatus.unexpectedError);
+    expect(result.snapshot, isNull);
+    expect(
+      (await AcademicCredentialsService.instance.getStatus()).oaAccount,
+      '20260002',
+    );
+    expect(cachedResult, isNull);
   });
 }

--- a/test/academic_login_validation_service_test.dart
+++ b/test/academic_login_validation_service_test.dart
@@ -6,6 +6,8 @@
  * @Date : 2026-04-27
  */
 
+import 'dart:async';
+
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sspu_allinone/models/academic_login_validation.dart';
@@ -173,6 +175,108 @@ void main() {
 
     expect(result.status, AcademicLoginValidationStatus.captchaRequired);
   });
+
+  test('自动确保 OA 会话会合并并发登录请求', () async {
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      oaPassword: 'oa-pass',
+    );
+    final gateway = _FakeAcademicLoginGateway(
+      loginPage: _casLoginSnapshot(),
+      submitSnapshot: AcademicLoginHttpSnapshot(
+        finalUri: _oaEntranceUri,
+        statusCode: 200,
+        body: '<html>OA</html>',
+      ),
+    );
+    final service = _buildService(gateway: gateway, campusReachable: true);
+
+    final results = await Future.wait([
+      service.ensureSavedSession(forceRefresh: true),
+      service.ensureSavedSession(forceRefresh: true),
+    ]);
+
+    expect(results.every((result) => result.isSuccess), isTrue);
+    expect(gateway.openCount, 1);
+    expect(
+      await AcademicCredentialsService.instance.readOaLoginSession(),
+      isNotNull,
+    );
+  });
+
+  test('切换账号后不会复用进行中的旧账号 OA 登录会话', () async {
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      oaPassword: 'oa-pass',
+    );
+    final submitGate = Completer<void>();
+    final submitStarted = Completer<void>();
+    final gateway = _FakeAcademicLoginGateway(
+      submitGate: submitGate,
+      submitStarted: submitStarted,
+    );
+    final service = _buildService(gateway: gateway, campusReachable: true);
+
+    final firstResultFuture = service.ensureSavedSession(forceRefresh: true);
+    await submitStarted.future;
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260002',
+      oaPassword: 'oa-pass',
+    );
+    final secondResultFuture = service.ensureSavedSession(forceRefresh: true);
+    submitGate.complete();
+
+    final firstResult = await firstResultFuture;
+    final secondResult = await secondResultFuture;
+    final sessionSnapshot = await AcademicCredentialsService.instance
+        .readOaLoginSession();
+
+    expect(firstResult.status, AcademicLoginValidationStatus.unexpectedError);
+    expect(secondResult.status, AcademicLoginValidationStatus.success);
+    expect(gateway.openCount, 2);
+    expect(gateway.submittedFieldsHistory.map((fields) => fields['username']), [
+      '20260001',
+      '20260002',
+    ]);
+    expect(sessionSnapshot?.ownerAccount, '20260002');
+  });
+
+  test('同账号更新 OA 密码后不会复用进行中的旧密码登录会话', () async {
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      oaPassword: 'old-pass',
+    );
+    final submitGate = Completer<void>();
+    final submitStarted = Completer<void>();
+    final gateway = _FakeAcademicLoginGateway(
+      submitGate: submitGate,
+      submitStarted: submitStarted,
+    );
+    final service = _buildService(gateway: gateway, campusReachable: true);
+
+    final firstResultFuture = service.ensureSavedSession(forceRefresh: true);
+    await submitStarted.future;
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      oaPassword: 'new-pass',
+    );
+    final secondResultFuture = service.ensureSavedSession(forceRefresh: true);
+    submitGate.complete();
+
+    final firstResult = await firstResultFuture;
+    final secondResult = await secondResultFuture;
+    final sessionSnapshot = await AcademicCredentialsService.instance
+        .readOaLoginSession();
+
+    expect(firstResult.status, AcademicLoginValidationStatus.unexpectedError);
+    expect(secondResult.status, AcademicLoginValidationStatus.success);
+    expect(gateway.openCount, 2);
+    expect(gateway.submittedFieldsHistory.map((fields) => fields['username']), [
+      '20260001',
+      '20260001',
+    ]);
+    expect(sessionSnapshot?.ownerAccount, '20260001');
+  });
 }
 
 AcademicLoginValidationService _buildService({
@@ -225,6 +329,8 @@ class _FakeAcademicLoginGateway implements AcademicLoginGateway {
     AcademicLoginHttpSnapshot? loginPage,
     AcademicLoginHttpSnapshot? submitSnapshot,
     Map<String, String>? sessionCookieHeadersByHost,
+    this.submitGate,
+    this.submitStarted,
   }) : loginPage = loginPage ?? _casLoginSnapshot(),
        submitSnapshot =
            submitSnapshot ??
@@ -243,8 +349,11 @@ class _FakeAcademicLoginGateway implements AcademicLoginGateway {
   final AcademicLoginHttpSnapshot loginPage;
   final AcademicLoginHttpSnapshot submitSnapshot;
   final Map<String, String> sessionCookieHeadersByHost;
+  final Completer<void>? submitGate;
+  final Completer<void>? submitStarted;
   int openCount = 0;
   Map<String, String>? submittedFields;
+  final List<Map<String, String>> submittedFieldsHistory = [];
 
   @override
   Future<void> resetSession() async {}
@@ -268,6 +377,12 @@ class _FakeAcademicLoginGateway implements AcademicLoginGateway {
     required Duration timeout,
   }) async {
     submittedFields = fields;
+    submittedFieldsHistory.add(Map<String, String>.from(fields));
+    final submitStarted = this.submitStarted;
+    if (submitStarted != null && !submitStarted.isCompleted) {
+      submitStarted.complete();
+    }
+    await submitGate?.future;
     return submitSnapshot;
   }
 

--- a/test/academic_page_test.dart
+++ b/test/academic_page_test.dart
@@ -108,19 +108,18 @@ void main() {
   });
 
   testWidgets('教务中心自动刷新开启时会主动读取体育考勤', (tester) async {
+    final sportsService = _FakeSportsAttendanceClient(result: _successResult);
     await tester.pumpWidget(
       MaterialApp(
         home: AcademicPage(
           academicEamsService: _FakeAcademicEamsClient(
             result: _academicEamsResult,
           ),
-          sportsAttendanceService: _FakeSportsAttendanceClient(
-            result: _successResult,
-          ),
+          sportsAttendanceService: sportsService,
           studentReportService: _FakeStudentReportClient(result: _creditResult),
           academicEamsAutoRefreshEnabledOverride: false,
           sportsAttendanceAutoRefreshEnabledOverride: true,
-          sportsAttendanceAutoRefreshIntervalOverride: 30,
+          sportsAttendanceAutoRefreshIntervalOverride: 1,
           studentReportAutoRefreshEnabledOverride: false,
         ),
       ),
@@ -129,6 +128,12 @@ void main() {
     await pumpUntilFound(tester, find.text('8'));
 
     expect(find.text('总次数'), findsOneWidget);
+    expect(sportsService.fetchCount, 1);
+
+    await tester.pump(const Duration(minutes: 1));
+    await tester.pump();
+
+    expect(sportsService.fetchCount, 2);
     await disposeAcademicPage(tester);
   });
 

--- a/test/academic_page_test_support.dart
+++ b/test/academic_page_test_support.dart
@@ -9,23 +9,39 @@
 part of 'academic_page_test.dart';
 
 class _FakeSportsAttendanceClient implements SportsAttendanceClient {
-  const _FakeSportsAttendanceClient({required this.result});
+  _FakeSportsAttendanceClient({required this.result});
 
   final SportsAttendanceQueryResult result;
+  int fetchCount = 0;
+
+  @override
+  Future<SportsAttendanceQueryResult?>
+  readLatestCachedAttendanceSummary() async {
+    return null;
+  }
 
   @override
   Future<SportsAttendanceQueryResult> fetchAttendanceSummary() async {
+    fetchCount++;
     return result;
   }
 }
 
 class _FakeStudentReportClient implements StudentReportClient {
-  const _FakeStudentReportClient({required this.result});
+  _FakeStudentReportClient({required this.result});
 
   final StudentReportQueryResult result;
+  int fetchCount = 0;
+
+  @override
+  Future<StudentReportQueryResult?>
+  readLatestCachedSecondClassroomCredits() async {
+    return null;
+  }
 
   @override
   Future<StudentReportQueryResult> fetchSecondClassroomCredits() async {
+    fetchCount++;
     return result;
   }
 
@@ -36,17 +52,31 @@ class _FakeStudentReportClient implements StudentReportClient {
 }
 
 class _FakeAcademicEamsClient implements AcademicEamsClient {
-  const _FakeAcademicEamsClient({required this.result});
+  _FakeAcademicEamsClient({required this.result});
 
   final AcademicEamsQueryResult result;
+  int overviewFetchCount = 0;
+  int courseTableFetchCount = 0;
+
+  @override
+  Future<AcademicEamsQueryResult?> readLatestCachedCourseTable() async {
+    return null;
+  }
+
+  @override
+  Future<AcademicEamsQueryResult?> readLatestCachedOverview() async {
+    return null;
+  }
 
   @override
   Future<AcademicEamsQueryResult> fetchCourseTable() async {
+    courseTableFetchCount++;
     return result;
   }
 
   @override
   Future<AcademicEamsQueryResult> fetchOverview() async {
+    overviewFetchCount++;
     return result;
   }
 }

--- a/test/authenticated_data_cache_service_test.dart
+++ b/test/authenticated_data_cache_service_test.dart
@@ -1,0 +1,174 @@
+/*
+ * 鉴权业务数据缓存服务测试 — 校验快照持久化与最近三条保留策略
+ * @Project : SSPU-AllinOne
+ * @File : authenticated_data_cache_service_test.dart
+ * @Author : Qintsg
+ * @Date : 2026-05-31
+ */
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sspu_allinone/services/authenticated_data_cache_service.dart';
+import 'package:sspu_allinone/services/storage_service.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    StorageService.debugUseSharedPreferencesStorageForTesting(true);
+  });
+
+  tearDown(() {
+    StorageService.debugUseSharedPreferencesStorageForTesting(null);
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('缓存按获取时间倒序读取并只保留最近三条', () async {
+    const collection = 'test_authenticated_cache';
+    for (var index = 0; index < 5; index++) {
+      await AuthenticatedDataCacheService.saveLatest(
+        collection: collection,
+        accountKey: '20260001',
+        fetchedAt: DateTime(2026, 5, 1, 8, index),
+        data: {'value': index},
+      );
+    }
+
+    final entries = await AuthenticatedDataCacheService.readLatestRecords(
+      collection,
+    );
+
+    expect(entries, hasLength(3));
+    expect(entries.map((entry) => entry.data['value']), [4, 3, 2]);
+    expect(await StorageService.getCollectionCount(collection), 3);
+  });
+
+  test('按账号读取缓存，避免切换账号后展示他人数据', () async {
+    const collection = 'test_account_scoped_authenticated_cache';
+    await AuthenticatedDataCacheService.saveLatest(
+      collection: collection,
+      accountKey: '20260001',
+      fetchedAt: DateTime(2026, 5, 1, 8),
+      data: const {'value': 'first-account'},
+    );
+    await AuthenticatedDataCacheService.saveLatest(
+      collection: collection,
+      accountKey: '20260002',
+      fetchedAt: DateTime(2026, 5, 1, 9),
+      data: const {'value': 'second-account'},
+    );
+
+    final firstAccountEntry = await AuthenticatedDataCacheService.readLatest(
+      collection,
+      accountKey: '20260001',
+    );
+
+    expect(firstAccountEntry?.data['value'], 'first-account');
+    expect(
+      await AuthenticatedDataCacheService.readLatest(
+        collection,
+        accountKey: '20269999',
+      ),
+      isNull,
+    );
+  });
+
+  test('每个账号独立保留最近三条，同获取时间不会互相覆盖', () async {
+    const collection = 'test_owner_scoped_authenticated_cache';
+    for (var index = 0; index < 5; index++) {
+      for (final account in ['20260001', '20260002']) {
+        await AuthenticatedDataCacheService.saveLatest(
+          collection: collection,
+          accountKey: account,
+          fetchedAt: DateTime(2026, 5, 1, 8, index),
+          data: {'value': index},
+        );
+      }
+    }
+
+    final firstAccountEntries =
+        await AuthenticatedDataCacheService.readLatestRecords(
+          collection,
+          accountKey: '20260001',
+        );
+    final secondAccountEntries =
+        await AuthenticatedDataCacheService.readLatestRecords(
+          collection,
+          accountKey: '20260002',
+        );
+
+    expect(firstAccountEntries, hasLength(3));
+    expect(secondAccountEntries, hasLength(3));
+    expect(firstAccountEntries.map((entry) => entry.data['value']), [4, 3, 2]);
+    expect(secondAccountEntries.map((entry) => entry.data['value']), [4, 3, 2]);
+    expect(await StorageService.getCollectionCount(collection), 6);
+  });
+
+  test('缓存持久化 owner 使用不可逆标识，不写入明文学工号', () async {
+    const collection = 'test_private_owner_authenticated_cache';
+    await AuthenticatedDataCacheService.saveLatest(
+      collection: collection,
+      accountKey: '20260001',
+      fetchedAt: DateTime(2026, 5, 1, 8),
+      data: const {'value': 'cached'},
+    );
+
+    final storedPayload = (await StorageService.getAllData(
+      collection,
+    )).values.single;
+
+    expect(storedPayload.toString(), isNot(contains('20260001')));
+    expect(storedPayload['ownerAccount'], isNotEmpty);
+    expect(storedPayload['ownerAccount'], isNot('20260001'));
+    expect(
+      await AuthenticatedDataCacheService.readLatest(
+        collection,
+        accountKey: '20260001',
+      ),
+      isNotNull,
+    );
+  });
+
+  test('缓存持久化前移除 URI 中的敏感查询参数', () async {
+    const collection = 'test_sanitized_uri_authenticated_cache';
+    await AuthenticatedDataCacheService.saveLatest(
+      collection: collection,
+      accountKey: '20260001',
+      fetchedAt: DateTime(2026, 5, 1, 8),
+      data: const {
+        'sourceUri': 'https://id.sspu.edu.cn/cas/login?ticket=ST-secret#token',
+        'snapshot': {
+          'finalUri': 'https://jx.sspu.edu.cn/eams/std.action?ids=20260001',
+        },
+        'records': [
+          {'sourceUri': 'https://card.sspu.edu.cn/epay/?token=secret'},
+        ],
+      },
+    );
+
+    final storedPayload = (await StorageService.getAllData(
+      collection,
+    )).values.single;
+
+    expect(storedPayload.toString(), isNot(contains('ticket')));
+    expect(storedPayload.toString(), isNot(contains('ST-secret')));
+    expect(storedPayload.toString(), isNot(contains('ids')));
+    expect(storedPayload.toString(), isNot(contains('20260001')));
+    expect(storedPayload.toString(), isNot(contains('token')));
+    expect(storedPayload['sourceUri'], 'https://id.sspu.edu.cn/cas/login');
+    expect(
+      (storedPayload['snapshot'] as Map<String, dynamic>)['finalUri'],
+      'https://jx.sspu.edu.cn/eams/std.action',
+    );
+  });
+
+  test('缓存条目可按自动刷新间隔判断是否过期', () async {
+    final entry = AuthenticatedDataCacheEntry(
+      key: 'sample',
+      fetchedAt: DateTime.now().subtract(const Duration(minutes: 31)),
+      data: const {'value': 'cached'},
+    );
+
+    expect(entry.isStaleFor(30), isTrue);
+    expect(entry.isStaleFor(0), isFalse);
+  });
+}

--- a/test/campus_card_service_test.dart
+++ b/test/campus_card_service_test.dart
@@ -9,6 +9,7 @@
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sspu_allinone/models/academic_credentials.dart';
 import 'package:sspu_allinone/models/academic_login_validation.dart';
 import 'package:sspu_allinone/models/campus_card.dart';
 import 'package:sspu_allinone/services/academic_credentials_service.dart';
@@ -145,6 +146,111 @@ void main() {
     expect(result.snapshot?.records.length, 2);
     expect(result.snapshot?.records.last.type, '充值');
     expect(result.snapshot?.records.last.amount, 50.00);
+  });
+
+  test('成功查询写入校园卡缓存且失败不会覆盖最近缓存', () async {
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      oaPassword: 'oa-pass',
+    );
+    await AcademicCredentialsService.instance.saveOaLoginSession(
+      _sessionSnapshot,
+    );
+    final service = _buildService(
+      gateway: _FakeCampusCardGateway(),
+      campusReachable: true,
+    );
+
+    final result = await service.fetchCampusCard();
+    final cachedResult = await service.readLatestCachedCampusCard();
+
+    expect(result.status, CampusCardQueryStatus.success);
+    expect(cachedResult?.snapshot?.balance, 23.45);
+
+    final failedService = _buildService(
+      gateway: _FakeCampusCardGateway(),
+      campusReachable: false,
+    );
+    final failedResult = await failedService.fetchCampusCard();
+    final cachedAfterFailure = await failedService.readLatestCachedCampusCard();
+
+    expect(failedResult.status, CampusCardQueryStatus.campusNetworkUnavailable);
+    expect(cachedAfterFailure?.snapshot?.balance, 23.45);
+  });
+
+  test('查询过程中切换账号时不会把旧账号校园卡写入新账号缓存', () async {
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      oaPassword: 'oa-pass',
+    );
+    final service = _buildService(
+      gateway: _FakeCampusCardGateway(),
+      campusReachable: true,
+      refreshOaLogin: () async {
+        await AcademicCredentialsService.instance.saveCredentials(
+          oaAccount: '20260002',
+          oaPassword: 'oa-pass',
+        );
+        await AcademicCredentialsService.instance.saveOaLoginSession(
+          _sessionSnapshot,
+        );
+        return AcademicLoginValidationResult(
+          status: AcademicLoginValidationStatus.success,
+          message: 'OA 登录校验通过',
+          detail: '已刷新 OA 会话',
+          checkedAt: DateTime(2026, 4, 30),
+          entranceUri: _oaEntranceUri,
+          finalUri: _oaEntranceUri,
+          sessionSnapshot: _sessionSnapshot,
+        );
+      },
+    );
+
+    final result = await service.fetchCampusCard();
+    final cachedResult = await service.readLatestCachedCampusCard();
+
+    expect(result.status, CampusCardQueryStatus.unexpectedError);
+    expect(result.snapshot, isNull);
+    expect(
+      (await AcademicCredentialsService.instance.getStatus()).oaAccount,
+      '20260002',
+    );
+    expect(cachedResult, isNull);
+  });
+
+  test('查询过程中清除 OA 密码时不会重新写入校园卡缓存', () async {
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      oaPassword: 'oa-pass',
+    );
+    final service = _buildService(
+      gateway: _FakeCampusCardGateway(),
+      campusReachable: true,
+      refreshOaLogin: () async {
+        await AcademicCredentialsService.instance.clearSecret(
+          AcademicCredentialSecret.oaPassword,
+        );
+        await AcademicCredentialsService.instance.saveOaLoginSession(
+          _sessionSnapshot,
+        );
+        return AcademicLoginValidationResult(
+          status: AcademicLoginValidationStatus.success,
+          message: 'OA 登录校验通过',
+          detail: '已刷新 OA 会话',
+          checkedAt: DateTime(2026, 4, 30),
+          entranceUri: _oaEntranceUri,
+          finalUri: _oaEntranceUri,
+          sessionSnapshot: _sessionSnapshot,
+        );
+      },
+    );
+
+    final result = await service.fetchCampusCard();
+    final cachedResult = await service.readLatestCachedCampusCard();
+
+    expect(result.status, CampusCardQueryStatus.unexpectedError);
+    expect(result.snapshot, isNull);
+    expect(cachedResult, isNull);
   });
 }
 

--- a/test/course_schedule_page_test.dart
+++ b/test/course_schedule_page_test.dart
@@ -19,14 +19,20 @@ Future<void> pumpUntilFound(WidgetTester tester, Finder finder) async {
   }
 }
 
+Future<void> disposeCourseSchedulePage(WidgetTester tester) async {
+  await tester.pumpWidget(const SizedBox.shrink());
+  await tester.pump(const Duration(milliseconds: 120));
+}
+
 void main() {
   testWidgets('课程表页面自动刷新开启时会主动读取课表', (tester) async {
+    final service = _FakeAcademicEamsClient(result: _successResult);
     await tester.pumpWidget(
       MaterialApp(
         home: CourseSchedulePage(
-          academicEamsService: _FakeAcademicEamsClient(result: _successResult),
+          academicEamsService: service,
           autoRefreshEnabledOverride: true,
-          autoRefreshIntervalOverride: 30,
+          autoRefreshIntervalOverride: 1,
         ),
       ),
     );
@@ -38,6 +44,13 @@ void main() {
     expect(find.text('高等数学'), findsOneWidget);
     expect(find.textContaining('周一 第1-2节'), findsOneWidget);
     expect(find.text('返回'), findsNothing);
+    expect(service.courseTableFetchCount, 1);
+
+    await tester.pump(const Duration(minutes: 1));
+    await tester.pump();
+
+    expect(service.courseTableFetchCount, 2);
+    await disposeCourseSchedulePage(tester);
   });
 
   testWidgets('课程表页面展示缺少 OA 密码提示', (tester) async {
@@ -57,6 +70,30 @@ void main() {
 
     expect(find.text('请先保存 OA 账号密码'), findsOneWidget);
     expect(find.textContaining('刷新 OA/CAS 会话'), findsOneWidget);
+    await disposeCourseSchedulePage(tester);
+  });
+
+  testWidgets('课程表页面优先使用可用缓存覆盖无课表初始结果', (tester) async {
+    final service = _FakeAcademicEamsClient(
+      result: _missingPassword,
+      cachedResult: _successResult,
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CourseSchedulePage(
+          academicEamsService: service,
+          initialResult: _missingPassword,
+          autoRefreshEnabledOverride: false,
+        ),
+      ),
+    );
+
+    await pumpUntilFound(tester, find.text('高等数学'));
+
+    expect(find.text('高等数学'), findsOneWidget);
+    expect(find.text('请先保存 OA 账号密码'), findsNothing);
+    expect(service.cachedCourseTableReadCount, 1);
+    await disposeCourseSchedulePage(tester);
   });
 
   testWidgets('课程表页面作为二级页面打开时显示返回按钮', (tester) async {
@@ -80,16 +117,32 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('返回'), findsOneWidget);
+    await disposeCourseSchedulePage(tester);
   });
 }
 
 class _FakeAcademicEamsClient implements AcademicEamsClient {
-  const _FakeAcademicEamsClient({required this.result});
+  _FakeAcademicEamsClient({required this.result, this.cachedResult});
 
   final AcademicEamsQueryResult result;
+  final AcademicEamsQueryResult? cachedResult;
+  int courseTableFetchCount = 0;
+  int cachedCourseTableReadCount = 0;
+
+  @override
+  Future<AcademicEamsQueryResult?> readLatestCachedCourseTable() async {
+    cachedCourseTableReadCount++;
+    return cachedResult;
+  }
+
+  @override
+  Future<AcademicEamsQueryResult?> readLatestCachedOverview() async {
+    return null;
+  }
 
   @override
   Future<AcademicEamsQueryResult> fetchCourseTable() async {
+    courseTableFetchCount++;
     return result;
   }
 

--- a/test/email_page_test.dart
+++ b/test/email_page_test.dart
@@ -85,7 +85,7 @@ void main() {
         home: EmailPage(
           emailService: service,
           emailAutoRefreshEnabledOverride: true,
-          emailAutoRefreshIntervalOverride: 30,
+          emailAutoRefreshIntervalOverride: 1,
         ),
       ),
     );
@@ -93,6 +93,10 @@ void main() {
     await pumpUntilFound(tester, find.text('教务通知'));
 
     expect(service.fetchCount, 1);
+    await tester.pump(const Duration(minutes: 1));
+    await tester.pump();
+
+    expect(service.fetchCount, 2);
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pump(const Duration(milliseconds: 120));
   });
@@ -102,6 +106,13 @@ class _FakeEmailClient implements EmailMailboxClient {
   int fetchCount = 0;
   int validateCount = 0;
   EmailProtocol? lastValidatedProtocol;
+
+  @override
+  Future<EmailMailboxQueryResult?> readLatestCachedMessages(
+    EmailProtocol protocol,
+  ) async {
+    return null;
+  }
 
   @override
   Future<EmailMailboxQueryResult> fetchMessages({

--- a/test/email_service_test.dart
+++ b/test/email_service_test.dart
@@ -6,9 +6,12 @@
  * @Date : 2026-05-01
  */
 
+import 'dart:io';
+
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sspu_allinone/models/academic_credentials.dart';
 import 'package:sspu_allinone/models/email_mailbox.dart';
 import 'package:sspu_allinone/services/academic_credentials_service.dart';
 import 'package:sspu_allinone/services/email_service.dart';
@@ -81,6 +84,97 @@ void main() {
     expect(result.snapshot?.messages.single.subject, '教务通知');
   });
 
+  test('邮箱读取成功写入协议缓存且失败不会覆盖最近缓存', () async {
+    final receivedAt = DateTime(2026, 5, 1, 8, 30);
+    final mailSnapshot = EmailMessageSnapshot(
+      id: 'IMAP:1',
+      subject: '教务通知',
+      senderName: '教务处',
+      senderAddress: 'notice@sspu.edu.cn',
+      preview: '请查看最新通知。',
+      body: '请查看最新通知。',
+      receivedAt: receivedAt,
+    );
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      emailPassword: 'mail-pass',
+    );
+    final service = EmailService(
+      gateway: _FakeEmailGateway(messages: [mailSnapshot]),
+    );
+
+    final result = await service.fetchMessages(protocol: EmailProtocol.imap);
+    final cachedResult = await service.readLatestCachedMessages(
+      EmailProtocol.imap,
+    );
+
+    expect(result.status, EmailQueryStatus.success);
+    expect(cachedResult?.snapshot?.messages.single.subject, '教务通知');
+    final cachedReceivedAt = cachedResult?.snapshot?.messages.single.receivedAt;
+    expect(cachedReceivedAt?.isUtc, isFalse);
+    expect(cachedReceivedAt?.isAtSameMomentAs(receivedAt), isTrue);
+
+    final failedService = EmailService(
+      gateway: _FakeEmailGateway(error: const SocketException('offline')),
+    );
+    final failedResult = await failedService.fetchMessages(
+      protocol: EmailProtocol.imap,
+    );
+    final cachedAfterFailure = await failedService.readLatestCachedMessages(
+      EmailProtocol.imap,
+    );
+
+    expect(failedResult.status, EmailQueryStatus.networkError);
+    expect(cachedAfterFailure?.snapshot?.messages.single.subject, '教务通知');
+  });
+
+  test('邮箱缓存持久化不写入明文邮箱账号', () async {
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      emailPassword: 'mail-pass',
+    );
+    final service = EmailService(
+      gateway: _FakeEmailGateway(messages: [_mailSnapshot]),
+    );
+
+    await service.fetchMessages(protocol: EmailProtocol.imap);
+    final storedPayload = (await StorageService.getAllData(
+      '${StorageKeys.emailMailboxCacheCollection}_imap',
+    )).values.single;
+    final cachedResult = await service.readLatestCachedMessages(
+      EmailProtocol.imap,
+    );
+
+    expect(storedPayload.toString(), isNot(contains('20260001@sspu.edu.cn')));
+    expect(storedPayload.toString(), isNot(contains('20260001')));
+    expect(cachedResult?.snapshot?.account, isEmpty);
+    expect(cachedResult?.snapshot?.messages.single.subject, '教务通知');
+  });
+
+  test('邮箱读取过程中清除邮箱密码时不会重新写入邮箱缓存', () async {
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      emailPassword: 'mail-pass',
+    );
+    final service = EmailService(
+      gateway: _FakeEmailGateway(
+        messages: [_mailSnapshot],
+        beforeReturn: () => AcademicCredentialsService.instance.clearSecret(
+          AcademicCredentialSecret.emailPassword,
+        ),
+      ),
+    );
+
+    final result = await service.fetchMessages(protocol: EmailProtocol.imap);
+    final cachedResult = await service.readLatestCachedMessages(
+      EmailProtocol.imap,
+    );
+
+    expect(result.status, EmailQueryStatus.unexpectedError);
+    expect(result.snapshot, isNull);
+    expect(cachedResult, isNull);
+  });
+
   test('SMTP 仅允许登录校验不允许收信', () async {
     await AcademicCredentialsService.instance.saveCredentials(
       oaAccount: '20260001',
@@ -102,9 +196,11 @@ void main() {
 }
 
 class _FakeEmailGateway implements EmailGateway {
-  _FakeEmailGateway({this.messages = const []});
+  _FakeEmailGateway({this.messages = const [], this.error, this.beforeReturn});
 
   final List<EmailMessageSnapshot> messages;
+  final Object? error;
+  final Future<void> Function()? beforeReturn;
   int fetchImapCount = 0;
   int fetchPopCount = 0;
   int validateSmtpCount = 0;
@@ -120,6 +216,9 @@ class _FakeEmailGateway implements EmailGateway {
   }) async {
     fetchImapCount++;
     lastAccount = account;
+    final error = this.error;
+    if (error != null) throw error;
+    await beforeReturn?.call();
     return messages;
   }
 
@@ -133,6 +232,9 @@ class _FakeEmailGateway implements EmailGateway {
   }) async {
     fetchPopCount++;
     lastAccount = account;
+    final error = this.error;
+    if (error != null) throw error;
+    await beforeReturn?.call();
     return messages;
   }
 

--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -96,6 +96,81 @@ void main() {
     await disposeHomePage(tester);
   });
 
+  testWidgets('首页进入时优先显示未过期校园卡缓存且不主动刷新', (tester) async {
+    final service = _FakeCampusCardClient(
+      result: _successResult,
+      cachedResult: _freshCachedResult,
+    );
+    final campusNetworkStatusService = _buildCampusNetworkStatusService();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: HomePage(
+          campusCardService: service,
+          campusNetworkStatusService: campusNetworkStatusService,
+          campusCardAutoRefreshEnabledOverride: true,
+          campusCardAutoRefreshIntervalOverride: 30,
+        ),
+      ),
+    );
+
+    await pumpUntilFound(tester, find.text('¥88.88'));
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.text('¥88.88'), findsOneWidget);
+    expect(service.fetchCount, 0);
+    await disposeHomePage(tester);
+  });
+
+  testWidgets('首页静默自动刷新失败时保留已有校园卡缓存', (tester) async {
+    final service = _FakeCampusCardClient(
+      result: _missingAccountResult,
+      cachedResult: _staleCachedResult,
+    );
+    final campusNetworkStatusService = _buildCampusNetworkStatusService();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: HomePage(
+          campusCardService: service,
+          campusNetworkStatusService: campusNetworkStatusService,
+          campusCardAutoRefreshEnabledOverride: true,
+          campusCardAutoRefreshIntervalOverride: 30,
+        ),
+      ),
+    );
+
+    await pumpUntilFound(tester, find.text('¥66.66'));
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(service.fetchCount, 1);
+    expect(find.text('¥66.66'), findsOneWidget);
+    expect(find.text('请先保存学工号'), findsNothing);
+    await disposeHomePage(tester);
+  });
+
+  testWidgets('首页停留期间按自动刷新间隔静默更新校园卡', (tester) async {
+    final service = _FakeCampusCardClient(result: _successResult);
+    final campusNetworkStatusService = _buildCampusNetworkStatusService();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: HomePage(
+          campusCardService: service,
+          campusNetworkStatusService: campusNetworkStatusService,
+          campusCardAutoRefreshEnabledOverride: true,
+          campusCardAutoRefreshIntervalOverride: 1,
+        ),
+      ),
+    );
+
+    await pumpUntilFound(tester, find.text('¥23.45'));
+    expect(service.fetchCount, 1);
+
+    await tester.pump(const Duration(minutes: 1));
+    await tester.pump();
+
+    expect(service.fetchCount, 2);
+    await disposeHomePage(tester);
+  });
+
   testWidgets('首页右上角显示小型网络状态指示', (tester) async {
     final campusNetworkStatusService = _buildCampusNetworkStatusService();
     await tester.pumpWidget(
@@ -132,10 +207,16 @@ CampusNetworkStatusService _buildCampusNetworkStatusService() {
 }
 
 class _FakeCampusCardClient implements CampusCardBalanceClient {
-  _FakeCampusCardClient({required this.result});
+  _FakeCampusCardClient({required this.result, this.cachedResult});
 
   final CampusCardQueryResult result;
+  final CampusCardQueryResult? cachedResult;
   int fetchCount = 0;
+
+  @override
+  Future<CampusCardQueryResult?> readLatestCachedCampusCard() async {
+    return cachedResult;
+  }
 
   @override
   Future<CampusCardQueryResult> fetchCampusCard({
@@ -173,3 +254,49 @@ final CampusCardQueryResult _successResult = CampusCardQueryResult(
     ],
   ),
 );
+
+final CampusCardQueryResult _freshCachedResult = _buildCachedResult(
+  balance: 88.88,
+  status: '正常',
+  checkedAt: DateTime.now(),
+);
+
+final CampusCardQueryResult _staleCachedResult = _buildCachedResult(
+  balance: 66.66,
+  status: '正常',
+  checkedAt: DateTime.now().subtract(const Duration(hours: 2)),
+);
+
+final CampusCardQueryResult _missingAccountResult = CampusCardQueryResult(
+  status: CampusCardQueryStatus.missingOaAccount,
+  message: '请先保存学工号',
+  detail: '本地安全存储中没有 OA 账号。',
+  checkedAt: DateTime(2026, 4, 30, 10, 30),
+  entranceUri: Uri.parse(
+    'https://oa.sspu.edu.cn//interface/Entrance.jsp?id=xykxt',
+  ),
+);
+
+CampusCardQueryResult _buildCachedResult({
+  required double balance,
+  required String status,
+  required DateTime checkedAt,
+}) {
+  return CampusCardQueryResult(
+    status: CampusCardQueryStatus.success,
+    message: '已显示本地校园卡缓存',
+    detail: '显示最近一次成功读取并保存的校园卡余额、状态和交易记录。',
+    checkedAt: checkedAt,
+    entranceUri: Uri.parse(
+      'https://oa.sspu.edu.cn//interface/Entrance.jsp?id=xykxt',
+    ),
+    finalUri: Uri.parse('https://card.sspu.edu.cn/epay/'),
+    snapshot: CampusCardSnapshot(
+      balance: balance,
+      status: status,
+      fetchedAt: checkedAt,
+      sourceUri: Uri.parse('https://card.sspu.edu.cn/epay/'),
+      records: const [],
+    ),
+  );
+}

--- a/test/settings_security_section_test.dart
+++ b/test/settings_security_section_test.dart
@@ -9,7 +9,9 @@
 import 'package:sspu_allinone/design/fluent_ui.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sspu_allinone/services/academic_credentials_service.dart';
+import 'package:sspu_allinone/services/storage_service.dart';
 import 'package:sspu_allinone/widgets/settings_security_section.dart';
 
 /// 等待目标组件出现，覆盖安全存储异步加载后的首帧。
@@ -21,6 +23,17 @@ Future<void> pumpUntilFound(WidgetTester tester, Finder finder) async {
 }
 
 void main() {
+  setUp(() {
+    FlutterSecureStorage.setMockInitialValues({});
+    SharedPreferences.setMockInitialValues({});
+    StorageService.debugUseSharedPreferencesStorageForTesting(true);
+  });
+
+  tearDown(() {
+    StorageService.debugUseSharedPreferencesStorageForTesting(null);
+    SharedPreferences.setMockInitialValues({});
+  });
+
   Future<void> configureNarrowView(WidgetTester tester) async {
     tester.view.physicalSize = const Size(320, 720);
     tester.view.devicePixelRatio = 1.0;

--- a/test/sports_attendance_service_test.dart
+++ b/test/sports_attendance_service_test.dart
@@ -116,6 +116,57 @@ void main() {
     expect(result.summary?.records.length, 5);
   });
 
+  test('体育部考勤成功查询写入缓存且失败不会覆盖最近缓存', () async {
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      sportsQueryPassword: 'sports-pass',
+    );
+    final service = _buildService(
+      gateway: _FakeSportsAttendanceGateway(),
+      campusReachable: true,
+    );
+
+    final result = await service.fetchAttendanceSummary();
+    final cachedResult = await service.readLatestCachedAttendanceSummary();
+
+    expect(result.status, SportsAttendanceQueryStatus.success);
+    expect(cachedResult?.summary?.totalCount, 8);
+
+    final failedService = _buildService(
+      gateway: _FakeSportsAttendanceGateway(),
+      campusReachable: false,
+    );
+    final failedResult = await failedService.fetchAttendanceSummary();
+    final cachedAfterFailure = await failedService
+        .readLatestCachedAttendanceSummary();
+
+    expect(
+      failedResult.status,
+      SportsAttendanceQueryStatus.campusNetworkUnavailable,
+    );
+    expect(cachedAfterFailure?.summary?.totalCount, 8);
+  });
+
+  test('体育部查询过程中清除查询密码时不会重新写入考勤缓存', () async {
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      sportsQueryPassword: 'sports-pass',
+    );
+    final gateway = _FakeSportsAttendanceGateway(
+      beforeScoreReturn: () => AcademicCredentialsService.instance.clearSecret(
+        AcademicCredentialSecret.sportsQueryPassword,
+      ),
+    );
+    final service = _buildService(gateway: gateway, campusReachable: true);
+
+    final result = await service.fetchAttendanceSummary();
+    final cachedResult = await service.readLatestCachedAttendanceSummary();
+
+    expect(result.status, SportsAttendanceQueryStatus.unexpectedError);
+    expect(result.summary, isNull);
+    expect(cachedResult, isNull);
+  });
+
   test('体育部登录失败时返回凭据未通过', () async {
     await AcademicCredentialsService.instance.saveCredentials(
       oaAccount: '20260001',
@@ -202,6 +253,7 @@ class _FakeSportsAttendanceGateway implements SportsAttendanceGateway {
     SportsAttendanceHttpSnapshot? loginPage,
     SportsAttendanceHttpSnapshot? submitPage,
     SportsAttendanceHttpSnapshot? scorePage,
+    this.beforeScoreReturn,
   }) : loginPage =
            loginPage ??
            _loginSnapshot('''
@@ -225,6 +277,7 @@ class _FakeSportsAttendanceGateway implements SportsAttendanceGateway {
   final SportsAttendanceHttpSnapshot loginPage;
   final SportsAttendanceHttpSnapshot submitPage;
   final SportsAttendanceHttpSnapshot scorePage;
+  final Future<void> Function()? beforeScoreReturn;
   int openCount = 0;
   Map<String, String>? submittedFields;
 
@@ -255,6 +308,7 @@ class _FakeSportsAttendanceGateway implements SportsAttendanceGateway {
     Uri scoreUri,
     Duration timeout,
   ) async {
+    await beforeScoreReturn?.call();
     return scorePage;
   }
 }

--- a/test/student_report_service_test.dart
+++ b/test/student_report_service_test.dart
@@ -11,6 +11,7 @@ import 'dart:async';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sspu_allinone/models/academic_credentials.dart';
 import 'package:sspu_allinone/models/academic_login_validation.dart';
 import 'package:sspu_allinone/models/student_report.dart';
 import 'package:sspu_allinone/services/academic_credentials_service.dart';
@@ -331,5 +332,34 @@ void main() {
     expect(records?.single.itemName, '迎新志愿服务');
     expect(records?.single.status, isNull);
     expect(records?.single.credit, 1);
+  });
+
+  test('第二课堂查询过程中清除 OA 密码时不会重新写入学工缓存', () async {
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      oaPassword: 'oa-pass',
+    );
+    final gateway = _FakeStudentReportGateway(
+      beforeCreditReturn: () => AcademicCredentialsService.instance.clearSecret(
+        AcademicCredentialSecret.oaPassword,
+      ),
+    );
+    final service = _buildService(
+      gateway: gateway,
+      campusReachable: true,
+      refreshOaLogin: () async {
+        await AcademicCredentialsService.instance.saveOaLoginSession(
+          _sessionSnapshot,
+        );
+        return _loginSuccessResult();
+      },
+    );
+
+    final result = await service.fetchSecondClassroomCredits();
+    final cachedResult = await service.readLatestCachedSecondClassroomCredits();
+
+    expect(result.status, StudentReportQueryStatus.unexpectedError);
+    expect(result.summary, isNull);
+    expect(cachedResult, isNull);
   });
 }

--- a/test/student_report_service_test_support.dart
+++ b/test/student_report_service_test_support.dart
@@ -36,6 +36,7 @@ class _FakeStudentReportGateway implements StudentReportGateway {
     StudentReportHttpSnapshot? creditPage,
     StudentReportHttpSnapshot? reportEntryPage,
     this.timeoutReportEntry = false,
+    this.beforeCreditReturn,
   }) : entryPage = entryPage ?? _snapshot(_homeHtml),
        creditPage = creditPage ?? _snapshot(_creditHtml),
        reportEntryPage = reportEntryPage ?? _snapshot(_homeHtml);
@@ -47,6 +48,7 @@ class _FakeStudentReportGateway implements StudentReportGateway {
   final StudentReportHttpSnapshot entryPage;
   final StudentReportHttpSnapshot creditPage;
   final StudentReportHttpSnapshot reportEntryPage;
+  final Future<void> Function()? beforeCreditReturn;
   final List<Map<String, String>> resetCookieHeaders = [];
   final List<Uri> fetchedUris = [];
   int openCount = 0;
@@ -90,6 +92,7 @@ class _FakeStudentReportGateway implements StudentReportGateway {
       if (requireAuthCreditFirst && _creditFetchCount == 1) {
         return _localLoginSnapshot;
       }
+      await beforeCreditReturn?.call();
       return creditPage;
     }
     return StudentReportHttpSnapshot(


### PR DESCRIPTION
## 变更说明

为所有鉴权业务数据新增本地缓存与自动/手动刷新机制，支撑 issue #157。

### 主要变更
- 新增 AuthenticatedDataCacheService：按账号隔离、每类数据保留最近 3 条、owner 使用不可逆标识
- 校园卡、体育部考勤、第二课堂学分、本专科教务（摘要/课表）、学校邮箱进入缓存/自动刷新体系
- 页面进入时优先展示本地缓存，按配置间隔静默刷新；静默失败保留旧缓存
- 教务凭据变更时通过流通知已挂载页面清空旧账号 UI 状态
- OA 自动会话获取并绑定账号与密码指纹，防止同账号换密后复用旧 Cookie
- 凭据变更/切换账号时放弃 in-flight 结果，不缓存不展示，受 EAMS 只读搜索同样保护
- 缓存持久化前主动剥离 URI 查询参数/fragment，不写入学工号、邮箱账号、学生 ID 等标识

### 验证记录
- lutter analyze --no-fatal-infos 无问题
- lutter test 全部 167 项通过
- git diff --check 无 CRLF 告警
- 多轮 review 修复隐私阻断点

### 影响范围
- 校园卡、体育部、学工报表、本专科教务、学校邮箱的页面与服务
- 教务凭据安全存储与会话管理
- IndexedStack 保持页面存活时，旧账号业务数据通过凭据变更流即时失效

### 回滚方式
revert 本 PR 的 merge commit 即可。

## 关联 Issue

Closes #157
