### PR TITLE
feat(eams): 展示加密学籍信息卡片

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -61,6 +61,7 @@ class _AppShellState extends State<AppShell> {
       selectedIcon: FluentIcons.home,
       body: HomePage(
         campusNetworkStatusService: widget.campusNetworkStatusService,
+        onOpenSettings: () => _selectDestination(6),
       ),
     ),
     const _AppDestination(

--- a/lib/models/academic_eams/profile.dart
+++ b/lib/models/academic_eams/profile.dart
@@ -14,6 +14,9 @@ class AcademicEamsProfile {
     required this.department,
     required this.major,
     required this.className,
+    required this.gender,
+    required this.studyLength,
+    required this.educationLevel,
     required this.rawFields,
   });
 
@@ -32,6 +35,15 @@ class AcademicEamsProfile {
   /// 班级名称。
   final String? className;
 
+  /// 性别。
+  final String? gender;
+
+  /// 学制。
+  final String? studyLength;
+
+  /// 学历层次。
+  final String? educationLevel;
+
   /// 原始字段集合，供页面结构变化时回退展示。
   final Map<String, String> rawFields;
 
@@ -39,10 +51,13 @@ class AcademicEamsProfile {
   factory AcademicEamsProfile.fromJson(Map<String, dynamic> json) {
     return AcademicEamsProfile(
       name: json['name'] as String?,
-      studentId: null,
+      studentId: json['studentId'] as String?,
       department: json['department'] as String?,
       major: json['major'] as String?,
       className: json['className'] as String?,
+      gender: json['gender'] as String?,
+      studyLength: json['studyLength'] as String?,
+      educationLevel: json['educationLevel'] as String?,
       rawFields: const {},
     );
   }
@@ -51,10 +66,19 @@ class AcademicEamsProfile {
   Map<String, dynamic> toJson() {
     return {
       'name': name,
+      'studentId': studentId,
       'department': department,
       'major': major,
       'className': className,
+      'gender': gender,
+      'studyLength': studyLength,
+      'educationLevel': educationLevel,
     };
+  }
+
+  /// 转换为普通缓存可持久化 JSON，移除学籍明文字段。
+  Map<String, dynamic> toPublicCacheJson() {
+    return {'hasProfile': hasAnyValue};
   }
 
   /// 是否至少解析出一个核心字段。
@@ -65,6 +89,20 @@ class AcademicEamsProfile {
       department,
       major,
       className,
+      gender,
+      studyLength,
+      educationLevel,
     ].any((value) => value != null && value.trim().isNotEmpty);
+  }
+
+  /// 首页学籍卡片所需字段是否完整。
+  bool get hasHomeSummary {
+    return [
+      name,
+      studentId,
+      department,
+      major,
+      className,
+    ].every((value) => value != null && value.trim().isNotEmpty);
   }
 }

--- a/lib/models/academic_eams/snapshot.dart
+++ b/lib/models/academic_eams/snapshot.dart
@@ -115,7 +115,7 @@ class AcademicEamsSnapshot {
       'warnings': warnings,
       'hasCourseOfferingEntry': hasCourseOfferingEntry,
       'hasFreeClassroomEntry': hasFreeClassroomEntry,
-      'profile': profile?.toJson(),
+      'profile': profile?.toPublicCacheJson(),
       'courseTable': courseTable?.toJson(),
       'grades': grades?.toJson(),
       'programPlan': programPlan?.toJson(),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -11,12 +11,16 @@ import 'dart:async';
 import '../design/fluent_ui.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import '../models/campus_card.dart';
+import '../models/academic_credentials.dart';
+import '../models/academic_eams.dart';
 import '../models/message_item.dart';
 import '../services/academic_credentials_service.dart';
+import '../services/academic_eams_service.dart';
 import '../services/app_display_name_service.dart';
 import '../services/campus_card_service.dart';
 import '../services/campus_network_status_service.dart';
 import '../services/message_state_service.dart';
+import '../services/storage_service.dart';
 import '../theme/fluent_tokens.dart';
 import '../utils/webview_env.dart';
 import '../widgets/campus_network_status_indicator.dart';
@@ -25,6 +29,7 @@ import 'webview_page.dart';
 
 part 'home_campus_card_balance_card.dart';
 part 'home_campus_card_detail_page.dart';
+part 'home_student_profile_card.dart';
 
 /// 主页
 /// 展示欢迎信息与最新消息列表
@@ -41,12 +46,20 @@ class HomePage extends StatefulWidget {
   /// 测试专用：覆盖校园卡余额自动刷新间隔。
   final int? campusCardAutoRefreshIntervalOverride;
 
+  /// 本专科教务服务，测试中可替换为 fake。
+  final AcademicEamsClient? academicEamsService;
+
+  /// 打开设置页回调。
+  final VoidCallback? onOpenSettings;
+
   const HomePage({
     super.key,
     this.campusCardService,
     this.campusNetworkStatusService,
     this.campusCardAutoRefreshEnabledOverride,
     this.campusCardAutoRefreshIntervalOverride,
+    this.academicEamsService,
+    this.onOpenSettings,
   });
 
   @override
@@ -58,6 +71,11 @@ class _HomePageState extends State<HomePage> {
   List<MessageItem> _latestMessages = [];
 
   CampusCardQueryResult? _campusCardResult;
+  AcademicCredentialsStatus _credentialsStatus =
+      const AcademicCredentialsStatus.empty();
+  AcademicEamsProfile? _studentProfile;
+  bool _isLoadingStudentProfile = false;
+  bool _studentProfileCardVisible = true;
   bool _isLoadingCampusCard = false;
   bool _campusCardAutoRefreshEnabled = false;
   Timer? _campusCardAutoRefreshTimer;
@@ -67,12 +85,20 @@ class _HomePageState extends State<HomePage> {
     return widget.campusCardService ?? CampusCardService.instance;
   }
 
+  AcademicEamsClient get _academicEamsService {
+    return widget.academicEamsService ?? AcademicEamsService.instance;
+  }
+
   @override
   void initState() {
     super.initState();
     _credentialChangeSubscription = AcademicCredentialsService.instance.changes
-        .listen((_) => _clearAuthenticatedState());
+        .listen((_) {
+          _clearAuthenticatedState();
+          unawaited(_loadStudentProfileCard(forceRefresh: true));
+        });
     _loadLatestMessages();
+    _loadStudentProfileCard();
     _loadCampusCardCacheAndSettings();
   }
 
@@ -80,7 +106,38 @@ class _HomePageState extends State<HomePage> {
     if (!mounted) return;
     setState(() {
       _campusCardResult = null;
+      _studentProfile = null;
+      _credentialsStatus = const AcademicCredentialsStatus.empty();
+      _isLoadingStudentProfile = false;
       _isLoadingCampusCard = false;
+    });
+  }
+
+  /// 读取首页学籍卡片设置和安全缓存，必要时静默补全。
+  Future<void> _loadStudentProfileCard({bool forceRefresh = false}) async {
+    final visible = await StorageService.getBool(
+      StorageKeys.homeStudentProfileCardVisible,
+      defaultValue: true,
+    );
+    final status = await AcademicCredentialsService.instance.getStatus();
+    final cachedProfile = await _academicEamsService.readCachedStudentProfile();
+    if (!mounted) return;
+    setState(() {
+      _studentProfileCardVisible = visible;
+      _credentialsStatus = status;
+      _studentProfile = cachedProfile;
+    });
+    if (!visible || status.oaAccount.trim().isEmpty || !status.hasOaPassword) {
+      return;
+    }
+    if (!forceRefresh && cachedProfile?.hasHomeSummary == true) return;
+    setState(() => _isLoadingStudentProfile = true);
+    final refreshedProfile = await _academicEamsService
+        .refreshStudentProfileIfIncomplete(forceRefresh: forceRefresh);
+    if (!mounted) return;
+    setState(() {
+      _studentProfile = refreshedProfile ?? _studentProfile;
+      _isLoadingStudentProfile = false;
     });
   }
 
@@ -247,8 +304,19 @@ class _HomePageState extends State<HomePage> {
 
             const SizedBox(height: FluentSpacing.l),
 
+            if (_studentProfileCardVisible) ...[
+              _buildStudentProfileCard(context)
+                  .animate(delay: 100.ms)
+                  .fadeIn(
+                    duration: FluentDuration.slow,
+                    curve: FluentEasing.decelerate,
+                  )
+                  .slideY(begin: 0.05, end: 0),
+              const SizedBox(height: FluentSpacing.l),
+            ],
+
             _buildCampusCardBalanceCard(context)
-                .animate(delay: 100.ms)
+                .animate(delay: 150.ms)
                 .fadeIn(
                   duration: FluentDuration.slow,
                   curve: FluentEasing.decelerate,
@@ -297,7 +365,7 @@ class _HomePageState extends State<HomePage> {
                     ],
                   ),
                 )
-                .animate(delay: 200.ms)
+                .animate(delay: 250.ms)
                 .fadeIn(
                   duration: FluentDuration.slow,
                   curve: FluentEasing.decelerate,

--- a/lib/pages/home_student_profile_card.dart
+++ b/lib/pages/home_student_profile_card.dart
@@ -1,0 +1,163 @@
+/*
+ * 主页学籍信息卡片 — 展示本专科教务学籍摘要
+ * @Project : SSPU-AllinOne
+ * @File : home_student_profile_card.dart
+ * @Author : Qintsg
+ * @Date : 2026-06-09
+ */
+
+part of 'home_page.dart';
+
+extension _HomeStudentProfileCard on _HomePageState {
+  /// 构建首页学籍信息卡片。
+  Widget _buildStudentProfileCard(BuildContext context) {
+    final theme = FluentTheme.of(context);
+    final profile = _studentProfile;
+    final hasCredentials =
+        _credentialsStatus.oaAccount.trim().isNotEmpty &&
+        _credentialsStatus.hasOaPassword;
+
+    return FluentSurface(
+      key: const Key('home-student-profile-card'),
+      padding: const EdgeInsets.all(FluentSpacing.l),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(child: Text('学籍信息', style: theme.typography.subtitle)),
+              Text(
+                '本专科教务',
+                style: theme.typography.caption?.copyWith(
+                  color: theme.resources.textFillColorSecondary,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: FluentSpacing.xl),
+          if (!hasCredentials) ...[
+            Text('需要先保存 OA 账号密码', style: theme.typography.bodyStrong),
+            const SizedBox(height: FluentSpacing.xs),
+            Text(
+              '学籍信息会在保存后自动读取',
+              style: theme.typography.caption?.copyWith(
+                color: theme.resources.textFillColorSecondary,
+              ),
+            ),
+            const SizedBox(height: FluentSpacing.m),
+            Align(
+              alignment: Alignment.centerRight,
+              child: FluentButton.primary(
+                onPressed: widget.onOpenSettings,
+                child: const Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(FluentIcons.settings, size: 14),
+                    SizedBox(width: 6),
+                    Text('前往设置'),
+                  ],
+                ),
+              ),
+            ),
+          ] else if (_isLoadingStudentProfile && profile == null) ...[
+            const Row(
+              children: [
+                SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: FluentProgressRing(strokeWidth: 2),
+                ),
+                SizedBox(width: FluentSpacing.s),
+                Text('正在读取学籍信息...'),
+              ],
+            ),
+          ] else if (profile == null || !profile.hasAnyValue) ...[
+            Text('暂未读取到学籍信息', style: theme.typography.bodyStrong),
+            const SizedBox(height: FluentSpacing.xs),
+            Text(
+              '应用会在启动或更新 OA 凭据后自动尝试补全',
+              style: theme.typography.caption?.copyWith(
+                color: theme.resources.textFillColorSecondary,
+              ),
+            ),
+          ] else ...[
+            _buildStudentProfileSummary(context, profile),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStudentProfileSummary(
+    BuildContext context,
+    AcademicEamsProfile profile,
+  ) {
+    final theme = FluentTheme.of(context);
+    final name = _profileValue(profile.name);
+    final studentId = _profileValue(profile.studentId);
+    final department = _profileValue(profile.department);
+    final major = _profileValue(profile.major);
+    final className = _profileValue(profile.className);
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final compact = constraints.maxWidth < 520;
+        if (compact) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(child: Text(name, style: theme.typography.subtitle)),
+                  Text(studentId, style: theme.typography.bodyStrong),
+                ],
+              ),
+              const SizedBox(height: FluentSpacing.m),
+              Text(
+                department,
+                style: theme.typography.body?.copyWith(
+                  color: theme.resources.textFillColorSecondary,
+                ),
+              ),
+              const SizedBox(height: FluentSpacing.xs),
+              Row(
+                children: [
+                  Expanded(child: Text(major)),
+                  Text(className),
+                ],
+              ),
+            ],
+          );
+        }
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(child: Text(name, style: theme.typography.subtitle)),
+                Text(studentId, style: theme.typography.bodyStrong),
+              ],
+            ),
+            const SizedBox(height: FluentSpacing.m),
+            Row(
+              children: [
+                Expanded(flex: 3, child: Text(department)),
+                Expanded(flex: 2, child: Text(major)),
+                Expanded(
+                  flex: 2,
+                  child: Text(className, textAlign: TextAlign.end),
+                ),
+              ],
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  String _profileValue(String? value) {
+    final normalized = value?.trim();
+    return normalized == null || normalized.isEmpty ? '未读取' : normalized;
+  }
+}

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -90,6 +90,10 @@ class _SettingsPageState extends State<SettingsPage>
   @override
   bool _dndEnabled = false;
 
+  /// 首页是否显示学籍信息卡片。
+  @override
+  bool _homeStudentProfileCardVisible = true;
+
   /// 勿扰开始时间。
   @override
   int _dndStartHour = 22;

--- a/lib/pages/settings_page_actions.dart
+++ b/lib/pages/settings_page_actions.dart
@@ -32,6 +32,9 @@ mixin _SettingsPageActions on State<SettingsPage> {
   bool get _dndEnabled;
   set _dndEnabled(bool value);
 
+  bool get _homeStudentProfileCardVisible;
+  set _homeStudentProfileCardVisible(bool value);
+
   int get _dndStartHour;
   set _dndStartHour(int value);
 
@@ -89,6 +92,10 @@ mixin _SettingsPageActions on State<SettingsPage> {
 
     final notifEnabled = await _messageState.isNotificationEnabled();
     final dndOn = await _messageState.isDndEnabled();
+    final homeStudentProfileCardVisible = await StorageService.getBool(
+      StorageKeys.homeStudentProfileCardVisible,
+      defaultValue: true,
+    );
     final dndStartHour = await _messageState.getDndStartHour();
     final dndStartMinute = await _messageState.getDndStartMinute();
     final dndEndHour = await _messageState.getDndEndHour();
@@ -127,6 +134,7 @@ mixin _SettingsPageActions on State<SettingsPage> {
       _closeBehavior = behavior;
       _notificationEnabled = notifEnabled;
       _dndEnabled = dndOn;
+      _homeStudentProfileCardVisible = homeStudentProfileCardVisible;
       _dndStartHour = dndStartHour;
       _dndStartMinute = dndStartMinute;
       _dndEndHour = dndEndHour;
@@ -185,6 +193,16 @@ mixin _SettingsPageActions on State<SettingsPage> {
     await _messageState.setDndEnabled(enabled);
     if (!mounted) return;
     setState(() => _dndEnabled = enabled);
+  }
+
+  /// 修改首页学籍信息卡片显示开关。
+  Future<void> _onHomeStudentProfileCardVisibleChanged(bool visible) async {
+    await StorageService.setBool(
+      StorageKeys.homeStudentProfileCardVisible,
+      visible,
+    );
+    if (!mounted) return;
+    setState(() => _homeStudentProfileCardVisible = visible);
   }
 
   /// 修改勿扰开始时间。

--- a/lib/pages/settings_page_layout.dart
+++ b/lib/pages/settings_page_layout.dart
@@ -202,6 +202,7 @@ mixin _SettingsPageLayout on State<SettingsPage>, _SettingsPageActions {
           closeBehavior: _closeBehavior,
           notificationEnabled: _notificationEnabled,
           dndEnabled: _dndEnabled,
+          homeStudentProfileCardVisible: _homeStudentProfileCardVisible,
           dndStartHour: _dndStartHour,
           dndStartMinute: _dndStartMinute,
           dndEndHour: _dndEndHour,
@@ -209,6 +210,8 @@ mixin _SettingsPageLayout on State<SettingsPage>, _SettingsPageActions {
           onCloseBehaviorChanged: _onCloseBehaviorChanged,
           onNotificationChanged: _onNotificationChanged,
           onDndChanged: _onDndChanged,
+          onHomeStudentProfileCardVisibleChanged:
+              _onHomeStudentProfileCardVisibleChanged,
           onDndStartChanged: _onDndStartChanged,
           onDndEndChanged: _onDndEndChanged,
         );

--- a/lib/services/academic_credentials_service.dart
+++ b/lib/services/academic_credentials_service.dart
@@ -12,6 +12,7 @@ import 'dart:convert';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import '../models/academic_credentials.dart';
+import '../models/academic_eams.dart';
 import '../models/academic_login_validation.dart';
 import 'authenticated_data_cache_service.dart';
 import 'storage_service.dart';
@@ -44,6 +45,9 @@ class AcademicCredentialsService {
 
   /// OA 登录会话快照存储键，保存 Cookie 等可复用身份信息。
   static const String _oaLoginSessionKey = 'academic_login_session_snapshot';
+
+  /// 学籍信息安全缓存存储键。
+  static const String _studentProfileKey = 'academic_student_profile_snapshot';
 
   /// 系统安全存储实例。
   /// Android 端由 flutter_secure_storage 使用当前默认加密实现托管密钥。
@@ -88,12 +92,15 @@ class AcademicCredentialsService {
         hasOaAccountChanged || (oaPassword != null && oaPassword.isNotEmpty);
 
     if (shouldClearOaSession) await clearOaLoginSession();
+    if (hasOaAccountChanged) await clearStudentProfile();
     await _writeOrDeleteWhenBlank(_oaAccountKey, normalizedOaAccount);
     await _secureStorage.delete(key: _legacyEmailAccountKey);
     await _writeWhenPresent(_oaPasswordKey, oaPassword);
     await _writeWhenPresent(_sportsQueryPasswordKey, sportsQueryPassword);
     await _writeWhenPresent(_emailPasswordKey, emailPassword);
-    if (hasOaAccountChanged) _notifyChanged();
+    if (hasOaAccountChanged || (oaPassword != null && oaPassword.isNotEmpty)) {
+      _notifyChanged();
+    }
   }
 
   /// 读取指定密码字段原文，供后续登录外部网站使用。
@@ -171,11 +178,55 @@ class AcademicCredentialsService {
     await _secureStorage.delete(key: _oaLoginSessionKey);
   }
 
+  /// 保存当前 OA 账号绑定的学籍信息。
+  Future<void> saveStudentProfile(AcademicEamsProfile profile) async {
+    final ownerAccount = _normalizeAccount(
+      await _readValue(_oaAccountKey) ?? '',
+    );
+    if (ownerAccount.isEmpty || !profile.hasAnyValue) return;
+    final ownerHash = _ownerAccountHash(ownerAccount);
+    if (ownerHash.isEmpty) return;
+    final payload = Map<String, dynamic>.from(profile.toJson());
+    payload['ownerAccount'] = ownerHash;
+    payload['savedAt'] = DateTime.now().toUtc().toIso8601String();
+    await _secureStorage.write(
+      key: _studentProfileKey,
+      value: jsonEncode(payload),
+    );
+  }
+
+  /// 读取当前 OA 账号绑定的学籍信息。
+  Future<AcademicEamsProfile?> readStudentProfile() async {
+    final payload = await _readValue(_studentProfileKey);
+    if (payload == null || payload.trim().isEmpty) return null;
+    try {
+      final decoded = jsonDecode(payload) as Map<String, dynamic>;
+      final ownerAccount = _normalizeAccount(
+        await _readValue(_oaAccountKey) ?? '',
+      );
+      if (ownerAccount.isEmpty ||
+          decoded['ownerAccount'] != _ownerAccountHash(ownerAccount)) {
+        return null;
+      }
+      return AcademicEamsProfile.fromJson(decoded);
+    } catch (_) {
+      await clearStudentProfile();
+      return null;
+    }
+  }
+
+  /// 清除学籍信息安全缓存。
+  Future<void> clearStudentProfile() async {
+    await _secureStorage.delete(key: _studentProfileKey);
+  }
+
   /// 清除指定密码字段。
   Future<void> clearSecret(AcademicCredentialSecret secret) async {
     await _secureStorage.delete(key: _keyOf(secret));
     if (secret == AcademicCredentialSecret.oaPassword) {
       await clearOaLoginSession();
+      await clearStudentProfile();
+      _notifyChanged();
     }
   }
 
@@ -196,6 +247,7 @@ class AcademicCredentialsService {
     _sportsQueryPasswordKey,
     _emailPasswordKey,
     _oaLoginSessionKey,
+    _studentProfileKey,
   ];
 
   /// 读取单个安全存储值。
@@ -243,6 +295,14 @@ class AcademicCredentialsService {
     if (normalizedOwnerAccount.isEmpty || oaPassword.isEmpty) return '';
     return StorageService.hashPassword(
       'academic-login-session:$normalizedOwnerAccount:$oaPassword',
+    );
+  }
+
+  String _ownerAccountHash(String ownerAccount) {
+    final normalizedOwnerAccount = _normalizeAccount(ownerAccount);
+    if (normalizedOwnerAccount.isEmpty) return '';
+    return StorageService.hashPassword(
+      'academic-student-profile:$normalizedOwnerAccount',
     );
   }
 

--- a/lib/services/academic_eams_discovery.dart
+++ b/lib/services/academic_eams_discovery.dart
@@ -46,23 +46,30 @@ extension _AcademicEamsDiscovery on AcademicEamsService {
       ..._extractReadonlyEntries(homeSnapshot),
     ];
     var discoveryHadFailure = false;
-    for (var menuId = 1; menuId <= 60; menuId++) {
+    final attemptedSubmenuUris = <String>{};
+
+    Future<void> fetchSubmenu(Uri submenuUri) async {
+      if (!attemptedSubmenuUris.add(submenuUri.toString())) return;
       try {
-        final snapshot = await _gateway.fetchPage(
-          submenuBaseUri.replace(queryParameters: {'menu.id': '$menuId'}),
-          timeout,
-        );
+        final snapshot = await _gateway.fetchPage(submenuUri, timeout);
         if (_isAuthenticationRequired(snapshot) || _isUnavailable(snapshot)) {
-          continue;
+          return;
         }
         entries.addAll(_extractReadonlyEntries(snapshot));
       } on DioException catch (_) {
         discoveryHadFailure = true;
-        continue;
       } on TimeoutException catch (_) {
         discoveryHadFailure = true;
-        continue;
       }
+    }
+
+    for (final submenuUri in _rootSubmenuUris()) {
+      await fetchSubmenu(submenuUri);
+    }
+    for (var menuId = 1; menuId <= 60; menuId++) {
+      await fetchSubmenu(
+        submenuBaseUri.replace(queryParameters: {'menu.id': '$menuId'}),
+      );
     }
 
     final featureUris = <_AcademicFeature, Uri>{};
@@ -74,19 +81,25 @@ extension _AcademicEamsDiscovery on AcademicEamsService {
       if (!matchedEntry.isEmpty) featureUris[feature] = matchedEntry.uri;
     }
 
-    final fallbackCandidates = <_AcademicFeature, String>{
-      _AcademicFeature.courseTable: 'courseTableForStd.action',
-      _AcademicFeature.gradeCurrent: 'teach/grade/course/person.action',
-      _AcademicFeature.gradeHistory:
-          'teach/grade/course/person!historyCourseGrade.action?projectType=MAJOR',
-      _AcademicFeature.programPlan: 'teach/program/student/myPlan.action',
-      _AcademicFeature.exams: 'stdExamTable.action',
-      _AcademicFeature.courseOfferingsEntry: 'publicSearch.action',
+    final fallbackCandidates = <_AcademicFeature, List<String>>{
+      _AcademicFeature.studentProfile: ['studentDetail.action', 'std.action'],
+      _AcademicFeature.courseTable: ['courseTableForStd.action'],
+      _AcademicFeature.gradeCurrent: ['teach/grade/course/person.action'],
+      _AcademicFeature.gradeHistory: [
+        'teach/grade/course/person!historyCourseGrade.action?projectType=MAJOR',
+      ],
+      _AcademicFeature.programPlan: ['teach/program/student/myPlan.action'],
+      _AcademicFeature.exams: ['stdExamTable.action'],
+      _AcademicFeature.courseOfferingsEntry: ['publicSearch.action'],
     };
     for (final entry in fallbackCandidates.entries) {
       if (featureUris.containsKey(entry.key)) continue;
-      if (await _verifyReadonlyPage(homeUri.resolve(entry.value))) {
-        featureUris[entry.key] = homeUri.resolve(entry.value);
+      for (final candidate in entry.value) {
+        final candidateUri = homeUri.resolve(candidate);
+        if (await _verifyReadonlyPage(candidateUri)) {
+          featureUris[entry.key] = candidateUri;
+          break;
+        }
       }
     }
 
@@ -112,6 +125,13 @@ extension _AcademicEamsDiscovery on AcademicEamsService {
     final label = entry.label.replaceAll(RegExp(r'\s+'), '');
     final path = entry.uri.path.toLowerCase();
     return switch (feature) {
+      _AcademicFeature.studentProfile =>
+        path.contains('/studentdetail.action') ||
+            path.contains('/std.action') ||
+            path.contains('student') && label.contains('个人') ||
+            label.contains('学籍信息') ||
+            label.contains('个人信息') ||
+            label.contains('学生信息'),
       _AcademicFeature.courseTable =>
         path.contains('coursetableforstd.action') || label.contains('课表'),
       _AcademicFeature.gradeCurrent =>
@@ -133,6 +153,11 @@ extension _AcademicEamsDiscovery on AcademicEamsService {
             path.contains('free') ||
             path.contains('classroom'),
     };
+  }
+
+  Iterable<Uri> _rootSubmenuUris() sync* {
+    yield submenuBaseUri.replace(queryParameters: {'menu.id': ''});
+    yield submenuBaseUri;
   }
 
   bool _isAuthenticationRequired(AcademicEamsHttpSnapshot snapshot) {
@@ -188,6 +213,7 @@ extension _AcademicEamsDiscovery on AcademicEamsService {
   String _featureLabel(_AcademicFeature feature) {
     return switch (feature) {
       _AcademicFeature.courseTable => '课表',
+      _AcademicFeature.studentProfile => '学籍信息',
       _AcademicFeature.gradeCurrent => '当前成绩',
       _AcademicFeature.gradeHistory => '历史成绩',
       _AcademicFeature.programPlan => '培养计划',

--- a/lib/services/academic_eams_overview_flow.dart
+++ b/lib/services/academic_eams_overview_flow.dart
@@ -72,6 +72,19 @@ extension _AcademicEamsOverviewFlow on AcademicEamsService {
         if (!await _hasSameOaCredentials(oaAccount, oaPassword)) {
           return _credentialsChangedResult(campusStatus, result.finalUri);
         }
+        final profile = result.snapshot!.profile;
+        final parsedStudentId = profile?.studentId?.trim();
+        if (parsedStudentId != null &&
+            parsedStudentId.isNotEmpty &&
+            parsedStudentId != oaAccount) {
+          return _studentProfileOwnerMismatchResult(
+            campusStatus,
+            result.finalUri,
+          );
+        }
+        if (profile != null && profile.hasHomeSummary) {
+          await _credentialsService.saveStudentProfile(profile);
+        }
         await _saveAcademicEamsCache(
           scope: scope,
           accountKey: oaAccount,
@@ -139,6 +152,19 @@ extension _AcademicEamsOverviewFlow on AcademicEamsService {
       AcademicEamsQueryStatus.unexpectedError,
       message: '本专科教务查询已取消',
       detail: '教务凭据已在查询过程中变更，已丢弃本次教务结果。',
+      finalUri: finalUri,
+      campusNetworkStatus: campusStatus,
+    );
+  }
+
+  AcademicEamsQueryResult _studentProfileOwnerMismatchResult(
+    CampusNetworkStatus? campusStatus,
+    Uri? finalUri,
+  ) {
+    return _buildResult(
+      AcademicEamsQueryStatus.unexpectedError,
+      message: '学籍信息账号不一致',
+      detail: '本专科教务页面返回的学号与当前 OA 账号不一致，已丢弃本次学籍信息。',
       finalUri: finalUri,
       campusNetworkStatus: campusStatus,
     );
@@ -293,6 +319,12 @@ extension _AcademicEamsOverviewFlow on AcademicEamsService {
 
     if (scope == _AcademicFetchScope.overview) {
       await _fetchOptionalFeature(
+        _AcademicFeature.studentProfile,
+        featureUris,
+        featureSnapshots,
+        warnings,
+      );
+      await _fetchOptionalFeature(
         _AcademicFeature.gradeCurrent,
         featureUris,
         featureSnapshots,
@@ -331,8 +363,15 @@ extension _AcademicEamsOverviewFlow on AcademicEamsService {
       await _resolveOptionalFeatureSnapshots(featureSnapshots, warnings);
     }
 
-    final allSnapshots = [homeSnapshot, ...featureSnapshots.values];
-    final profile = _parseProfile(allSnapshots);
+    final studentProfileSnapshot =
+        featureSnapshots[_AcademicFeature.studentProfile];
+    final profile = studentProfileSnapshot == null
+        ? _parseProfile([
+            homeSnapshot,
+            for (final entry in featureSnapshots.entries)
+              if (entry.key != _AcademicFeature.studentProfile) entry.value,
+          ])
+        : _parseProfile([studentProfileSnapshot]);
     final courseTable = courseSnapshot == null
         ? null
         : _parseCourseTable(courseSnapshot);

--- a/lib/services/academic_eams_page_parser.dart
+++ b/lib/services/academic_eams_page_parser.dart
@@ -167,16 +167,17 @@ List<_AcademicReadonlyEntry> _extractReadonlyEntries(
   for (final element in document.querySelectorAll('a,span,div,li')) {
     final text = _cleanText(element.text);
     if (text.isEmpty || !keywords.any(text.contains)) continue;
-    final rawUri =
-        element.attributes['href'] ??
-        element.attributes['url'] ??
-        element.attributes['menuurl'] ??
-        '';
+    final href = element.attributes['href']?.trim() ?? '';
+    final rawUri = href == '#'
+        ? ''
+        : href.isNotEmpty
+        ? href
+        : element.attributes['url'] ?? element.attributes['menuurl'] ?? '';
     final onclick = element.attributes['onclick'] ?? '';
     final target = rawUri.isNotEmpty
         ? rawUri
         : _extractActionFromOnclick(onclick);
-    if (target.isEmpty) continue;
+    if (target.isEmpty || target == '#') continue;
     final uri = snapshot.finalUri.resolve(target);
     final key = '$text|$uri';
     if (!seen.add(key) || !_isReadonlyEntry(text, uri)) continue;

--- a/lib/services/academic_eams_page_parser_profile.dart
+++ b/lib/services/academic_eams_page_parser_profile.dart
@@ -20,20 +20,28 @@ AcademicEamsProfile? _parseProfile(List<AcademicEamsHttpSnapshot> snapshots) {
           .toList();
       if (cells.length < 2) continue;
       for (var index = 0; index < cells.length - 1; index++) {
-        final label = cells[index].replaceAll(RegExp(r'[:：]$'), '').trim();
+        final label = _normalizeProfileLabel(cells[index]);
         final value = cells[index + 1].trim();
-        if (_looksLikeProfileLabel(label) && value.isNotEmpty) {
+        if (_looksLikeProfileLabel(label) &&
+            value.isNotEmpty &&
+            !_looksLikeProfileLabel(_normalizeProfileLabel(value))) {
           rawFields.putIfAbsent(label, () => value);
         }
       }
     }
+    _captureProfileFromTables(rawFields, document);
 
     final bodyText = _cleanText(document.body?.text ?? snapshot.body);
     _captureProfileByRegex(rawFields, bodyText, '姓名');
     _captureProfileByRegex(rawFields, bodyText, '学号');
     _captureProfileByRegex(rawFields, bodyText, '院系');
+    _captureProfileByRegex(rawFields, bodyText, '学院');
     _captureProfileByRegex(rawFields, bodyText, '专业');
+    _captureProfileByRegex(rawFields, bodyText, '行政班级');
     _captureProfileByRegex(rawFields, bodyText, '班级');
+    _captureProfileByRegex(rawFields, bodyText, '性别');
+    _captureProfileByRegex(rawFields, bodyText, '学制');
+    _captureProfileByRegex(rawFields, bodyText, '学历层次');
   }
 
   if (rawFields.isEmpty) return null;
@@ -42,8 +50,53 @@ AcademicEamsProfile? _parseProfile(List<AcademicEamsHttpSnapshot> snapshots) {
     studentId: rawFields['学号'] ?? rawFields['学工号'],
     department: rawFields['院系'] ?? rawFields['学院'],
     major: rawFields['专业'],
-    className: rawFields['班级'],
+    className: rawFields['行政班级'] ?? rawFields['班级'],
+    gender: rawFields['性别'],
+    studyLength: rawFields['学制'],
+    educationLevel: rawFields['学历层次'] ?? rawFields['培养层次'],
     rawFields: Map.unmodifiable(rawFields),
   );
   return profile.hasAnyValue ? profile : null;
+}
+
+void _captureProfileFromTables(
+  Map<String, String> rawFields,
+  html_dom.Document document,
+) {
+  for (final table in document.querySelectorAll('table')) {
+    final rows = table.querySelectorAll('tr');
+    if (rows.length < 2) continue;
+    final headers = rows.first
+        .querySelectorAll('th,td')
+        .map((cell) => _normalizeProfileLabel(_cleanText(cell.text)))
+        .toList();
+    if (headers.where(_looksLikeProfileLabel).length < 2) continue;
+    for (final row in rows.skip(1)) {
+      final values = row
+          .querySelectorAll('th,td')
+          .map((cell) => _cleanText(cell.text))
+          .toList();
+      if (values.length < 2) continue;
+      for (
+        var index = 0;
+        index < headers.length && index < values.length;
+        index++
+      ) {
+        final label = headers[index];
+        final value = values[index];
+        if (_looksLikeProfileLabel(label) && value.isNotEmpty) {
+          rawFields.putIfAbsent(label, () => value);
+        }
+      }
+      break;
+    }
+  }
+}
+
+String _normalizeProfileLabel(String value) {
+  return _cleanText(value)
+      .replaceAll(RegExp(r'[:：]$'), '')
+      .replaceAll('所在', '')
+      .replaceAll('名称', '')
+      .trim();
 }

--- a/lib/services/academic_eams_page_parser_tables.dart
+++ b/lib/services/academic_eams_page_parser_tables.dart
@@ -151,7 +151,21 @@ String _weekdayLabel(int weekday) {
 }
 
 bool _looksLikeProfileLabel(String text) {
-  return ['姓名', '学生姓名', '学号', '学工号', '院系', '学院', '专业', '班级'].contains(text);
+  return [
+    '姓名',
+    '学生姓名',
+    '学号',
+    '学工号',
+    '院系',
+    '学院',
+    '专业',
+    '行政班级',
+    '班级',
+    '性别',
+    '学制',
+    '学历层次',
+    '培养层次',
+  ].contains(text);
 }
 
 void _captureProfileByRegex(
@@ -159,7 +173,11 @@ void _captureProfileByRegex(
   String bodyText,
   String label,
 ) {
-  final pattern = RegExp('$label[:：]\\s*([^\\s]+)');
+  final escapedLabel = RegExp.escape(label);
+  final pattern = RegExp(
+    '$escapedLabel[:：]'
+    r'\s*([^：:]+?)(?=\s+[\u4e00-\u9fa5]{2,8}[:：]|$)',
+  );
   final match = pattern.firstMatch(bodyText);
   final value = match?.group(1)?.trim();
   if (value != null && value.isNotEmpty) {

--- a/lib/services/academic_eams_service.dart
+++ b/lib/services/academic_eams_service.dart
@@ -38,6 +38,14 @@ part 'academic_eams_shell_followups.dart';
 
 /// 教务中心与课程表页可依赖的只读接口。
 abstract class AcademicEamsClient {
+  /// 读取当前 OA 账号的本地加密学籍缓存。
+  Future<AcademicEamsProfile?> readCachedStudentProfile();
+
+  /// 学籍信息缺失或不完整时静默刷新。
+  Future<AcademicEamsProfile?> refreshStudentProfileIfIncomplete({
+    bool forceRefresh = false,
+  });
+
   /// 读取最近一次本地本专科教务摘要缓存。
   Future<AcademicEamsQueryResult?> readLatestCachedOverview();
 
@@ -105,6 +113,7 @@ typedef AcademicEamsOaLoginRefresher =
 enum _AcademicFetchScope { overview, courseTableOnly }
 
 enum _AcademicFeature {
+  studentProfile,
   courseTable,
   gradeCurrent,
   gradeHistory,
@@ -323,6 +332,29 @@ class AcademicEamsService implements AcademicEamsClient {
     );
   }
 
+  /// 读取当前 OA 账号绑定的加密学籍缓存。
+  @override
+  Future<AcademicEamsProfile?> readCachedStudentProfile() {
+    return _credentialsService.readStudentProfile();
+  }
+
+  /// 学籍信息缺失或不完整时静默刷新。
+  @override
+  Future<AcademicEamsProfile?> refreshStudentProfileIfIncomplete({
+    bool forceRefresh = false,
+  }) async {
+    final cachedProfile = await _credentialsService.readStudentProfile();
+    if (!forceRefresh && cachedProfile?.hasHomeSummary == true) {
+      return cachedProfile;
+    }
+    final result = await fetchOverview(requireCampusNetwork: false);
+    if (result.isSuccess) {
+      return result.snapshot?.profile ??
+          await _credentialsService.readStudentProfile();
+    }
+    return cachedProfile;
+  }
+
   /// 读取最近一次本地课表缓存。
   @override
   Future<AcademicEamsQueryResult?> readLatestCachedCourseTable() async {
@@ -346,13 +378,31 @@ class AcademicEamsService implements AcademicEamsClient {
     );
     if (entry == null) return null;
     final snapshot = AcademicEamsSnapshot.fromJson(entry.data);
+    final secureProfile = await _credentialsService.readStudentProfile();
+    final mergedSnapshot = secureProfile == null
+        ? snapshot
+        : AcademicEamsSnapshot(
+            fetchedAt: snapshot.fetchedAt,
+            sourceUri: snapshot.sourceUri,
+            warnings: snapshot.warnings,
+            hasCourseOfferingEntry: snapshot.hasCourseOfferingEntry,
+            hasFreeClassroomEntry: snapshot.hasFreeClassroomEntry,
+            profile: secureProfile,
+            courseTable: snapshot.courseTable,
+            grades: snapshot.grades,
+            programPlan: snapshot.programPlan,
+            programCompletion: snapshot.programCompletion,
+            exams: snapshot.exams,
+            courseOfferingsPreview: snapshot.courseOfferingsPreview,
+            freeClassroomsPreview: snapshot.freeClassroomsPreview,
+          );
     return _buildResult(
       AcademicEamsQueryStatus.success,
       message: message,
       detail: detail,
-      checkedAt: snapshot.fetchedAt,
-      finalUri: snapshot.sourceUri,
-      snapshot: snapshot,
+      checkedAt: mergedSnapshot.fetchedAt,
+      finalUri: mergedSnapshot.sourceUri,
+      snapshot: mergedSnapshot,
     );
   }
 }

--- a/lib/services/academic_oa_session_prewarm_service.dart
+++ b/lib/services/academic_oa_session_prewarm_service.dart
@@ -6,8 +6,12 @@
  * @Date : 2026-06-04
  */
 
+import 'dart:async';
+
 import '../models/academic_login_validation.dart';
+import '../models/academic_eams.dart';
 import 'academic_credentials_service.dart';
+import 'academic_eams_service.dart';
 import 'academic_login_validation_service.dart';
 
 /// 确保本地 OA 会话可用的回调，便于测试中注入 fake。
@@ -17,17 +21,25 @@ typedef AcademicOaSessionEnsurer =
       bool requireCampusNetwork,
     });
 
+/// 静默补全本专科教务学籍信息的回调。
+typedef AcademicStudentProfilePrewarmer =
+    Future<AcademicEamsProfile?> Function({bool forceRefresh});
+
 /// 在不阻塞 UI 的情况下静默准备 OA/CAS 登录会话。
 class AcademicOaSessionPrewarmService {
   /// 创建可注入依赖的预热服务。
   AcademicOaSessionPrewarmService({
     AcademicCredentialsService? credentialsService,
     AcademicOaSessionEnsurer? ensureSession,
+    AcademicStudentProfilePrewarmer? ensureStudentProfile,
   }) : _credentialsService =
            credentialsService ?? AcademicCredentialsService.instance,
        _ensureSession =
            ensureSession ??
-           AcademicLoginValidationService.instance.ensureSavedSession;
+           AcademicLoginValidationService.instance.ensureSavedSession,
+       _ensureStudentProfile =
+           ensureStudentProfile ??
+           AcademicEamsService.instance.refreshStudentProfileIfIncomplete;
 
   /// 全局单例。
   static final AcademicOaSessionPrewarmService instance =
@@ -35,17 +47,21 @@ class AcademicOaSessionPrewarmService {
 
   final AcademicCredentialsService _credentialsService;
   final AcademicOaSessionEnsurer _ensureSession;
+  final AcademicStudentProfilePrewarmer _ensureStudentProfile;
 
   /// 若本地已保存 OA 账号和密码，则静默确保会话存在。
   Future<AcademicLoginValidationResult?> prewarm({
     bool forceRefresh = true,
     bool requireCampusNetwork = false,
+    bool refreshStudentProfile = true,
   }) async {
+    var shouldRefreshStudentProfile = false;
     try {
       final status = await _credentialsService.getStatus();
       if (status.oaAccount.trim().isEmpty || !status.hasOaPassword) {
         return null;
       }
+      shouldRefreshStudentProfile = refreshStudentProfile;
       return await _ensureSession(
         forceRefresh: forceRefresh,
         requireCampusNetwork: requireCampusNetwork,
@@ -53,6 +69,20 @@ class AcademicOaSessionPrewarmService {
     } catch (_) {
       // 预热失败不应阻断启动或保存凭据流程；业务页仍会在读取时给出明确状态。
       return null;
+    } finally {
+      if (shouldRefreshStudentProfile) {
+        unawaited(_prewarmStudentProfile(forceRefresh: forceRefresh));
+      }
+    }
+  }
+
+  Future<void> _prewarmStudentProfile({required bool forceRefresh}) async {
+    try {
+      final status = await _credentialsService.getStatus();
+      if (status.oaAccount.trim().isEmpty || !status.hasOaPassword) return;
+      await _ensureStudentProfile(forceRefresh: forceRefresh);
+    } catch (_) {
+      // 学籍静默补全失败不应阻断启动或保存凭据流程。
     }
   }
 }

--- a/lib/services/storage_keys.dart
+++ b/lib/services/storage_keys.dart
@@ -28,6 +28,10 @@ class StorageKeys {
   /// 关闭行为偏好（ask / minimize / exit）。
   static const String closeBehavior = 'close_behavior';
 
+  /// 首页是否显示学籍信息卡片。
+  static const String homeStudentProfileCardVisible =
+      'home_student_profile_card_visible';
+
   /// 校园网 / VPN 状态检测间隔（分钟，0 = 关闭自动检测）。
   static const String campusNetworkDetectionIntervalMinutes =
       'campus_network_detection_interval_minutes';

--- a/lib/widgets/settings_general_section.dart
+++ b/lib/widgets/settings_general_section.dart
@@ -23,6 +23,9 @@ class SettingsGeneralSection extends StatelessWidget {
   /// 是否启用勿扰。
   final bool dndEnabled;
 
+  /// 首页是否显示学籍信息卡片。
+  final bool homeStudentProfileCardVisible;
+
   /// 勿扰开始时间。
   final int dndStartHour;
   final int dndStartMinute;
@@ -40,6 +43,9 @@ class SettingsGeneralSection extends StatelessWidget {
   /// 勿扰开关回调。
   final ValueChanged<bool> onDndChanged;
 
+  /// 首页学籍信息卡片显示开关回调。
+  final ValueChanged<bool> onHomeStudentProfileCardVisibleChanged;
+
   /// 勿扰开始时间修改回调。
   final Future<void> Function(int hour, int minute) onDndStartChanged;
 
@@ -51,6 +57,7 @@ class SettingsGeneralSection extends StatelessWidget {
     required this.closeBehavior,
     required this.notificationEnabled,
     required this.dndEnabled,
+    required this.homeStudentProfileCardVisible,
     required this.dndStartHour,
     required this.dndStartMinute,
     required this.dndEndHour,
@@ -58,6 +65,7 @@ class SettingsGeneralSection extends StatelessWidget {
     required this.onCloseBehaviorChanged,
     required this.onNotificationChanged,
     required this.onDndChanged,
+    required this.onHomeStudentProfileCardVisibleChanged,
     required this.onDndStartChanged,
     required this.onDndEndChanged,
   });
@@ -69,10 +77,40 @@ class SettingsGeneralSection extends StatelessWidget {
       children: [
         _buildWindowBehaviorSection(context),
         const SizedBox(height: AppSpacing.lg),
+        _buildHomeDisplaySection(context),
+        const SizedBox(height: AppSpacing.lg),
         SettingsUpdateSection(),
         const SizedBox(height: AppSpacing.lg),
         _buildNotificationSection(context),
       ],
+    );
+  }
+
+  Widget _buildHomeDisplaySection(BuildContext context) {
+    final type = context.fluentType;
+    return FluentCard(
+      padding: EdgeInsets.zero,
+      child: Padding(
+        padding: AppSpacing.cardPadding,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Semantics(header: true, child: Text('首页显示', style: type.subtitle1)),
+            const SizedBox(height: AppSpacing.md),
+            buildResponsiveSettingsRow(
+              context: context,
+              icon: FluentIcons.contact,
+              title: Text('显示学籍信息卡片', style: type.body1Strong),
+              subtitle: Text('在主页首屏展示姓名、学号、院系、专业和行政班级', style: type.caption1),
+              trailing: FluentSwitch(
+                key: const Key('settings-home-student-profile-card-switch'),
+                value: homeStudentProfileCardVisible,
+                onChanged: onHomeStudentProfileCardVisibleChanged,
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 
@@ -85,10 +123,7 @@ class SettingsGeneralSection extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Semantics(
-              header: true,
-              child: Text('窗口行为', style: type.subtitle1),
-            ),
+            Semantics(header: true, child: Text('窗口行为', style: type.subtitle1)),
             const SizedBox(height: AppSpacing.md),
             buildResponsiveSettingsRow(
               context: context,
@@ -131,10 +166,7 @@ class SettingsGeneralSection extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Semantics(
-              header: true,
-              child: Text('消息推送', style: type.subtitle1),
-            ),
+            Semantics(header: true, child: Text('消息推送', style: type.subtitle1)),
             const SizedBox(height: AppSpacing.md),
             buildResponsiveSettingsRow(
               context: context,

--- a/lib/widgets/settings_security_section.dart
+++ b/lib/widgets/settings_security_section.dart
@@ -13,6 +13,7 @@ import '../design/fluent_ui.dart';
 import '../models/academic_credentials.dart';
 import '../models/academic_login_validation.dart';
 import '../services/academic_credentials_service.dart';
+import '../services/academic_oa_session_prewarm_service.dart';
 import '../services/academic_login_validation_service.dart';
 import '../theme/fluent_tokens.dart';
 import 'app_feedback.dart';
@@ -55,6 +56,9 @@ class SettingsSecuritySection extends StatefulWidget {
   /// 可替换的 OA 登录校验服务，便于测试中使用 fake 网关。
   final AcademicLoginValidationService? academicLoginValidationService;
 
+  /// 可替换的 OA 会话与学籍预热服务，便于测试触发链路。
+  final AcademicOaSessionPrewarmService? academicOaSessionPrewarmService;
+
   const SettingsSecuritySection({
     super.key,
     required this.isPasswordEnabled,
@@ -68,6 +72,7 @@ class SettingsSecuritySection extends StatefulWidget {
     required this.onClearMessageCache,
     required this.onClearAllData,
     this.academicLoginValidationService,
+    this.academicOaSessionPrewarmService,
   });
 
   @override
@@ -95,6 +100,11 @@ class _SettingsSecuritySectionState extends State<SettingsSecuritySection> {
   AcademicLoginValidationService get _academicLoginValidationService {
     return widget.academicLoginValidationService ??
         AcademicLoginValidationService.instance;
+  }
+
+  AcademicOaSessionPrewarmService get _academicOaSessionPrewarmService {
+    return widget.academicOaSessionPrewarmService ??
+        AcademicOaSessionPrewarmService.instance;
   }
 
   @override
@@ -138,9 +148,11 @@ class _SettingsSecuritySectionState extends State<SettingsSecuritySection> {
     setState(() => _isSavingCredentials = true);
 
     try {
+      final previousStatus = await _academicCredentials.getStatus();
+      final enteredOaPassword = _nullablePassword(_oaPasswordController.text);
       await _academicCredentials.saveCredentials(
         oaAccount: _oaAccountController.text,
-        oaPassword: _nullablePassword(_oaPasswordController.text),
+        oaPassword: enteredOaPassword,
         sportsQueryPassword: _nullablePassword(_sportsPasswordController.text),
         emailPassword: _nullablePassword(_emailPasswordController.text),
       );
@@ -151,7 +163,14 @@ class _SettingsSecuritySectionState extends State<SettingsSecuritySection> {
         _credentialsStatus = status;
         _isSavingCredentials = false;
       });
-      unawaited(_prewarmAcademicLoginSession(status));
+      unawaited(
+        _prewarmAcademicLoginSession(
+          status,
+          forceRefreshStudentProfile:
+              previousStatus.oaAccount.trim() != status.oaAccount.trim() ||
+              (enteredOaPassword != null && enteredOaPassword.isNotEmpty),
+        ),
+      );
       _showCredentialInfoBar('教务凭据已保存', FluentInfoSeverity.success);
     } catch (_) {
       if (!mounted) return;
@@ -204,13 +223,15 @@ class _SettingsSecuritySectionState extends State<SettingsSecuritySection> {
 
   /// 保存凭据后静默准备 OA 会话，避免用户必须手动点击“验证 OA 登录”。
   Future<void> _prewarmAcademicLoginSession(
-    AcademicCredentialsStatus status,
-  ) async {
+    AcademicCredentialsStatus status, {
+    required bool forceRefreshStudentProfile,
+  }) async {
     if (status.oaAccount.trim().isEmpty || !status.hasOaPassword) return;
     try {
-      await _academicLoginValidationService.ensureSavedSession(
+      await _academicOaSessionPrewarmService.prewarm(
         forceRefresh: true,
         requireCampusNetwork: false,
+        refreshStudentProfile: forceRefreshStudentProfile,
       );
     } catch (_) {
       // 静默预热失败不打断保存流程；用户仍可手动验证查看具体原因。

--- a/test/academic_eams_service_test.dart
+++ b/test/academic_eams_service_test.dart
@@ -175,6 +175,13 @@ void main() {
     expect(gateway.openCount, 2);
     expect(gateway.resetCookieHeaders.last['oa.sspu.edu.cn'], contains('OA='));
     expect(result.snapshot?.profile?.name, '张三');
+    expect(result.snapshot?.profile?.studentId, '20260001');
+    expect(result.snapshot?.profile?.department, '计算机与信息工程学院');
+    expect(result.snapshot?.profile?.major, '软件工程');
+    expect(result.snapshot?.profile?.className, '软件 241');
+    expect(result.snapshot?.profile?.gender, '男');
+    expect(result.snapshot?.profile?.studyLength, '4 年');
+    expect(result.snapshot?.profile?.educationLevel, '本科');
     expect(result.snapshot?.courseTable?.entries.length, 1);
     expect(result.snapshot?.grades?.historyRecords.length, 1);
     expect(result.snapshot?.programCompletion?.completedCredits, 7);
@@ -183,7 +190,46 @@ void main() {
     expect(result.snapshot?.hasFreeClassroomEntry, isTrue);
   });
 
-  test('本专科教务缓存不持久化明文学号或原始个人字段', () async {
+  test('从空根菜单发现真实学籍个人信息入口', () async {
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      oaPassword: 'oa-pass',
+    );
+    await AcademicCredentialsService.instance.saveOaLoginSession(
+      academicEamsSessionSnapshot,
+    );
+    final gateway = FakeAcademicEamsGateway(
+      disableNumberedStudentProfileMenu: true,
+    );
+    final service = buildAcademicEamsServiceForTest(
+      gateway: gateway,
+      campusReachable: true,
+    );
+
+    final result = await service.fetchOverview();
+
+    expect(result.status, AcademicEamsQueryStatus.success);
+    expect(result.snapshot?.profile?.studentId, '20260001');
+    expect(result.snapshot?.profile?.name, '张三');
+    expect(
+      gateway.requestedPageUris,
+      contains(
+        predicate<Uri>(
+          (uri) =>
+              uri.path.contains('home!submenus.action') &&
+              (uri.queryParameters['menu.id'] ?? '').isEmpty,
+        ),
+      ),
+    );
+    expect(
+      gateway.requestedPageUris.any(
+        (uri) => uri.path.contains('studentDetail.action'),
+      ),
+      isTrue,
+    );
+  });
+
+  test('本专科教务缓存不持久化明文学籍字段并从安全存储恢复学籍', () async {
     await AcademicCredentialsService.instance.saveCredentials(
       oaAccount: '20260001',
       oaPassword: 'oa-pass',
@@ -200,13 +246,98 @@ void main() {
     final storedPayload = (await StorageService.getAllData(
       StorageKeys.academicEamsOverviewCacheCollection,
     )).values.single;
+    final storedProfile = storedPayload['profile'];
     final cachedResult = await service.readLatestCachedOverview();
+    final secureProfile = await AcademicCredentialsService.instance
+        .readStudentProfile();
 
     expect(storedPayload.toString(), isNot(contains('20260001')));
+    expect(storedPayload.toString(), isNot(contains('张三')));
+    expect(storedPayload.toString(), isNot(contains('软件 241')));
     expect(storedPayload.toString(), isNot(contains('学号')));
+    expect(storedProfile.toString(), isNot(contains('计算机与信息工程学院')));
+    expect(storedProfile.toString(), isNot(contains('软件工程')));
+    expect(secureProfile?.studentId, '20260001');
+    expect(secureProfile?.gender, '男');
+    expect(secureProfile?.studyLength, '4 年');
+    expect(secureProfile?.educationLevel, '本科');
     expect(cachedResult?.snapshot?.profile?.name, '张三');
-    expect(cachedResult?.snapshot?.profile?.studentId, isNull);
+    expect(cachedResult?.snapshot?.profile?.studentId, '20260001');
     expect(cachedResult?.snapshot?.profile?.rawFields, isEmpty);
+  });
+
+  test('学籍页学号与 OA 账号不一致时不保存学籍缓存', () async {
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      oaPassword: 'oa-pass',
+    );
+    await AcademicCredentialsService.instance.saveOaLoginSession(
+      academicEamsSessionSnapshot,
+    );
+    final service = buildAcademicEamsServiceForTest(
+      gateway: FakeAcademicEamsGateway(
+        studentProfileSnapshot: AcademicEamsHttpSnapshot(
+          finalUri: Uri.parse('https://jx.sspu.edu.cn/eams/std.action'),
+          statusCode: 200,
+          body: '''
+<html><body><table>
+<tr><th>学号</th><th>姓名</th><th>专业</th></tr>
+<tr><td>20269999</td><td>李四</td><td>软件工程</td></tr>
+</table></body></html>
+''',
+        ),
+      ),
+      campusReachable: true,
+    );
+
+    final result = await service.fetchOverview();
+
+    expect(result.status, AcademicEamsQueryStatus.unexpectedError);
+    expect(result.message, '学籍信息账号不一致');
+    expect(
+      await AcademicCredentialsService.instance.readStudentProfile(),
+      isNull,
+    );
+  });
+
+  test('学籍页解析失败时保留旧加密学籍缓存', () async {
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      oaPassword: 'oa-pass',
+    );
+    await AcademicCredentialsService.instance.saveOaLoginSession(
+      academicEamsSessionSnapshot,
+    );
+    await AcademicCredentialsService.instance.saveStudentProfile(
+      const AcademicEamsProfile(
+        name: '旧缓存',
+        studentId: '20260001',
+        department: '旧学院',
+        major: '旧专业',
+        className: '旧班级',
+        gender: '男',
+        studyLength: '4 年',
+        educationLevel: '本科',
+        rawFields: {},
+      ),
+    );
+    final service = buildAcademicEamsServiceForTest(
+      gateway: FakeAcademicEamsGateway(
+        studentProfileSnapshot: AcademicEamsHttpSnapshot(
+          finalUri: Uri.parse('https://jx.sspu.edu.cn/eams/std.action'),
+          statusCode: 200,
+          body: '<html><body><p>暂无可解析学籍字段</p></body></html>',
+        ),
+      ),
+      campusReachable: true,
+    );
+
+    await service.fetchOverview();
+    final cachedProfile = await AcademicCredentialsService.instance
+        .readStudentProfile();
+
+    expect(cachedProfile?.name, '旧缓存');
+    expect(cachedProfile?.major, '旧专业');
   });
 
   test('独立课表读取只解析当前学期课表', () async {

--- a/test/academic_eams_service_test_support.dart
+++ b/test/academic_eams_service_test_support.dart
@@ -35,11 +35,16 @@ class FakeAcademicEamsGateway implements AcademicEamsGateway {
   FakeAcademicEamsGateway({
     this.requireAuthFirst = false,
     this.failFreeClassroomMenuOnce = false,
+    this.studentProfileSnapshot,
+    this.disableNumberedStudentProfileMenu = false,
   });
 
   final bool requireAuthFirst;
   final bool failFreeClassroomMenuOnce;
+  final AcademicEamsHttpSnapshot? studentProfileSnapshot;
+  final bool disableNumberedStudentProfileMenu;
   final List<Map<String, String>> resetCookieHeaders = [];
+  final List<Uri> requestedPageUris = [];
   int openCount = 0;
   String? lastSubmittedMethod;
   Map<String, String>? lastSubmittedFields;
@@ -65,12 +70,21 @@ class FakeAcademicEamsGateway implements AcademicEamsGateway {
     Uri pageUri,
     Duration timeout,
   ) async {
+    requestedPageUris.add(pageUri);
     final path = pageUri.path;
+    if (path.contains('home!submenus.action') &&
+        (pageUri.queryParameters['menu.id'] == null ||
+            pageUri.queryParameters['menu.id'] == '')) {
+      return academicEamsRootSubmenuSnapshot;
+    }
     if (path.contains('home!submenus.action') &&
         pageUri.queryParameters['menu.id'] == '5') {
       if (failFreeClassroomMenuOnce && !_hasFailedFreeClassroomMenu) {
         _hasFailedFreeClassroomMenu = true;
         throw TimeoutException('menu timeout');
+      }
+      if (disableNumberedStudentProfileMenu) {
+        return academicEamsSubmenuWithoutStudentProfileSnapshot;
       }
       return academicEamsSubmenuSnapshot;
     }
@@ -78,6 +92,9 @@ class FakeAcademicEamsGateway implements AcademicEamsGateway {
       return academicEamsEmptySubmenuSnapshot;
     }
     if (path.contains('home!index.action')) return academicEamsHomeSnapshot;
+    if (path.contains('studentDetail.action') || path.contains('std.action')) {
+      return studentProfileSnapshot ?? academicEamsStudentProfileSnapshot;
+    }
     if (path.contains('courseTableForStd.action')) {
       return academicEamsCourseTableSnapshot;
     }
@@ -177,6 +194,31 @@ final AcademicEamsHttpSnapshot academicEamsEmptySubmenuSnapshot =
       body: '<html><body></body></html>',
     );
 
+final AcademicEamsHttpSnapshot academicEamsRootSubmenuSnapshot =
+    AcademicEamsHttpSnapshot(
+      finalUri: Uri.parse(
+        'https://jx.sspu.edu.cn/eams/home!submenus.action?menu.id=',
+      ),
+      statusCode: 200,
+      body: '''
+<html>
+  <body>
+    <ul class="menu">
+      <li class="expand">
+        <a class="first_menu" href="#">学籍信息</a>
+        <ul class="scroll_box">
+          <li>
+            <a class="p_1" href="/eams/studentDetail.action"
+               onclick="return bg.Go(this,'main',true)">个人信息</a>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </body>
+</html>
+''',
+    );
+
 final AcademicEamsHttpSnapshot academicEamsSubmenuSnapshot =
     AcademicEamsHttpSnapshot(
       finalUri: Uri.parse(
@@ -187,6 +229,45 @@ final AcademicEamsHttpSnapshot academicEamsSubmenuSnapshot =
 <html>
   <body>
     <a href="/eams/freeClassroom.action">空闲教室查询</a>
+    <a href="/eams/std.action">学籍信息-个人信息</a>
+  </body>
+</html>
+''',
+    );
+
+final AcademicEamsHttpSnapshot
+academicEamsSubmenuWithoutStudentProfileSnapshot = AcademicEamsHttpSnapshot(
+  finalUri: Uri.parse(
+    'https://jx.sspu.edu.cn/eams/home!submenus.action?menu.id=5',
+  ),
+  statusCode: 200,
+  body: '''
+<html>
+  <body>
+    <a href="/eams/freeClassroom.action">空闲教室查询</a>
+  </body>
+</html>
+''',
+);
+
+final AcademicEamsHttpSnapshot academicEamsStudentProfileSnapshot =
+    AcademicEamsHttpSnapshot(
+      finalUri: Uri.parse('https://jx.sspu.edu.cn/eams/studentDetail.action'),
+      statusCode: 200,
+      body: '''
+<html>
+  <body>
+    <h2>学籍信息</h2>
+    <table>
+      <tr>
+        <th>学号</th><th>姓名</th><th>性别</th><th>院系</th>
+        <th>专业</th><th>行政班级</th><th>学制</th><th>学历层次</th>
+      </tr>
+      <tr>
+        <td>20260001</td><td>张三</td><td>男</td><td>计算机与信息工程学院</td>
+        <td>软件工程</td><td>软件 241</td><td>4 年</td><td>本科</td>
+      </tr>
+    </table>
   </body>
 </html>
 ''',

--- a/test/academic_oa_session_prewarm_service_test.dart
+++ b/test/academic_oa_session_prewarm_service_test.dart
@@ -8,6 +8,7 @@
 
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:sspu_allinone/models/academic_eams.dart';
 import 'package:sspu_allinone/models/academic_login_validation.dart';
 import 'package:sspu_allinone/services/academic_credentials_service.dart';
 import 'package:sspu_allinone/services/academic_oa_session_prewarm_service.dart';
@@ -20,6 +21,7 @@ void main() {
   test('缺少 OA 账号或密码时不触发会话预热', () async {
     var ensureCalled = false;
     final service = AcademicOaSessionPrewarmService(
+      ensureStudentProfile: ({bool forceRefresh = false}) async => null,
       ensureSession:
           ({
             bool forceRefresh = false,
@@ -47,7 +49,12 @@ void main() {
       oaPassword: 'oa-pass',
     );
     final calls = <Map<String, bool>>[];
+    final profileForceRefreshValues = <bool>[];
     final service = AcademicOaSessionPrewarmService(
+      ensureStudentProfile: ({bool forceRefresh = false}) async {
+        profileForceRefreshValues.add(forceRefresh);
+        return _studentProfile();
+      },
       ensureSession:
           ({
             bool forceRefresh = false,
@@ -67,9 +74,11 @@ void main() {
     );
 
     expect(result?.isSuccess, isTrue);
+    await Future<void>.delayed(Duration.zero);
     expect(calls, [
       {'forceRefresh': true, 'requireCampusNetwork': false},
     ]);
+    expect(profileForceRefreshValues, [true]);
   });
 
   test('默认预热会强制刷新旧 OA 会话', () async {
@@ -79,6 +88,7 @@ void main() {
     );
     final calls = <Map<String, bool>>[];
     final service = AcademicOaSessionPrewarmService(
+      ensureStudentProfile: ({bool forceRefresh = false}) async => null,
       ensureSession:
           ({
             bool forceRefresh = false,
@@ -105,6 +115,7 @@ void main() {
       oaPassword: 'oa-pass',
     );
     final service = AcademicOaSessionPrewarmService(
+      ensureStudentProfile: ({bool forceRefresh = false}) async => null,
       ensureSession:
           ({
             bool forceRefresh = false,
@@ -118,6 +129,20 @@ void main() {
 
     expect(result, isNull);
   });
+}
+
+AcademicEamsProfile _studentProfile() {
+  return const AcademicEamsProfile(
+    name: '张三',
+    studentId: '20260001',
+    department: '计算机与信息工程学院',
+    major: '软件工程',
+    className: '软件 241',
+    gender: '男',
+    studyLength: '4 年',
+    educationLevel: '本科',
+    rawFields: {},
+  );
 }
 
 AcademicLoginValidationResult _successResult() {

--- a/test/academic_page_test_support.dart
+++ b/test/academic_page_test_support.dart
@@ -79,6 +79,18 @@ class _FakeAcademicEamsClient implements AcademicEamsClient {
   }
 
   @override
+  Future<AcademicEamsProfile?> readCachedStudentProfile() async {
+    return null;
+  }
+
+  @override
+  Future<AcademicEamsProfile?> refreshStudentProfileIfIncomplete({
+    bool forceRefresh = false,
+  }) async {
+    return result.snapshot?.profile;
+  }
+
+  @override
   Future<AcademicEamsQueryResult> fetchCourseTable({
     bool requireCampusNetwork = true,
   }) async {
@@ -194,6 +206,9 @@ final AcademicEamsQueryResult _academicEamsResult = AcademicEamsQueryResult(
       department: '计算机与信息工程学院',
       major: '软件工程',
       className: '软件 241',
+      gender: '男',
+      studyLength: '4 年',
+      educationLevel: '本科',
       rawFields: {'姓名': '张三', '学号': '20260001'},
     ),
     courseTable: AcademicCourseTableSnapshot(

--- a/test/course_schedule_page_test.dart
+++ b/test/course_schedule_page_test.dart
@@ -174,6 +174,18 @@ class _FakeAcademicEamsClient implements AcademicEamsClient {
   }
 
   @override
+  Future<AcademicEamsProfile?> readCachedStudentProfile() async {
+    return null;
+  }
+
+  @override
+  Future<AcademicEamsProfile?> refreshStudentProfileIfIncomplete({
+    bool forceRefresh = false,
+  }) async {
+    return result.snapshot?.profile;
+  }
+
+  @override
   Future<AcademicEamsQueryResult> fetchCourseTable({
     bool requireCampusNetwork = true,
   }) async {
@@ -308,6 +320,9 @@ final AcademicEamsQueryResult _successResult = AcademicEamsQueryResult(
       department: '计算机与信息工程学院',
       major: '软件工程',
       className: '软件 241',
+      gender: '男',
+      studyLength: '4 年',
+      educationLevel: '本科',
       rawFields: {'姓名': '张三'},
     ),
     courseTable: AcademicCourseTableSnapshot(

--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -7,10 +7,14 @@
  */
 
 import 'package:sspu_allinone/design/fluent_ui.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sspu_allinone/models/academic_eams.dart';
 import 'package:sspu_allinone/models/campus_card.dart';
 import 'package:sspu_allinone/pages/home_page.dart';
+import 'package:sspu_allinone/services/academic_credentials_service.dart';
+import 'package:sspu_allinone/services/academic_eams_service.dart';
 import 'package:sspu_allinone/services/campus_card_service.dart';
 import 'package:sspu_allinone/services/campus_network_status_service.dart';
 import 'package:sspu_allinone/services/storage_service.dart';
@@ -33,6 +37,7 @@ Future<void> disposeHomePage(WidgetTester tester) async {
 Future<void> pumpHomePage(
   WidgetTester tester, {
   CampusCardBalanceClient? campusCardService,
+  AcademicEamsClient? academicEamsService,
   required CampusNetworkStatusService campusNetworkStatusService,
   required bool campusCardAutoRefreshEnabledOverride,
   int campusCardAutoRefreshIntervalOverride = 30,
@@ -41,6 +46,7 @@ Future<void> pumpHomePage(
     FluentApp(
       home: HomePage(
         campusCardService: campusCardService,
+        academicEamsService: academicEamsService,
         campusNetworkStatusService: campusNetworkStatusService,
         campusCardAutoRefreshEnabledOverride:
             campusCardAutoRefreshEnabledOverride,
@@ -53,6 +59,7 @@ Future<void> pumpHomePage(
 
 void main() {
   setUp(() {
+    FlutterSecureStorage.setMockInitialValues({});
     SharedPreferences.setMockInitialValues({});
     StorageService.debugUseSharedPreferencesStorageForTesting(true);
   });
@@ -91,6 +98,115 @@ void main() {
     expect(find.text('校园卡详情'), findsOneWidget);
     expect(find.text('余额：¥23.45'), findsOneWidget);
     expect(find.text('交易记录查询'), findsOneWidget);
+    await disposeHomePage(tester);
+  });
+
+  testWidgets('首页学籍信息卡片展示身份摘要且无刷新时间', (tester) async {
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      oaPassword: 'oa-pass',
+    );
+    final academicService = _FakeAcademicEamsClient(
+      cachedProfile: _studentProfile,
+    );
+    final campusNetworkStatusService = _buildCampusNetworkStatusService();
+
+    await pumpHomePage(
+      tester,
+      academicEamsService: academicService,
+      campusNetworkStatusService: campusNetworkStatusService,
+      campusCardAutoRefreshEnabledOverride: false,
+    );
+    await pumpUntilFound(tester, find.text('学籍信息'));
+
+    final profileCard = find.byKey(const Key('home-student-profile-card'));
+    expect(profileCard, findsOneWidget);
+    expect(
+      find.descendant(of: profileCard, matching: find.text('本专科教务')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: profileCard, matching: find.text('张三')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: profileCard, matching: find.text('20260001')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: profileCard, matching: find.text('计算机与信息工程学院')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: profileCard, matching: find.text('软件工程')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: profileCard, matching: find.text('软件 241')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: profileCard, matching: find.textContaining('来自学籍信息')),
+      findsNothing,
+    );
+    expect(
+      find.descendant(of: profileCard, matching: find.textContaining('上次刷新')),
+      findsNothing,
+    );
+    expect(
+      find.descendant(
+        of: profileCard,
+        matching: find.byIcon(FluentIcons.refresh),
+      ),
+      findsNothing,
+    );
+    expect(academicService.refreshCount, 0);
+    await disposeHomePage(tester);
+  });
+
+  testWidgets('首页无 OA 账密时学籍卡片显示设置引导', (tester) async {
+    var settingsOpened = false;
+    final campusNetworkStatusService = _buildCampusNetworkStatusService();
+    await tester.pumpWidget(
+      FluentApp(
+        home: HomePage(
+          academicEamsService: _FakeAcademicEamsClient(),
+          campusNetworkStatusService: campusNetworkStatusService,
+          campusCardAutoRefreshEnabledOverride: false,
+          onOpenSettings: () => settingsOpened = true,
+        ),
+      ),
+    );
+    await pumpUntilFound(tester, find.text('需要先保存 OA 账号密码'));
+
+    expect(find.text('学籍信息会在保存后自动读取'), findsOneWidget);
+    await tester.tap(find.text('前往设置'));
+    await tester.pump();
+    expect(settingsOpened, isTrue);
+    await disposeHomePage(tester);
+  });
+
+  testWidgets('首页学籍卡片隐藏设置关闭后不展示', (tester) async {
+    await StorageService.setBool(
+      StorageKeys.homeStudentProfileCardVisible,
+      false,
+    );
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      oaPassword: 'oa-pass',
+    );
+    final campusNetworkStatusService = _buildCampusNetworkStatusService();
+    await pumpHomePage(
+      tester,
+      academicEamsService: _FakeAcademicEamsClient(
+        cachedProfile: _studentProfile,
+      ),
+      campusNetworkStatusService: campusNetworkStatusService,
+      campusCardAutoRefreshEnabledOverride: false,
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.text('学籍信息'), findsNothing);
     await disposeHomePage(tester);
   });
 
@@ -230,6 +346,62 @@ class _FakeCampusCardClient implements CampusCardBalanceClient {
     return result;
   }
 }
+
+class _FakeAcademicEamsClient implements AcademicEamsClient {
+  _FakeAcademicEamsClient({this.cachedProfile});
+
+  final AcademicEamsProfile? cachedProfile;
+  int refreshCount = 0;
+
+  @override
+  Future<AcademicEamsProfile?> readCachedStudentProfile() async {
+    return cachedProfile;
+  }
+
+  @override
+  Future<AcademicEamsProfile?> refreshStudentProfileIfIncomplete({
+    bool forceRefresh = false,
+  }) async {
+    refreshCount++;
+    return cachedProfile;
+  }
+
+  @override
+  Future<AcademicEamsQueryResult> fetchCourseTable({
+    bool requireCampusNetwork = true,
+  }) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AcademicEamsQueryResult> fetchOverview({
+    bool requireCampusNetwork = true,
+  }) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AcademicEamsQueryResult?> readLatestCachedCourseTable() async {
+    return null;
+  }
+
+  @override
+  Future<AcademicEamsQueryResult?> readLatestCachedOverview() async {
+    return null;
+  }
+}
+
+const AcademicEamsProfile _studentProfile = AcademicEamsProfile(
+  name: '张三',
+  studentId: '20260001',
+  department: '计算机与信息工程学院',
+  major: '软件工程',
+  className: '软件 241',
+  gender: '男',
+  studyLength: '4 年',
+  educationLevel: '本科',
+  rawFields: {},
+);
 
 final CampusCardQueryResult _successResult = CampusCardQueryResult(
   status: CampusCardQueryStatus.success,

--- a/test/settings_security_section_test.dart
+++ b/test/settings_security_section_test.dart
@@ -11,7 +11,9 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sspu_allinone/models/academic_login_validation.dart';
+import 'package:sspu_allinone/models/academic_eams.dart';
 import 'package:sspu_allinone/services/academic_credentials_service.dart';
+import 'package:sspu_allinone/services/academic_oa_session_prewarm_service.dart';
 import 'package:sspu_allinone/services/academic_login_validation_service.dart';
 import 'package:sspu_allinone/services/storage_service.dart';
 import 'package:sspu_allinone/widgets/settings_security_section.dart';
@@ -55,6 +57,7 @@ void main() {
     required bool isQuickAuthAvailable,
     bool isQuickAuthBusy = false,
     AcademicLoginValidationService? academicLoginValidationService,
+    AcademicOaSessionPrewarmService? academicOaSessionPrewarmService,
   }) async {
     await tester.pumpWidget(
       FluentApp(
@@ -72,6 +75,7 @@ void main() {
               onClearMessageCache: () {},
               onClearAllData: () {},
               academicLoginValidationService: academicLoginValidationService,
+              academicOaSessionPrewarmService: academicOaSessionPrewarmService,
             ),
           ),
         ),
@@ -128,14 +132,14 @@ void main() {
 
   testWidgets('保存 OA 凭据后自动静默预热登录会话', (tester) async {
     FlutterSecureStorage.setMockInitialValues({});
-    final validationService = _RecordingAcademicLoginValidationService();
+    final prewarmService = _RecordingAcademicOaSessionPrewarmService();
 
     await pumpSecuritySection(
       tester,
       isPasswordEnabled: false,
       isQuickAuthEnabled: false,
       isQuickAuthAvailable: false,
-      academicLoginValidationService: validationService,
+      academicOaSessionPrewarmService: prewarmService,
     );
     await pumpUntilFound(tester, find.text('保存教务凭据'));
 
@@ -146,8 +150,9 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 50));
 
-    expect(validationService.forceRefreshValues, [true]);
-    expect(validationService.requireCampusNetworkValues, [false]);
+    expect(prewarmService.forceRefreshValues, [true]);
+    expect(prewarmService.requireCampusNetworkValues, [false]);
+    expect(prewarmService.refreshStudentProfileValues, [true]);
     expect(
       await AcademicCredentialsService.instance.readOaLoginSession(),
       isNull,
@@ -220,57 +225,44 @@ void main() {
   });
 }
 
-class _RecordingAcademicLoginValidationService
-    extends AcademicLoginValidationService {
-  _RecordingAcademicLoginValidationService()
-    : super(gateway: _UnusedAcademicLoginGateway());
+class _RecordingAcademicOaSessionPrewarmService
+    extends AcademicOaSessionPrewarmService {
+  _RecordingAcademicOaSessionPrewarmService()
+    : super(
+        ensureSession:
+            ({
+              bool forceRefresh = false,
+              bool requireCampusNetwork = true,
+            }) async => _successResult(),
+        ensureStudentProfile: ({bool forceRefresh = false}) async =>
+            const AcademicEamsProfile(
+              name: '张三',
+              studentId: '20260001',
+              department: '计算机与信息工程学院',
+              major: '软件工程',
+              className: '软件 241',
+              gender: '男',
+              studyLength: '4 年',
+              educationLevel: '本科',
+              rawFields: {},
+            ),
+      );
 
   final List<bool> forceRefreshValues = [];
   final List<bool> requireCampusNetworkValues = [];
+  final List<bool> refreshStudentProfileValues = [];
 
   @override
-  Future<AcademicLoginValidationResult> ensureSavedSession({
-    bool forceRefresh = false,
-    bool requireCampusNetwork = true,
+  Future<AcademicLoginValidationResult?> prewarm({
+    bool forceRefresh = true,
+    bool requireCampusNetwork = false,
+    bool refreshStudentProfile = true,
   }) async {
     forceRefreshValues.add(forceRefresh);
     requireCampusNetworkValues.add(requireCampusNetwork);
+    refreshStudentProfileValues.add(refreshStudentProfile);
     return _successResult();
   }
-
-  @override
-  Future<AcademicLoginValidationResult> validateSavedCredentials({
-    bool requireCampusNetwork = true,
-  }) async {
-    return _successResult();
-  }
-}
-
-class _UnusedAcademicLoginGateway implements AcademicLoginGateway {
-  @override
-  AcademicLoginSessionSnapshot currentSessionSnapshot({
-    required Uri entranceUri,
-    required Uri finalUri,
-  }) => throw UnimplementedError();
-
-  @override
-  Future<String> fetchPublicKey(Duration timeout) => throw UnimplementedError();
-
-  @override
-  Future<AcademicLoginHttpSnapshot> openLoginPage(
-    Uri entranceUri,
-    Duration timeout,
-  ) => throw UnimplementedError();
-
-  @override
-  Future<void> resetSession() async {}
-
-  @override
-  Future<AcademicLoginHttpSnapshot> submitLogin({
-    required Uri loginUri,
-    required Map<String, String> fields,
-    required Duration timeout,
-  }) => throw UnimplementedError();
 }
 
 AcademicLoginValidationResult _successResult() {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -20,6 +20,7 @@ import 'package:sspu_allinone/services/wxmp_config_service.dart';
 import 'package:sspu_allinone/widgets/app_feedback.dart';
 import 'package:sspu_allinone/widgets/campus_network_status_indicator.dart';
 import 'package:sspu_allinone/widgets/settings_auto_refresh_section.dart';
+import 'package:sspu_allinone/widgets/settings_general_section.dart';
 import 'package:sspu_allinone/widgets/settings_wechat_section.dart';
 
 /// 等待目标组件出现，避免页面异步加载尚未完成时提前断言。
@@ -493,6 +494,47 @@ void main() {
     await tester.tap(find.text('前往设置').first);
     await tester.pump(const Duration(milliseconds: 150));
     expect(selectedShortcut, 3);
+  });
+
+  testWidgets('常规设置分区显示首页学籍卡片开关', (WidgetTester tester) async {
+    var visible = true;
+    await tester.pumpWidget(
+      FluentApp(
+        home: ScaffoldPage(
+          content: SingleChildScrollView(
+            child: SettingsGeneralSection(
+              closeBehavior: 'ask',
+              notificationEnabled: true,
+              dndEnabled: false,
+              homeStudentProfileCardVisible: true,
+              dndStartHour: 22,
+              dndStartMinute: 0,
+              dndEndHour: 7,
+              dndEndMinute: 0,
+              onCloseBehaviorChanged: (_) {},
+              onNotificationChanged: (_) {},
+              onDndChanged: (_) {},
+              onHomeStudentProfileCardVisibleChanged: (value) =>
+                  visible = value,
+              onDndStartChanged: (_, _) async {},
+              onDndEndChanged: (_, _) async {},
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('首页显示'), findsOneWidget);
+    expect(find.text('显示学籍信息卡片'), findsOneWidget);
+    await tester.tap(
+      find.byKey(const Key('settings-home-student-profile-card-switch')),
+    );
+    await tester.pump();
+    expect(visible, isFalse);
+    await tester.pump(const Duration(milliseconds: 120));
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
   });
 
   testWidgets('页面反馈连续显示时替换上一条信息条', (WidgetTester tester) async {


### PR DESCRIPTION
## 变更说明
- 新增首页模块化学籍信息卡片，展示姓名、学号、院系、专业、行政班级，并支持设置隐藏。
- 扩展本专科教务学籍个人信息解析，解析并加密保存 8 个字段；普通缓存仅保留是否存在学籍信息。
- 修复真实 EAMS 左侧菜单发现：先读取 `home!submenus.action?menu.id=` 空根菜单，识别 `/eams/studentDetail.action` 个人信息入口。
- 更新 OA 凭据保存/启动预热链路，在学籍信息缺失或账号密码更新后自动补全。

## 根因
真实 jx.sspu.edu.cn 首页通过空 `menu.id` 加载左侧导航；原实现只扫描 `menu.id=1..60`，因此漏掉“学籍信息 / 个人信息”入口，并回退到真实环境返回 403 的 `std.action`。

## 验证
- `flutter analyze --no-fatal-infos`
- `flutter test test/academic_eams_service_test.dart test/home_page_test.dart test/settings_security_section_test.dart test/academic_oa_session_prewarm_service_test.dart test/widget_test.dart test/course_schedule_page_test.dart`
- 使用本地已保存 OA 凭据进行脱敏真实验证：`studentDetail.action` 可访问，8 个学籍字段均解析成功并写入安全缓存。

## 风险与回滚
- 影响范围集中在本专科教务菜单发现、学籍缓存和首页卡片。
- 如真实 EAMS 菜单再次变更，可回滚本 PR 或保留安全缓存读取并调整菜单发现候选。
