### PR TITLE
fix(settings): 修复侧栏导航鼠标移入深色闪烁

### DIFF
--- a/lib/widgets/settings_widgets.dart
+++ b/lib/widgets/settings_widgets.dart
@@ -102,7 +102,7 @@ Widget buildSettingsNavItem({
   );
 }
 
-class _SettingsNavItem extends StatefulWidget {
+class _SettingsNavItem extends StatelessWidget {
   const _SettingsNavItem({
     required this.isSelected,
     required this.icon,
@@ -120,114 +120,149 @@ class _SettingsNavItem extends StatefulWidget {
   final FluentTypography type;
 
   @override
-  State<_SettingsNavItem> createState() => _SettingsNavItemState();
-}
-
-class _SettingsNavItemState extends State<_SettingsNavItem> {
-  bool _hovered = false;
-  bool _pressed = false;
-  bool _focused = false;
-
-  @override
   Widget build(BuildContext context) {
-    final colors = widget.colors;
-    final type = widget.type;
-    final background = widget.isSelected
-        ? colors.brandBackgroundSelected.withValues(alpha: 0.12)
-        : _pressed
-        ? colors.neutralBackground1Pressed
-        : _hovered || _focused
-        ? colors.neutralBackground1Hover
-        : Colors.transparent;
-
     return Semantics(
       button: true,
-      selected: widget.isSelected,
-      child: Shortcuts(
+      selected: isSelected,
+      child: HoverButton(
+        cursor: SystemMouseCursors.click,
+        onPressed: onTap,
+        semanticLabel: label,
         shortcuts: const <ShortcutActivator, Intent>{
           SingleActivator(LogicalKeyboardKey.enter): ActivateIntent(),
           SingleActivator(LogicalKeyboardKey.numpadEnter): ActivateIntent(),
           SingleActivator(LogicalKeyboardKey.space): ActivateIntent(),
         },
-        child: FocusableActionDetector(
-          mouseCursor: SystemMouseCursors.click,
-          onShowFocusHighlight: (focused) => setState(() => _focused = focused),
-          onShowHoverHighlight: (hovered) => setState(() {
-            _hovered = hovered;
-            if (!hovered) _pressed = false;
-          }),
-          actions: <Type, Action<Intent>>{
-            ActivateIntent: CallbackAction<ActivateIntent>(
-              onInvoke: (_) {
-                widget.onTap();
-                return null;
-              },
-            ),
-          },
-          child: GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTap: widget.onTap,
-            onTapDown: (_) => setState(() => _pressed = true),
-            onTapUp: (_) => setState(() => _pressed = false),
-            onTapCancel: () => setState(() => _pressed = false),
-            child: SizedBox(
-              width: double.infinity,
-              child: AnimatedContainer(
-                duration: AppMotion.short,
-                padding: const EdgeInsetsDirectional.symmetric(
-                  horizontal: AppSpacing.md,
-                  vertical: AppSpacing.sm,
-                ),
-                decoration: BoxDecoration(
-                  color: background,
-                  borderRadius: AppShapes.md,
-                  border: Border.all(
-                    color: _focused ? colors.brandStroke1 : Colors.transparent,
-                    width: 2,
+        builder: (context, states) {
+          final style = _resolveSettingsNavItemStyle(
+            context: context,
+            colors: colors,
+            type: type,
+            states: states,
+            isSelected: isSelected,
+          );
+
+          return SizedBox(
+            width: double.infinity,
+            child: AnimatedContainer(
+              duration: AppMotion.short,
+              padding: const EdgeInsetsDirectional.symmetric(
+                horizontal: AppSpacing.md,
+                vertical: AppSpacing.sm,
+              ),
+              decoration: BoxDecoration(
+                color: style.background,
+                borderRadius: AppShapes.md,
+                border: Border.all(color: style.border, width: 2),
+              ),
+              child: Row(
+                children: [
+                  AnimatedContainer(
+                    duration: AppMotion.short,
+                    width: 4,
+                    height: 24,
+                    margin: const EdgeInsetsDirectional.only(
+                      end: AppSpacing.sm,
+                    ),
+                    decoration: BoxDecoration(
+                      color: style.indicator,
+                      borderRadius: AppShapes.xs,
+                    ),
                   ),
-                ),
-                child: Row(
-                  children: [
-                    AnimatedContainer(
-                      duration: AppMotion.short,
-                      width: 4,
-                      height: 24,
-                      margin: const EdgeInsetsDirectional.only(
-                        end: AppSpacing.sm,
-                      ),
-                      decoration: BoxDecoration(
-                        color: widget.isSelected
-                            ? colors.brandBackground
-                            : Colors.transparent,
-                        borderRadius: AppShapes.xs,
-                      ),
-                    ),
-                    Icon(
-                      widget.icon,
-                      color: widget.isSelected
-                          ? colors.brandForeground1
-                          : colors.neutralForeground2,
-                    ),
-                    const SizedBox(width: AppSpacing.sm),
-                    Expanded(
-                      child: Text(
-                        widget.label,
-                        style: widget.isSelected
-                            ? type.body1Strong.copyWith(
-                                color: colors.brandForeground1,
-                              )
-                            : type.body1,
-                      ),
-                    ),
-                  ],
-                ),
+                  Icon(icon, color: style.foreground),
+                  const SizedBox(width: AppSpacing.sm),
+                  Expanded(child: Text(label, style: style.labelStyle)),
+                ],
               ),
             ),
-          ),
-        ),
+          );
+        },
       ),
     );
   }
+}
+
+class _SettingsNavItemStyle {
+  const _SettingsNavItemStyle({
+    required this.background,
+    required this.border,
+    required this.indicator,
+    required this.foreground,
+    required this.labelStyle,
+  });
+
+  /// 导航项背景色。
+  final Color background;
+
+  /// 导航项焦点描边色。
+  final Color border;
+
+  /// 选中指示条颜色。
+  final Color indicator;
+
+  /// 图标前景色。
+  final Color foreground;
+
+  /// 标签文本样式。
+  final TextStyle labelStyle;
+}
+
+/// 根据 Fluent 交互状态解析设置导航项视觉。
+_SettingsNavItemStyle _resolveSettingsNavItemStyle({
+  required BuildContext context,
+  required FluentColors colors,
+  required FluentTypography type,
+  required Set<WidgetState> states,
+  required bool isSelected,
+}) {
+  final resources = FluentTheme.of(context).resources;
+
+  if (states.isDisabled) {
+    return _SettingsNavItemStyle(
+      background: Colors.transparent,
+      border: Colors.transparent,
+      indicator: Colors.transparent,
+      foreground: colors.neutralForegroundDisabled,
+      labelStyle: type.body1.copyWith(color: colors.neutralForegroundDisabled),
+    );
+  }
+
+  final background = _resolveSettingsNavItemBackground(
+    resources: resources,
+    states: states,
+    isSelected: isSelected,
+  );
+  final foreground = isSelected
+      ? colors.brandForeground1
+      : colors.neutralForeground2;
+
+  return _SettingsNavItemStyle(
+    background: background,
+    border: states.isFocused ? colors.brandStroke1 : Colors.transparent,
+    indicator: isSelected ? colors.brandBackground : Colors.transparent,
+    foreground: foreground,
+    labelStyle: isSelected
+        ? type.body1Strong.copyWith(color: foreground)
+        : type.body1.copyWith(color: foreground),
+  );
+}
+
+/// 对齐 `NavigationPane` 普通导航项的浅色背景状态。
+Color _resolveSettingsNavItemBackground({
+  required ResourceDictionary resources,
+  required Set<WidgetState> states,
+  required bool isSelected,
+}) {
+  if (isSelected) {
+    return states.isHovered || states.isPressed
+        ? resources.subtleFillColorTertiary
+        : resources.subtleFillColorSecondary;
+  }
+
+  if (states.isPressed) return resources.subtleFillColorTertiary;
+  if (states.isHovered) return resources.subtleFillColorSecondary;
+
+  return resources.subtleFillColorTransparent;
 }
 
 /// 构建数值设置框。

--- a/test/fluent_accessibility_test.dart
+++ b/test/fluent_accessibility_test.dart
@@ -6,12 +6,83 @@
  * @Date : 2026-05-31
  */
 
+import 'dart:ui' show PointerDeviceKind;
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sspu_allinone/design/fluent_ui.dart';
 import 'package:sspu_allinone/widgets/settings_widgets.dart';
 
 void main() {
+  Widget buildSettingsNavHarness({
+    int selectedIndex = 0,
+    ValueChanged<int>? onSelected,
+  }) {
+    return FluentApp(
+      home: ScaffoldPage(
+        content: StatefulBuilder(
+          builder: (context, setState) {
+            void selectIndex(int index) {
+              setState(() => selectedIndex = index);
+              onSelected?.call(index);
+            }
+
+            return Column(
+              children: [
+                buildSettingsNavItem(
+                  context: context,
+                  index: 0,
+                  selectedIndex: selectedIndex,
+                  icon: FluentIcons.settings,
+                  label: '常规设置',
+                  onTap: () => selectIndex(0),
+                ),
+                buildSettingsNavItem(
+                  context: context,
+                  index: 1,
+                  selectedIndex: selectedIndex,
+                  icon: FluentIcons.sync,
+                  label: '自动刷新设置',
+                  onTap: () => selectIndex(1),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  BoxDecoration navItemDecoration(WidgetTester tester, String label) {
+    final finder = find.ancestor(
+      of: find.text(label),
+      matching: find.byType(AnimatedContainer),
+    );
+    return tester.widget<AnimatedContainer>(finder.first).decoration!
+        as BoxDecoration;
+  }
+
+  BoxDecoration navItemIndicatorDecoration(WidgetTester tester, String label) {
+    final row = find.ancestor(of: find.text(label), matching: find.byType(Row));
+    final indicator = find.descendant(
+      of: row.first,
+      matching: find.byType(AnimatedContainer),
+    );
+    return tester.widget<AnimatedContainer>(indicator.first).decoration!
+        as BoxDecoration;
+  }
+
+  Icon navItemIcon(WidgetTester tester, String label, IconData icon) {
+    final row = find.ancestor(of: find.text(label), matching: find.byType(Row));
+    return tester.widget<Icon>(
+      find.descendant(of: row.first, matching: find.byIcon(icon)).first,
+    );
+  }
+
+  ResourceDictionary navResources(WidgetTester tester, String label) {
+    return FluentTheme.of(tester.element(find.text(label))).resources;
+  }
+
   testWidgets('FluentSelect 支持键盘打开、移动并选择选项', (tester) async {
     var selectedValue = 0;
 
@@ -59,34 +130,7 @@ void main() {
     var selectedIndex = 0;
 
     await tester.pumpWidget(
-      FluentApp(
-        home: ScaffoldPage(
-          content: StatefulBuilder(
-            builder: (context, setState) {
-              return Column(
-                children: [
-                  buildSettingsNavItem(
-                    context: context,
-                    index: 0,
-                    selectedIndex: selectedIndex,
-                    icon: FluentIcons.settings,
-                    label: '常规设置',
-                    onTap: () => setState(() => selectedIndex = 0),
-                  ),
-                  buildSettingsNavItem(
-                    context: context,
-                    index: 1,
-                    selectedIndex: selectedIndex,
-                    icon: FluentIcons.sync,
-                    label: '自动刷新设置',
-                    onTap: () => setState(() => selectedIndex = 1),
-                  ),
-                ],
-              );
-            },
-          ),
-        ),
-      ),
+      buildSettingsNavHarness(onSelected: (index) => selectedIndex = index),
     );
 
     await tester.sendKeyEvent(LogicalKeyboardKey.tab);
@@ -97,6 +141,120 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(selectedIndex, 1);
+  });
+
+  testWidgets('设置侧栏导航项 hover 移出后恢复默认背景', (tester) async {
+    final previousHighlightStrategy = FocusManager.instance.highlightStrategy;
+    FocusManager.instance.highlightStrategy =
+        FocusHighlightStrategy.alwaysTraditional;
+    addTearDown(() {
+      FocusManager.instance.highlightStrategy = previousHighlightStrategy;
+    });
+
+    await tester.pumpWidget(buildSettingsNavHarness());
+
+    final resources = navResources(tester, '常规设置');
+    final pointer = await tester.createGesture(kind: PointerDeviceKind.mouse);
+
+    expect(
+      navItemDecoration(tester, '自动刷新设置').color,
+      resources.subtleFillColorTransparent,
+    );
+
+    await pointer.moveTo(tester.getCenter(find.text('自动刷新设置')));
+    await tester.pump();
+    expect(
+      navItemDecoration(tester, '自动刷新设置').color,
+      resources.subtleFillColorSecondary,
+    );
+
+    await pointer.moveTo(tester.getCenter(find.text('常规设置')));
+    await tester.pump();
+    expect(
+      navItemDecoration(tester, '自动刷新设置').color,
+      resources.subtleFillColorTransparent,
+    );
+  });
+
+  testWidgets('设置侧栏导航项 selected hover 不覆盖选中身份', (tester) async {
+    final previousHighlightStrategy = FocusManager.instance.highlightStrategy;
+    FocusManager.instance.highlightStrategy =
+        FocusHighlightStrategy.alwaysTraditional;
+    addTearDown(() {
+      FocusManager.instance.highlightStrategy = previousHighlightStrategy;
+    });
+
+    await tester.pumpWidget(buildSettingsNavHarness());
+
+    final colors = tester.element(find.text('常规设置')).fluentColors;
+    final resources = navResources(tester, '常规设置');
+    final pointer = await tester.createGesture(kind: PointerDeviceKind.mouse);
+
+    await pointer.moveTo(tester.getCenter(find.text('常规设置')));
+    await tester.pump();
+
+    expect(
+      navItemDecoration(tester, '常规设置').color,
+      resources.subtleFillColorTertiary,
+    );
+    expect(
+      navItemIndicatorDecoration(tester, '常规设置').color,
+      colors.brandBackground,
+    );
+    expect(
+      navItemIcon(tester, '常规设置', FluentIcons.settings).color,
+      colors.brandForeground1,
+    );
+    expect(
+      tester.widget<Text>(find.text('常规设置')).style?.color,
+      colors.brandForeground1,
+    );
+  });
+
+  testWidgets('设置侧栏导航项键盘焦点只显示焦点边框', (tester) async {
+    await tester.pumpWidget(buildSettingsNavHarness());
+
+    final colors = tester.element(find.text('自动刷新设置')).fluentColors;
+    final resources = navResources(tester, '自动刷新设置');
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+
+    final decoration = navItemDecoration(tester, '自动刷新设置');
+    expect(decoration.color, resources.subtleFillColorTransparent);
+    expect(decoration.border?.top.color, colors.brandStroke1);
+  });
+
+  testWidgets('设置侧栏导航项快速划过时旧项不残留 hover 背景', (tester) async {
+    final previousHighlightStrategy = FocusManager.instance.highlightStrategy;
+    FocusManager.instance.highlightStrategy =
+        FocusHighlightStrategy.alwaysTraditional;
+    addTearDown(() {
+      FocusManager.instance.highlightStrategy = previousHighlightStrategy;
+    });
+
+    await tester.pumpWidget(buildSettingsNavHarness());
+
+    final resources = navResources(tester, '常规设置');
+    final pointer = await tester.createGesture(kind: PointerDeviceKind.mouse);
+
+    await pointer.moveTo(tester.getCenter(find.text('自动刷新设置')));
+    await tester.pump();
+    await pointer.moveTo(tester.getCenter(find.text('常规设置')));
+    await tester.pump();
+    await pointer.moveTo(tester.getCenter(find.text('自动刷新设置')));
+    await tester.pump();
+
+    expect(
+      navItemDecoration(tester, '常规设置').color,
+      resources.subtleFillColorSecondary,
+    );
+    expect(
+      navItemDecoration(tester, '自动刷新设置').color,
+      resources.subtleFillColorSecondary,
+    );
   });
 
   testWidgets('FluentSurface 和 FluentCard 支持键盘激活', (tester) async {


### PR DESCRIPTION
## 变更说明

- 修复设置页侧边导航项鼠标移入 / 移出时闪现深色背景的问题。
- 将设置侧栏导航项的本地 `_hovered` / `_pressed` / `_focused` 状态机替换为 `HoverButton` 提供的统一 `WidgetState`。
- 背景状态对齐普通 `NavigationPane` 的 subtle fill 规则，避免 selected / hover 走品牌色深色填充。
- 补充 widget 回归测试覆盖 hover 移入移出、selected + hover、键盘 focus、快速划过多个导航项。

## 根因

设置侧栏导航项此前用自定义状态机叠加 AnimatedContainer，并使用 `brandBackgroundSelected.withValues(alpha: 0.12)` 作为选中背景。鼠标进入或离开导航项时，selected / hover / focus 背景在品牌色和中性 hover 色之间切换，视觉上会闪一下较深的样式。

## 验证记录

- `flutter test test\fluent_accessibility_test.dart`
- `flutter analyze --no-fatal-infos`

## 影响范围

- 设置页桌面侧边导航交互状态
- 不改窄屏下拉导航，不改设置页分区数据流

Closes #171
