### PR TITLE
fix(webview): 修复内嵌网页退出入口

### DIFF
--- a/lib/pages/webview_page.dart
+++ b/lib/pages/webview_page.dart
@@ -11,8 +11,8 @@ import '../design/fluent_ui.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-import '../theme/app_spacing.dart';
 import '../widgets/empty_state_view.dart';
+import '../widgets/webview_compact_toolbar.dart';
 
 /// 内嵌 WebView 页面。
 /// 在应用内打开网页链接，提供导航栏（返回/前进/刷新/外部浏览器）。
@@ -47,9 +47,6 @@ class _WebViewPageState extends State<WebViewPage> {
   /// 当前加载的 URL。
   String _currentUrl = '';
 
-  /// 是否可后退。
-  bool _canGoBack = false;
-
   /// 是否可前进。
   bool _canGoForward = false;
 
@@ -79,13 +76,9 @@ class _WebViewPageState extends State<WebViewPage> {
   /// 更新导航按钮状态（前进/后退可用性）。
   Future<void> _updateNavigationState() async {
     if (_controller == null) return;
-    final canBack = await _controller!.canGoBack();
     final canForward = await _controller!.canGoForward();
     if (mounted) {
-      setState(() {
-        _canGoBack = canBack;
-        _canGoForward = canForward;
-      });
+      setState(() => _canGoForward = canForward);
     }
   }
 
@@ -97,6 +90,18 @@ class _WebViewPageState extends State<WebViewPage> {
         (uri.scheme == 'http' || uri.scheme == 'https')) {
       await launchUrl(uri, mode: LaunchMode.externalApplication);
     }
+  }
+
+  /// WebView 返回按钮行为：有网页历史时后退网页，否则退出当前路由。
+  Future<void> _handleBackOrClose() async {
+    final controller = _controller;
+    if (controller != null && await controller.canGoBack()) {
+      await controller.goBack();
+      await _updateNavigationState();
+      return;
+    }
+    if (!mounted) return;
+    await Navigator.of(context).maybePop();
   }
 
   @override
@@ -134,89 +139,95 @@ class _WebViewPageState extends State<WebViewPage> {
     }
 
     return FluentPage(
-      header: FluentPageHeader(
-        title: Text(_title, overflow: TextOverflow.ellipsis, maxLines: 1),
-        commandBar: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            FluentIconButton(
-              tooltip: '后退',
-              icon: const Icon(FluentIcons.back),
-              onPressed: _canGoBack ? () => _controller?.goBack() : null,
-            ),
-            FluentIconButton(
-              tooltip: '前进',
-              icon: const Icon(FluentIcons.forward),
-              onPressed: _canGoForward ? () => _controller?.goForward() : null,
-            ),
-            FluentIconButton(
-              tooltip: '刷新',
-              icon: const Icon(FluentIcons.refresh),
-              onPressed: _isReady ? () => _controller?.reload() : null,
-            ),
-            FluentIconButton(
-              tooltip: '在浏览器中打开',
-              icon: const Icon(FluentIcons.openInNewWindow),
-              onPressed: _fallbackToExternalBrowser,
-            ),
-            const SizedBox(width: AppSpacing.sm),
-          ],
-        ),
-      ),
-      content: Stack(
+      content: Column(
         children: [
-          InAppWebView(
-            webViewEnvironment: widget.webViewEnvironment,
-            initialUrlRequest: URLRequest(url: WebUri(widget.url)),
-            initialSettings: InAppWebViewSettings(
-              javaScriptEnabled: true,
-              isInspectable: kDebugMode,
-              userAgent:
-                  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
-                  '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-            ),
-            onWebViewCreated: (controller) {
-              _controller = controller;
-              if (mounted) {
-                setState(() => _isReady = true);
-              }
-            },
-            onTitleChanged: (controller, title) {
-              if (mounted && title != null && title.isNotEmpty) {
-                setState(() => _title = title);
-              }
-            },
-            onUpdateVisitedHistory: (controller, url, isReload) {
-              if (url != null && mounted) {
-                setState(() => _currentUrl = url.toString());
-                _updateNavigationState();
-              }
-            },
-            onLoadStop: (controller, url) {
-              if (url != null && mounted) {
-                setState(() => _currentUrl = url.toString());
-                _updateNavigationState();
-              }
-            },
-            onProgressChanged: (controller, progress) {
-              if (mounted) {
-                setState(() => _progress = progress / 100.0);
-              }
-            },
-            onReceivedError: (controller, request, error) {
-              if (request.isForMainFrame == true && mounted) {
-                setState(() => _initFailed = true);
-                _fallbackToExternalBrowser();
-              }
-            },
+          WebViewCompactToolbar(
+            title: _title,
+            onBackPressed: _handleBackOrClose,
+            actions: [
+              FluentIconButton(
+                tooltip: '前进',
+                semanticLabel: '前进',
+                icon: const Icon(FluentIcons.forward),
+                onPressed: _canGoForward
+                    ? () => _controller?.goForward()
+                    : null,
+                size: 32,
+              ),
+              FluentIconButton(
+                tooltip: '刷新',
+                semanticLabel: '刷新',
+                icon: const Icon(FluentIcons.refresh),
+                onPressed: _isReady ? () => _controller?.reload() : null,
+                size: 32,
+              ),
+              FluentIconButton(
+                tooltip: '在浏览器中打开',
+                semanticLabel: '在浏览器中打开',
+                icon: const Icon(FluentIcons.openInNewWindow),
+                onPressed: _fallbackToExternalBrowser,
+                size: 32,
+              ),
+            ],
           ),
-          if (_progress > 0 && _progress < 1.0)
-            PositionedDirectional(
-              top: 0,
-              start: 0,
-              end: 0,
-              child: FluentProgressBar(value: _progress),
+          Expanded(
+            child: Stack(
+              children: [
+                InAppWebView(
+                  webViewEnvironment: widget.webViewEnvironment,
+                  initialUrlRequest: URLRequest(url: WebUri(widget.url)),
+                  initialSettings: InAppWebViewSettings(
+                    javaScriptEnabled: true,
+                    isInspectable: kDebugMode,
+                    userAgent:
+                        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
+                        '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+                  ),
+                  onWebViewCreated: (controller) {
+                    _controller = controller;
+                    if (mounted) {
+                      setState(() => _isReady = true);
+                    }
+                  },
+                  onTitleChanged: (controller, title) {
+                    if (mounted && title != null && title.isNotEmpty) {
+                      setState(() => _title = title);
+                    }
+                  },
+                  onUpdateVisitedHistory: (controller, url, isReload) {
+                    if (url != null && mounted) {
+                      setState(() => _currentUrl = url.toString());
+                      _updateNavigationState();
+                    }
+                  },
+                  onLoadStop: (controller, url) {
+                    if (url != null && mounted) {
+                      setState(() => _currentUrl = url.toString());
+                      _updateNavigationState();
+                    }
+                  },
+                  onProgressChanged: (controller, progress) {
+                    if (mounted) {
+                      setState(() => _progress = progress / 100.0);
+                    }
+                  },
+                  onReceivedError: (controller, request, error) {
+                    if (request.isForMainFrame == true && mounted) {
+                      setState(() => _initFailed = true);
+                      _fallbackToExternalBrowser();
+                    }
+                  },
+                ),
+                if (_progress > 0 && _progress < 1.0)
+                  PositionedDirectional(
+                    top: 0,
+                    start: 0,
+                    end: 0,
+                    child: FluentProgressBar(value: _progress),
+                  ),
+              ],
             ),
+          ),
         ],
       ),
     );
@@ -229,8 +240,15 @@ class _WebViewPageState extends State<WebViewPage> {
     required Widget child,
   }) {
     return FluentPage(
-      header: FluentPageHeader(title: Text(title)),
-      content: child,
+      content: Column(
+        children: [
+          WebViewCompactToolbar(
+            title: title,
+            onBackPressed: () => Navigator.of(context).maybePop(),
+          ),
+          Expanded(child: child),
+        ],
+      ),
     );
   }
 }

--- a/lib/pages/wxmp_login_page.dart
+++ b/lib/pages/wxmp_login_page.dart
@@ -13,6 +13,7 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import '../services/wxmp_article_service.dart';
 import '../services/wxmp_auth_service.dart';
 import '../theme/fluent_tokens.dart';
+import '../widgets/webview_compact_toolbar.dart';
 
 /// 公众号平台登录 URL
 const String _wxmpLoginUrl = 'https://mp.weixin.qq.com/';
@@ -258,38 +259,33 @@ class _WxmpLoginPageState extends State<WxmpLoginPage> {
     final isDark = theme.brightness == Brightness.dark;
 
     return FluentPage(
-      header: FluentPageHeader(
-        title: Text(_title),
-        commandBar: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (_extracting)
-              const Padding(
-                padding: EdgeInsets.only(right: 12),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    SizedBox(
-                      width: 16,
-                      height: 16,
+      content: Column(
+        children: [
+          WebViewCompactToolbar(
+            title: _title,
+            backSemanticLabel: _result?.success == true ? '完成' : '返回',
+            onBackPressed: () =>
+                Navigator.of(context).pop(_result?.success ?? false),
+            actions: [
+              if (_extracting)
+                const SizedBox.square(
+                  dimension: 48,
+                  child: Center(
+                    child: SizedBox.square(
+                      dimension: 16,
                       child: FluentProgressRing(strokeWidth: 2),
                     ),
-                    SizedBox(width: 8),
-                    Text('正在提取认证信息...'),
-                  ],
+                  ),
                 ),
-              ),
-            if (_result != null)
-              Padding(
-                padding: const EdgeInsets.only(right: 12),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(
+              if (_result != null)
+                SizedBox.square(
+                  dimension: 48,
+                  child: Center(
+                    child: Icon(
                       _result!.success
                           ? FluentIcons.checkMark
                           : FluentIcons.warning,
-                      size: 16,
+                      size: 18,
                       color: _result!.success
                           ? (isDark
                                 ? FluentDarkColors.statusSuccess
@@ -298,23 +294,13 @@ class _WxmpLoginPageState extends State<WxmpLoginPage> {
                                 ? FluentDarkColors.statusError
                                 : FluentLightColors.statusError),
                     ),
-                    const SizedBox(width: 6),
-                    Text(
-                      _result!.success ? '登录成功' : '提取失败',
-                      style: theme.typography.body,
-                    ),
-                  ],
+                  ),
                 ),
-              ),
-            FluentButton.outline(
-              onPressed: () =>
-                  Navigator.of(context).pop(_result?.success ?? false),
-              child: Text(_result?.success == true ? '完成' : '返回'),
-            ),
-          ],
-        ),
+            ],
+          ),
+          Expanded(child: _buildContent(context)),
+        ],
       ),
-      content: _buildContent(context),
     );
   }
 

--- a/lib/widgets/webview_compact_toolbar.dart
+++ b/lib/widgets/webview_compact_toolbar.dart
@@ -1,0 +1,76 @@
+/*
+ * WebView 紧凑工具栏 — 为内嵌网页页面提供稳定返回入口与低高度标题栏
+ * @Project : SSPU-AllinOne
+ * @File : webview_compact_toolbar.dart
+ * @Author : Qintsg
+ * @Date : 2026-06-07
+ */
+
+import '../design/fluent_ui.dart';
+
+/// WebView 页面紧凑工具栏。
+class WebViewCompactToolbar extends StatelessWidget {
+  const WebViewCompactToolbar({
+    super.key = const Key('webview-compact-toolbar'),
+    required this.title,
+    required this.onBackPressed,
+    this.backSemanticLabel = '返回',
+    this.actions = const [],
+  });
+
+  /// 当前页面标题。
+  final String title;
+
+  /// 返回或退出按钮回调。
+  final VoidCallback onBackPressed;
+
+  /// 返回按钮语义标签。
+  final String backSemanticLabel;
+
+  /// 右侧操作按钮。
+  final List<Widget> actions;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = FluentTheme.of(context);
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: theme.cardColor,
+        border: Border(
+          bottom: BorderSide(color: theme.resources.controlStrokeColorDefault),
+        ),
+      ),
+      child: SizedBox(
+        height: 48,
+        child: Row(
+          children: [
+            Semantics(
+              key: const Key('webview-back-close-button'),
+              button: true,
+              enabled: true,
+              label: backSemanticLabel,
+              onTap: onBackPressed,
+              child: FluentIconButton(
+                tooltip: backSemanticLabel,
+                icon: const Icon(FluentIcons.back),
+                onPressed: onBackPressed,
+                size: 32,
+                iconSize: 18,
+              ),
+            ),
+            Expanded(
+              child: Text(
+                title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.typography.bodyStrong,
+              ),
+            ),
+            for (final action in actions) action,
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/webview_page_test.dart
+++ b/test/webview_page_test.dart
@@ -1,0 +1,281 @@
+/*
+ * WebView 页面测试 — 校验紧凑工具栏与返回/退出行为
+ * @Project : SSPU-AllinOne
+ * @File : webview_page_test.dart
+ * @Author : Qintsg
+ * @Date : 2026-06-07
+ */
+
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sspu_allinone/design/fluent_ui.dart';
+import 'package:sspu_allinone/pages/webview_page.dart';
+import 'package:sspu_allinone/pages/wxmp_login_page.dart';
+
+void main() {
+  late InAppWebViewPlatform? previousPlatform;
+  late _TestInAppWebViewPlatform testPlatform;
+
+  setUp(() {
+    previousPlatform = InAppWebViewPlatform.instance;
+    testPlatform = _TestInAppWebViewPlatform();
+    InAppWebViewPlatform.instance = testPlatform;
+  });
+
+  tearDown(() {
+    if (previousPlatform != null) {
+      InAppWebViewPlatform.instance = previousPlatform!;
+    }
+  });
+
+  testWidgets('WebView 紧凑工具栏始终显示可点击退出入口并约束长标题', (tester) async {
+    final semantics = tester.ensureSemantics();
+    await _configureMobileView(tester);
+
+    try {
+      await tester.pumpWidget(
+        const FluentApp(
+          home: WebViewPage(
+            url: 'https://example.com/news',
+            initialTitle: '这是一条非常非常非常长的网页标题用于验证标题栏不会换行撑高或挤压右侧操作按钮',
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final toolbar = find.byKey(const Key('webview-compact-toolbar'));
+      final backCloseButton = find.byKey(
+        const Key('webview-back-close-button'),
+      );
+
+      expect(toolbar, findsOneWidget);
+      expect(backCloseButton, findsOneWidget);
+      expect(find.bySemanticsLabel('返回'), findsWidgets);
+      expect(
+        tester.getSemantics(find.bySemanticsLabel('返回').first),
+        matchesSemantics(
+          label: '返回',
+          isButton: true,
+          hasEnabledState: true,
+          isEnabled: true,
+          hasTapAction: true,
+        ),
+      );
+      expect(tester.getSize(toolbar).height, lessThanOrEqualTo(56));
+      expect(
+        tester.takeException(),
+        isNull,
+        reason: '紧凑标题栏不应在移动窄屏产生 overflow 异常',
+      );
+    } finally {
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      await _resetMobileView(tester);
+      semantics.dispose();
+    }
+  });
+
+  testWidgets('WebView 返回按钮有网页历史时优先后退网页', (tester) async {
+    testPlatform.controller.canGoBackValue = true;
+
+    await tester.pumpWidget(
+      const FluentApp(
+        home: WebViewPage(
+          url: 'https://example.com/news',
+          initialTitle: '网页标题',
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('webview-back-close-button')));
+    await tester.pump(const Duration(milliseconds: 120));
+
+    expect(testPlatform.controller.goBackCount, 1);
+  });
+
+  testWidgets('WebView 返回按钮无网页历史时退出当前路由', (tester) async {
+    testPlatform.controller.canGoBackValue = false;
+
+    await tester.pumpWidget(
+      FluentApp(
+        home: Builder(
+          builder: (context) => FluentButton(
+            onPressed: () {
+              Navigator.of(context).push(
+                FluentPageRoute(
+                  builder: (_) => const WebViewPage(
+                    url: 'https://example.com/news',
+                    initialTitle: '网页标题',
+                  ),
+                ),
+              );
+            },
+            child: const Text('打开 WebView'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('打开 WebView'));
+    await tester.pumpAndSettle();
+    expect(find.text('网页标题'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('webview-back-close-button')));
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 120));
+
+    expect(testPlatform.controller.goBackCount, 0);
+    expect(find.text('打开 WebView'), findsOneWidget);
+    expect(find.text('网页标题'), findsNothing);
+  });
+
+  testWidgets('WebView 无效链接状态页也保留顶部退出入口', (tester) async {
+    await tester.pumpWidget(
+      const FluentApp(
+        home: WebViewPage(
+          url: 'https://wywh.sspu.edu.cnjavascript:void(0);',
+          initialTitle: '无效链接',
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('链接无效，无法打开'), findsOneWidget);
+    expect(find.byKey(const Key('webview-compact-toolbar')), findsOneWidget);
+    expect(find.byKey(const Key('webview-back-close-button')), findsOneWidget);
+  });
+
+  testWidgets('公众号登录 WebView 使用紧凑工具栏且标题单行', (tester) async {
+    await _configureMobileView(tester);
+
+    try {
+      await tester.pumpWidget(const FluentApp(home: WxmpLoginPage()));
+      await tester.pump();
+
+      final toolbar = find.byKey(const Key('webview-compact-toolbar'));
+      final backCloseButton = find.byKey(
+        const Key('webview-back-close-button'),
+      );
+
+      expect(toolbar, findsOneWidget);
+      expect(backCloseButton, findsOneWidget);
+      expect(tester.getSize(toolbar).height, lessThanOrEqualTo(56));
+      expect(
+        tester.takeException(),
+        isNull,
+        reason: '公众号登录页工具栏不应在移动窄屏产生 overflow 异常',
+      );
+    } finally {
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      await _resetMobileView(tester);
+    }
+  });
+}
+
+/// 配置移动端窄屏视口。
+Future<void> _configureMobileView(WidgetTester tester) async {
+  tester.view.physicalSize = const Size(390, 844);
+  tester.view.devicePixelRatio = 1.0;
+  await tester.binding.setSurfaceSize(const Size(390, 844));
+}
+
+/// 恢复测试视口。
+Future<void> _resetMobileView(WidgetTester tester) async {
+  tester.view.resetPhysicalSize();
+  tester.view.resetDevicePixelRatio();
+  await tester.binding.setSurfaceSize(null);
+}
+
+class _TestInAppWebViewPlatform extends InAppWebViewPlatform {
+  final _TestPlatformInAppWebViewController controller =
+      _TestPlatformInAppWebViewController();
+
+  @override
+  PlatformInAppWebViewController createPlatformInAppWebViewController(
+    PlatformInAppWebViewControllerCreationParams params,
+  ) {
+    return controller;
+  }
+
+  @override
+  PlatformInAppWebViewWidget createPlatformInAppWebViewWidget(
+    PlatformInAppWebViewWidgetCreationParams params,
+  ) {
+    return _TestPlatformInAppWebViewWidget(params, controller);
+  }
+}
+
+class _TestPlatformInAppWebViewWidget extends PlatformInAppWebViewWidget {
+  _TestPlatformInAppWebViewWidget(super.params, this.controller)
+    : super.implementation();
+
+  final _TestPlatformInAppWebViewController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final appController = params.controllerFromPlatform?.call(controller);
+    if (appController is InAppWebViewController &&
+        !controller.callbacksDispatched) {
+      controller.callbacksDispatched = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        params.onWebViewCreated?.call(appController);
+        params.onTitleChanged?.call(appController, '网页标题');
+        params.onLoadStop?.call(appController, WebUri('https://example.com'));
+      });
+    }
+    return const ColoredBox(
+      key: Key('fake-in-app-webview'),
+      color: Color(0xFFEFEFEF),
+      child: SizedBox.expand(),
+    );
+  }
+
+  @override
+  T controllerFromPlatform<T>(PlatformInAppWebViewController controller) {
+    return params.controllerFromPlatform!.call(controller) as T;
+  }
+
+  @override
+  void dispose() {}
+}
+
+class _TestPlatformInAppWebViewController
+    extends PlatformInAppWebViewController {
+  _TestPlatformInAppWebViewController()
+    : super.implementation(
+        const PlatformInAppWebViewControllerCreationParams(id: 'test-webview'),
+      );
+
+  bool canGoBackValue = false;
+  bool canGoForwardValue = false;
+  int goBackCount = 0;
+  int goForwardCount = 0;
+  int reloadCount = 0;
+  bool callbacksDispatched = false;
+
+  @override
+  Future<bool> canGoBack() async => canGoBackValue;
+
+  @override
+  Future<void> goBack() async {
+    goBackCount++;
+  }
+
+  @override
+  Future<bool> canGoForward() async => canGoForwardValue;
+
+  @override
+  Future<void> goForward() async {
+    goForwardCount++;
+  }
+
+  @override
+  Future<void> reload() async {
+    reloadCount++;
+  }
+
+  @override
+  Future<WebUri?> getUrl() async => WebUri('https://example.com');
+}


### PR DESCRIPTION
## 变更说明

- 为内嵌 WebView 页面新增紧凑工具栏，左侧固定提供可点击返回入口，长标题单行省略。
- 普通 WebView 返回按钮改为：有网页历史时优先 `goBack()`，无网页历史时退出当前路由。
- 无效链接 / 初始化失败状态页也保留同一顶部退出入口。
- 公众号登录 WebView 同步使用紧凑工具栏，避免移动窄屏标题栏被长状态文案撑高或挤压。
- 新增 WebView widget 回归测试，使用 fake `InAppWebViewPlatform` 覆盖工具栏布局、返回行为和公众号登录页标题栏。

## 关联 Issue

Closes #199

## 影响范围

- `WebViewPage` 普通网页、信息渠道文章和首页消息进入的内嵌网页。
- `WxmpLoginPage` 公众号平台登录 WebView。
- WebView 页面标题栏高度、返回/退出语义、移动端窄屏布局。

## 验证记录

- [x] `flutter test test/webview_page_test.dart`
- [x] `flutter test test/widget_test.dart --name "WebView"`
- [x] `flutter test test/wxmp_login_page_test.dart`
- [x] `flutter analyze`
- [x] `flutter test`

## 回滚方式

- 回滚本 PR 提交即可恢复原有 `FluentPageHeader` 标题栏和旧 WebView 后退按钮行为。

## 检查清单

- [x] 已完成自测
- [x] 没有提交无关文件
- [x] 没有引入敏感信息
- [x] 已更新相关文档（本次为 UI/测试修复，无需同步发布文档）
- [x] 若修改版本 / Release / CI，已遵循 `docs/RELEASE.md`，且没有在用户可见文件名或说明中显式写出 `+build`
