### PR TITLE
ci(issue): 合并 develop 后关闭关联 issue

### DIFF
--- a/.github/workflows/close-linked-issues.yml
+++ b/.github/workflows/close-linked-issues.yml
@@ -1,0 +1,141 @@
+# 自动关闭关联 Issue — 补齐 develop 集成分支的关闭规则
+name: Close Linked Issues
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [develop]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  close-linked-issues:
+    name: Close linked issues after develop merge
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueNumbers = new Set();
+
+            function escapeRegExp(value) {
+              return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            }
+
+            function addIssue(number) {
+              const parsed = Number(number);
+              if (!Number.isInteger(parsed) || parsed <= 0) return;
+              issueNumbers.add(parsed);
+            }
+
+            function collectClosingKeywordIssues(text) {
+              if (!text) return;
+
+              const ownerPattern = escapeRegExp(owner);
+              const repoPattern = escapeRegExp(repo);
+              const sameRepoRefPattern =
+                `(?:#(\\d+)|${ownerPattern}\\/${repoPattern}#(\\d+)|https:\\/\\/github\\.com\\/${ownerPattern}\\/${repoPattern}\\/issues\\/(\\d+))`;
+              const closingPattern = new RegExp(
+                `\\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s*:?\\s+${sameRepoRefPattern}\\b`,
+                'gi',
+              );
+
+              for (const match of text.matchAll(closingPattern)) {
+                addIssue(match[1] || match[2] || match[3]);
+              }
+            }
+
+            async function collectManuallyLinkedIssues() {
+              try {
+                const result = await github.graphql(
+                  `query($owner: String!, $repo: String!, $number: Int!) {
+                    repository(owner: $owner, name: $repo) {
+                      pullRequest(number: $number) {
+                        closingIssuesReferences(first: 100) {
+                          nodes {
+                            number
+                            repository {
+                              name
+                              owner {
+                                login
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }`,
+                  {
+                    owner,
+                    repo,
+                    number: pr.number,
+                  },
+                );
+
+                const nodes =
+                  result.repository?.pullRequest?.closingIssuesReferences?.nodes || [];
+                for (const node of nodes) {
+                  const linkedOwner = node.repository?.owner?.login;
+                  const linkedRepo = node.repository?.name;
+                  if (
+                    linkedOwner?.toLowerCase() === owner.toLowerCase() &&
+                    linkedRepo?.toLowerCase() === repo.toLowerCase()
+                  ) {
+                    addIssue(node.number);
+                  }
+                }
+              } catch (error) {
+                core.warning(`Unable to read linked issues via GraphQL: ${error.message}`);
+              }
+            }
+
+            collectClosingKeywordIssues(pr.body || '');
+            await collectManuallyLinkedIssues();
+
+            if (issueNumbers.size === 0) {
+              core.info('No same-repository closing issue references detected.');
+              return;
+            }
+
+            for (const issueNumber of [...issueNumbers].sort((left, right) => left - right)) {
+              const { data: issue } = await github.rest.issues.get({
+                owner,
+                repo,
+                issue_number: issueNumber,
+              });
+
+              if (issue.pull_request) {
+                core.info(`#${issueNumber} is a pull request, skip.`);
+                continue;
+              }
+
+              if (issue.state === 'closed') {
+                core.info(`#${issueNumber} is already closed, skip.`);
+                continue;
+              }
+
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body: `已随 PR #${pr.number} 合并到 \`develop\` 自动关闭。`,
+              });
+
+              core.info(`Closed issue #${issueNumber}.`);
+            }

--- a/.github/分支命名规范.md
+++ b/.github/分支命名规范.md
@@ -32,6 +32,7 @@
 
 - 禁止直接向 `main` / `develop` 推送未审查提交。
 - Pull Request 标题与 commit message 统一使用 `type(scope): 中文摘要`。
+- 关联 Issue 的 PR 必须在正文保留 `Closes #123`、`Fixes #123` 或 `Resolves #123`；合并入 `develop` 后由 `Close Linked Issues` workflow 自动关闭同仓库 Issue。
 - `develop` / `main` 之间的同步 PR 必须使用 **merge commit**，不得使用 squash / rebase，否则会持续放大历史分叉并导致后续 direct PR 冲突。
 - 影响 `docs/`、依赖、构建发布、平台配置或 API 契约时，必须同步更新相关文档。
 - 修改 `.github/`、依赖或 Release 流程时，PR 中必须写明验证结果、影响平台与回滚方式。

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -86,8 +86,9 @@ version: 1.0.0.1-hotfix+12
 1. 默认从 `develop` 签出新分支。
 2. 按 `.github/分支命名规范.md` 选择分支名，例如 `feature/<topic>`、`fix/<topic>`、`refactor/<topic>`、`docs/<topic>`、`ci/<topic>`。
 3. 完成开发、测试与文档同步后，创建 PR 合并回 `develop`。
-4. PR 必须使用仓库模板填写变更说明、验证记录、影响范围和风险；修改 `.github/`、发布、构建或依赖时必须写明回滚方式。
-5. 禁止直接向 `develop` 或 `main` 推送未审查提交。
+4. PR 必须使用仓库模板填写变更说明、验证记录、影响范围和风险；关联 Issue 保留 `Closes #123` / `Fixes #123` / `Resolves #123` 等关闭关键字。
+5. PR 合并入 `develop` 后，`Close Linked Issues` workflow 会自动关闭同仓库内通过关闭关键字或 GitHub 关联关系识别到的 Issue。
+6. 禁止直接向 `develop` 或 `main` 推送未审查提交。
 
 ### 3.2 alpha / beta / rc 发布工作流
 

--- a/docs/specs/RepoWorkflow.md
+++ b/docs/specs/RepoWorkflow.md
@@ -19,8 +19,9 @@ Scope: repo
 1. 从 `develop` 同步最新代码。
 2. 根据 `.github/分支命名规范.md` 签出任务分支，例如 `feature/<topic>`、`fix/<topic>`、`refactor/<topic>`、`docs/<topic>`。
 3. 完成开发、测试、文档和模板更新。
-4. 按仓库 PR 模板创建合并到 `develop` 的 PR。
+4. 按仓库 PR 模板创建合并到 `develop` 的 PR；关联 Issue 必须在 PR 正文保留 `Closes #123` / `Fixes #123` / `Resolves #123` 等关闭关键字。
 5. PR 中写明变更说明、验证记录、影响范围和回滚方式。
+6. PR 合并入 `develop` 后，`Close Linked Issues` workflow 会关闭同仓库内通过关闭关键字或 GitHub 关联关系识别到的 Issue。
 
 ## Release 流程
 


### PR DESCRIPTION
## 变更说明

- 新增 `Close Linked Issues` workflow，在 PR merge 到 `develop` 后关闭同仓库关联 Issue。
- 工作流同时读取 PR 正文中的 closing keywords，以及 GitHub GraphQL 暴露的关联关系。
- 同步更新仓库工作流规范、分支命名规范和 Release 文档中的 PR 要求。

## 关联 Issue

无。

## 影响范围

- 仅影响 GitHub Actions 中 PR 合并后的 Issue 状态收口。
- 不影响 Flutter 应用代码、构建产物或发布版本号。
- fork PR 在 GitHub 默认只读 token 限制下可能无法由 `pull_request` 事件写入 Issue；同仓库 PR 不受影响。

## 验证记录

- [x] `git diff --check`
- [x] `python -c "import yaml; yaml.safe_load(open(r'.github/workflows/close-linked-issues.yml', encoding='utf-8')); print('yaml ok')"`
- [x] Node 正则检查：可从已合并 WebView PR 正文识别关联 Issue 编号。
- [x] `gh api graphql` 探测 `closingIssuesReferences` 字段可读。
- [ ] 未运行 `actionlint`：本机未安装。
- [ ] 未触发真实远端 `pull_request` closed 事件：需本 PR 合并后由后续 PR 验证。

## 回滚方式

- 回滚本 PR 即可移除自动关闭关联 Issue 的 workflow，并恢复文档说明。

## 检查清单

- [x] 已完成自测
- [x] 没有提交无关文件
- [x] 没有引入敏感信息
- [x] 已更新相关文档
- [x] 若修改版本 / Release / CI，已遵循 `docs/RELEASE.md`