### PR TITLE
fix(ui): 修复移动端安全区错位

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -200,10 +200,14 @@ class _CompactNavigationShell extends StatelessWidget {
     return ScaffoldPage(
       content: SafeArea(
         bottom: false,
-        child: _NavigationBody(
-          destinations: destinations,
-          selectedIndex: selectedIndex,
-          visitedIndexes: visitedIndexes,
+        child: MediaQuery.removePadding(
+          context: context,
+          removeBottom: true,
+          child: _NavigationBody(
+            destinations: destinations,
+            selectedIndex: selectedIndex,
+            visitedIndexes: visitedIndexes,
+          ),
         ),
       ),
       bottomBar: Container(

--- a/lib/design/components/fluent_page.dart
+++ b/lib/design/components/fluent_page.dart
@@ -72,6 +72,9 @@ class FluentPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final spacing = context.fluentSpacing;
+    final safeHeader = header == null
+        ? null
+        : SafeArea(bottom: false, child: header!);
     final body = scrollable
         ? SingleChildScrollView(
             padding: padding ?? EdgeInsets.all(spacing.xxl),
@@ -83,8 +86,8 @@ class FluentPage extends StatelessWidget {
         : content ?? const SizedBox.shrink();
 
     return fluent.ScaffoldPage(
-      header: header,
-      content: SafeArea(child: body),
+      header: safeHeader,
+      content: SafeArea(top: header == null, child: body),
     );
   }
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -44,13 +44,27 @@ Future<void> deleteDirectoryWithRetry(Directory directory) async {
 }
 
 void main() {
-  Future<void> configureMobileView(WidgetTester tester) async {
+  Future<void> configureMobileView(
+    WidgetTester tester, {
+    double topPadding = 0,
+    double bottomPadding = 0,
+  }) async {
     tester.view.physicalSize = const Size(390, 844);
     tester.view.devicePixelRatio = 1.0;
+    tester.view.padding = FakeViewPadding(
+      top: topPadding,
+      bottom: bottomPadding,
+    );
+    tester.view.viewPadding = FakeViewPadding(
+      top: topPadding,
+      bottom: bottomPadding,
+    );
     await tester.binding.setSurfaceSize(const Size(390, 844));
   }
 
   Future<void> resetMobileView(WidgetTester tester) async {
+    tester.view.resetPadding();
+    tester.view.resetViewPadding();
     tester.view.resetPhysicalSize();
     tester.view.resetDevicePixelRatio();
     await tester.binding.setSurfaceSize(null);
@@ -125,6 +139,80 @@ void main() {
       debugDefaultTargetPlatformOverride = previousTargetPlatform;
       StorageService.debugUseSharedPreferencesStorageForTesting(null);
       SharedPreferences.setMockInitialValues({});
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      await resetMobileView(tester);
+    }
+  });
+
+  Future<void> expectMobileSafeAreaLayout(
+    WidgetTester tester,
+    TargetPlatform platform,
+  ) async {
+    final previousTargetPlatform = debugDefaultTargetPlatformOverride;
+    debugDefaultTargetPlatformOverride = platform;
+    await configureMobileView(tester, topPadding: 44, bottomPadding: 34);
+
+    try {
+      SharedPreferences.setMockInitialValues({});
+      StorageService.debugUseSharedPreferencesStorageForTesting(true);
+      final service = _buildCampusNetworkStatusService();
+      await tester.pumpWidget(
+        FluentApp(home: AppShell(campusNetworkStatusService: service)),
+      );
+      await tester.pump(const Duration(milliseconds: 100));
+
+      final titleTop = tester.getTopLeft(find.text('主页').first).dy;
+      expect(titleTop, greaterThanOrEqualTo(44));
+
+      final bottomNavigation = find.byKey(
+        const Key('mobile-bottom-navigation'),
+      );
+      expect(bottomNavigation, findsOneWidget);
+      expect(tester.getBottomLeft(bottomNavigation).dy, 844);
+
+      final selectedHomeLabel = find
+          .descendant(of: bottomNavigation, matching: find.text('主页'))
+          .first;
+      expect(tester.getBottomLeft(selectedHomeLabel).dy, lessThanOrEqualTo(810));
+
+      await tester.pump(const Duration(milliseconds: 300));
+    } finally {
+      debugDefaultTargetPlatformOverride = previousTargetPlatform;
+      StorageService.debugUseSharedPreferencesStorageForTesting(null);
+      SharedPreferences.setMockInitialValues({});
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      await resetMobileView(tester);
+    }
+  }
+
+  testWidgets('移动端安全区不遮挡页面标题且底部导航贴合手势区', (
+    WidgetTester tester,
+  ) async {
+    await expectMobileSafeAreaLayout(tester, TargetPlatform.android);
+    await expectMobileSafeAreaLayout(tester, TargetPlatform.iOS);
+  });
+
+  testWidgets('移动端安全区保护 FluentPage 标题区域', (tester) async {
+    await configureMobileView(tester, topPadding: 44, bottomPadding: 34);
+
+    try {
+      await tester.pumpWidget(
+        const FluentApp(
+          home: FluentPage.scrollable(
+            header: FluentPageHeader(title: Text('测试页面')),
+            children: [Text('测试内容')],
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        tester.getTopLeft(find.text('测试页面')).dy,
+        greaterThanOrEqualTo(44),
+      );
+    } finally {
       await tester.pumpWidget(const SizedBox.shrink());
       await tester.pump();
       await resetMobileView(tester);


### PR DESCRIPTION
## 背景与目标

Closes #163。

修复 Android / iOS 移动端页面视图错位问题：顶部页面标题进入系统状态栏区域，底部导航与手势安全区之间出现异常空隙或黑边。

## 根因定位

- `fluent_ui` 的 `ScaffoldPage` 只处理键盘 `MediaQuery.viewInsets.bottom`，不会自动处理状态栏或系统手势区的 `MediaQuery.padding`。
- 项目封装的 `FluentPage` 只给 `content` 包了 `SafeArea`，`header` 仍由外部 `PageHeader` 直接布局，因此在 Android / iOS 有顶部安全区时页面标题可能被状态栏遮挡。
- 移动端 `_CompactNavigationShell` 外层和页面层同时参与 bottom padding 处理，安全区职责分散，容易造成底部导航与内容区域重复或错位。

## 变更说明

- `FluentPage` 改为让 header 与 content 分别按同一页面容器的安全区职责处理，确保页面标题不会进入系统状态栏。
- 移动端导航壳在页面内容区域移除 bottom padding，让底部手势区只由 bottom navigation 的 `SafeArea(top: false)` 消费，底栏背景仍贴合屏幕底部。
- 补充 Android / iOS compact 视口安全区回归测试，显式模拟 top 44 / bottom 34 的真机状态栏与手势条。

## 验证记录

- [x] `flutter test test/widget_test.dart --name "移动端安全区"`
- [x] `flutter analyze`
- [x] `flutter test`

## 风险与回滚

- 风险等级：中低
- 主要风险：页面通用 `FluentPage` 安全区处理改变，影响所有使用 `FluentPageHeader` 的页面顶部布局。
- 回滚方案：回退本 PR 即可恢复旧布局；新增回归测试会重新暴露 #163。
