### PR TITLE
fix(mobile): 修复输入法重复让位冲突

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -212,6 +212,7 @@ class _CompactNavigationShell extends StatelessWidget {
 
     return ScaffoldPage(
       padding: EdgeInsets.zero,
+      resizeToAvoidBottomInset: false,
       content: MediaQuery.removePadding(
         context: context,
         removeBottom: true,

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -49,6 +49,7 @@ void main() {
     WidgetTester tester, {
     double topPadding = 0,
     double bottomPadding = 0,
+    double keyboardInset = 0,
   }) async {
     tester.view.physicalSize = const Size(390, 844);
     tester.view.devicePixelRatio = 1.0;
@@ -60,12 +61,14 @@ void main() {
       top: topPadding,
       bottom: bottomPadding,
     );
+    tester.view.viewInsets = FakeViewPadding(bottom: keyboardInset);
     await tester.binding.setSurfaceSize(const Size(390, 844));
   }
 
   Future<void> resetMobileView(WidgetTester tester) async {
     tester.view.resetPadding();
     tester.view.resetViewPadding();
+    tester.view.resetViewInsets();
     tester.view.resetPhysicalSize();
     tester.view.resetDevicePixelRatio();
     await tester.binding.setSurfaceSize(null);
@@ -223,6 +226,46 @@ void main() {
   testWidgets('移动端安全区不遮挡页面标题且底部导航贴合手势区', (WidgetTester tester) async {
     await expectMobileSafeAreaLayout(tester, TargetPlatform.android);
     await expectMobileSafeAreaLayout(tester, TargetPlatform.iOS);
+  });
+
+  testWidgets('移动端输入法弹出时外层底部导航不重复让位', (WidgetTester tester) async {
+    final previousTargetPlatform = debugDefaultTargetPlatformOverride;
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    await configureMobileView(tester, bottomPadding: 24);
+
+    try {
+      SharedPreferences.setMockInitialValues({});
+      StorageService.debugUseSharedPreferencesStorageForTesting(true);
+      final service = _buildCampusNetworkStatusService();
+      await tester.pumpWidget(
+        FluentApp(home: AppShell(campusNetworkStatusService: service)),
+      );
+      await tester.pump(const Duration(milliseconds: 100));
+
+      final bottomNavigation = find.byKey(
+        const Key('mobile-bottom-navigation'),
+      );
+      expect(bottomNavigation, findsOneWidget);
+      expect(tester.getBottomLeft(bottomNavigation).dy, 844);
+
+      await configureMobileView(
+        tester,
+        bottomPadding: 24,
+        keyboardInset: 320,
+      );
+      await tester.pump();
+
+      expect(tester.getBottomLeft(bottomNavigation).dy, 844);
+
+      await tester.pump(const Duration(milliseconds: 300));
+    } finally {
+      debugDefaultTargetPlatformOverride = previousTargetPlatform;
+      StorageService.debugUseSharedPreferencesStorageForTesting(null);
+      SharedPreferences.setMockInitialValues({});
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      await resetMobileView(tester);
+    }
   });
 
   testWidgets('移动端安全区保护 FluentPage 标题区域', (tester) async {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -248,11 +248,7 @@ void main() {
       expect(bottomNavigation, findsOneWidget);
       expect(tester.getBottomLeft(bottomNavigation).dy, 844);
 
-      await configureMobileView(
-        tester,
-        bottomPadding: 24,
-        keyboardInset: 320,
-      );
+      await configureMobileView(tester, bottomPadding: 24, keyboardInset: 320);
       await tester.pump();
 
       expect(tester.getBottomLeft(bottomNavigation).dy, 844);


### PR DESCRIPTION
## 变更说明

修复移动端调起输入法时外层导航壳与页面内容同时响应键盘 inset，导致底部导航和页面出现重复让位、闪烁或布局错乱的问题。

本次将移动端 `_CompactNavigationShell` 外层 `ScaffoldPage` 的 `resizeToAvoidBottomInset` 关闭，让键盘让位由内部具体页面和滚动容器处理，并新增回归测试模拟键盘 `viewInsets.bottom`。

## 关联 Issue

Closes #244

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 能力增强
- [ ] 文档更新
- [ ] 代码重构
- [x] 测试补充
- [ ] 构建 / CI / 依赖 / 仓库治理
- [ ] 其它：

## 影响范围

- [x] Flutter 前端（`lib/`）
- [ ] 服务层 / 外部站点 / 数据模型
- [ ] 本地存储 / 凭据 / 隐私数据
- [x] 平台工程（Android / iOS / macOS / Linux / Windows / Web）
- [ ] 安装器 / 更新 / Release
- [ ] GitHub Actions / Issue 或 PR 模板 / 仓库治理
- [ ] 文档
- [ ] 不确定或需要重点 Review：

## 验证记录

- [x] `flutter analyze` 或 `flutter analyze --no-fatal-infos`
- [ ] `flutter test`
- [x] 针对性测试：`flutter test test/widget_test.dart --name "移动端输入法弹出时外层底部导航不重复让位"`
- [x] 针对性测试：`flutter test test/widget_test.dart --name "移动端"`
- [ ] 平台构建验证：
- [ ] 手动验证：
- [x] 未执行部分验证，原因：本次为窄范围移动端布局修复，未跑全量测试和真实设备手动输入法验证。

## 风险与回滚

- 风险等级：
  - [x] 低
  - [ ] 中
  - [ ] 高
- 主要风险：部分页面若自身滚动容器没有正确处理键盘遮挡，仍可能需要页面级优化；本 PR 只修复外层导航重复让位。
- 回滚方式：还原 `lib/app.dart` 中 `_CompactNavigationShell` 的 `resizeToAvoidBottomInset: false` 和对应测试改动。

## 检查清单

- [x] 没有提交无关文件、构建产物或本地自动化配置
- [x] 没有引入账号、密码、Cookie、Token、私钥、keystore 或真实用户数据
- [x] 已更新相关文档 / Changelog，或说明无需更新
- [x] 若修改版本 / Release / CI，已遵循 `docs/RELEASE.md`
- [x] 若无需关联 Issue，确认本 PR 属于 docs/chore/dependencies/release 等豁免场景
- [x] 用户可见文件名、Release 标题和说明中未显式写出 `+build`
