### PR TITLE
fix(macos): 修复 Release 构建钥匙串凭据保存失败 (errSecMissingEntitlement)

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -11,6 +11,8 @@
 	<key>com.apple.security.network.server</key>
 	<true/>
 	<key>keychain-access-groups</key>
-	<array/>
+	<array>
+		<string>8LDARH2S3X.cn.qintsg.sspuAllinOne</string>
+	</array>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -1,5 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>8LDARH2S3X.cn.qintsg.sspuAllinOne</string>
+	</array>
+</dict>
 </plist>


### PR DESCRIPTION
## 问题
macOS 正式签名公证后，`flutter_secure_storage` 无法写入钥匙串，设置页报"保存失败，请确认系统安全存储可用"。Debug 模式正常。

## 根因
`Release.entitlements` 的 `keychain-access-groups` 为空数组，macOS 不会自动派生 access group，导致 `SecItemDelete` 返回 `errSecMissingEntitlement (-34018)`。

## 修复内容
- **`Release.entitlements`** — 启用 App Sandbox + 显式 `keychain-access-groups` + `disable-library-validation` + `network.client`
- **`DebugProfile.entitlements`** — 显式 `keychain-access-groups` 字符串，与 Release 保持一致
- **`app_data_directory_service.dart`** — macOS 数据目录从 `$HOME/.sspu-aio` 迁移到 `Application Support`（兼容 App Sandbox），首次启动自动从旧路径迁移
- **`wxmp_config_service.dart`** — TOML 注释不再硬编码 `~/.sspu-aio/`
- **测试** — 验证 `Release.entitlements` 包含必需权限、`Release-unsigned.entitlements` 为空、workflow 有剥离逻辑

## 关联 Issue
Refs #246
Refs #248

