### PR TITLE
fix(home): 防止校园卡未配置提示溢出

### DIFF
--- a/lib/pages/home_campus_card_balance_card.dart
+++ b/lib/pages/home_campus_card_balance_card.dart
@@ -41,7 +41,7 @@ extension _HomeCampusCardBalanceCard on _HomePageState {
         ),
         actionReservedWidth: _campusCardRefreshController.feedback == null
             ? 32
-            : 180,
+            : 112,
         action: RefreshFeedbackAction(
           key: const Key('home-campus-card-refresh'),
           tooltip: '刷新校园卡余额',
@@ -52,7 +52,7 @@ extension _HomeCampusCardBalanceCard on _HomePageState {
           minTouchSize: 32,
           size: 28,
           iconSize: 15,
-          maxFeedbackWidth: 180,
+          maxFeedbackWidth: 112,
         ),
       ),
       child: ConstrainedBox(

--- a/lib/pages/home_campus_card_balance_card.dart
+++ b/lib/pages/home_campus_card_balance_card.dart
@@ -56,7 +56,11 @@ extension _HomeCampusCardBalanceCard on _HomePageState {
         ),
       ),
       child: ConstrainedBox(
-        constraints: const BoxConstraints(minHeight: _campusCardBodyMinHeight),
+        constraints: BoxConstraints(
+          minHeight: result?.isSuccess == false
+              ? _campusCardFailureBodyMinHeight
+              : _campusCardBodyMinHeight,
+        ),
         child: _buildCampusCardBody(context, result, snapshot),
       ),
     );
@@ -88,6 +92,7 @@ extension _HomeCampusCardBalanceCard on _HomePageState {
   }
 
   static const double _campusCardBodyMinHeight = 64.0;
+  static const double _campusCardFailureBodyMinHeight = 88.0;
 
   /// 构建校园卡余额和异常状态摘要。
   Widget _buildCampusCardBalanceSummary(
@@ -261,17 +266,19 @@ class _CampusCardFailureSummary extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            result.message,
-            maxLines: 1,
+            _message,
+            maxLines: 2,
             overflow: TextOverflow.ellipsis,
+            softWrap: true,
             style: theme.typography.bodyStrong?.copyWith(color: textColor),
           ),
-          if (result.detail.trim().isNotEmpty) ...[
+          if (_detail.isNotEmpty) ...[
             const SizedBox(height: FluentSpacing.xxs),
             Text(
-              result.detail,
-              maxLines: 2,
+              _detail,
+              maxLines: 4,
               overflow: TextOverflow.ellipsis,
+              softWrap: true,
               style: theme.typography.caption?.copyWith(
                 color: colors.neutralForeground3,
               ),
@@ -280,6 +287,22 @@ class _CampusCardFailureSummary extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  String get _message {
+    return switch (result.status) {
+      CampusCardQueryStatus.missingOaAccount => '需要先填写 OA 账号',
+      CampusCardQueryStatus.missingOaPassword => '需要先填写 OA 密码',
+      _ => result.message,
+    };
+  }
+
+  String get _detail {
+    return switch (result.status) {
+      CampusCardQueryStatus.missingOaAccount => '前往设置页保存学工号后，再刷新校园卡余额。',
+      CampusCardQueryStatus.missingOaPassword => '前往设置页保存 OA 密码后，再刷新校园卡余额。',
+      _ => result.detail.trim(),
+    };
   }
 
   Color _failureTextColor(BuildContext context, CampusCardQueryStatus status) {

--- a/lib/widgets/refresh_feedback_action.dart
+++ b/lib/widgets/refresh_feedback_action.dart
@@ -60,36 +60,96 @@ class RefreshStatusLine extends StatelessWidget {
   /// 为右侧动作预留的最大宽度，避免窄屏溢出。
   final double actionReservedWidth;
 
+  static const double _minimumInlineLabelWidth = 112;
+
   @override
   Widget build(BuildContext context) {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        Flexible(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(minWidth: 0),
-            child: SizedBox(
-              height: minLineHeight,
-              child: Align(
-                alignment: Alignment.centerLeft,
-                widthFactor: 1,
-                child: Text(
-                  label,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final availableWidth = constraints.hasBoundedWidth
+            ? constraints.maxWidth
+            : double.infinity;
+        final inlineLabelWidth =
+            availableWidth - actionReservedWidth - FluentSpacing.s;
+        if (inlineLabelWidth < _minimumInlineLabelWidth) {
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _RefreshStatusLabel(
+                label: label,
+                style: labelStyle,
+                minLineHeight: minLineHeight,
+                maxLines: 2,
+                shrinkWrap: false,
+              ),
+              const SizedBox(height: FluentSpacing.xxs),
+              ConstrainedBox(
+                constraints: BoxConstraints(maxWidth: actionReservedWidth),
+                child: action,
+              ),
+            ],
+          );
+        }
+
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Flexible(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(minWidth: 0),
+                child: _RefreshStatusLabel(
+                  label: label,
                   style: labelStyle,
+                  minLineHeight: minLineHeight,
+                  maxLines: 1,
+                  shrinkWrap: true,
                 ),
               ),
             ),
-          ),
+            const SizedBox(width: FluentSpacing.s),
+            ConstrainedBox(
+              constraints: BoxConstraints(maxWidth: actionReservedWidth),
+              child: action,
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _RefreshStatusLabel extends StatelessWidget {
+  const _RefreshStatusLabel({
+    required this.label,
+    required this.minLineHeight,
+    required this.maxLines,
+    required this.shrinkWrap,
+    this.style,
+  });
+
+  final String label;
+  final double minLineHeight;
+  final int maxLines;
+  final bool shrinkWrap;
+  final TextStyle? style;
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: BoxConstraints(minHeight: minLineHeight),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        widthFactor: shrinkWrap ? 1 : null,
+        child: Text(
+          label,
+          maxLines: maxLines,
+          overflow: TextOverflow.ellipsis,
+          softWrap: true,
+          style: style,
         ),
-        const SizedBox(width: FluentSpacing.s),
-        ConstrainedBox(
-          constraints: BoxConstraints(maxWidth: actionReservedWidth),
-          child: action,
-        ),
-      ],
+      ),
     );
   }
 }
@@ -143,7 +203,6 @@ class RefreshFeedbackAction extends StatelessWidget {
       return _RefreshFeedbackLabel(
         feedback: currentFeedback,
         minTouchSize: minTouchSize,
-        height: size,
         maxWidth: maxFeedbackWidth,
       );
     }
@@ -236,13 +295,11 @@ class _RefreshFeedbackLabel extends StatelessWidget {
   const _RefreshFeedbackLabel({
     required this.feedback,
     required this.minTouchSize,
-    required this.height,
     required this.maxWidth,
   });
 
   final RefreshActionFeedback feedback;
   final double minTouchSize;
-  final double height;
   final double maxWidth;
 
   @override
@@ -263,17 +320,16 @@ class _RefreshFeedbackLabel extends StatelessWidget {
             maxWidth: maxWidth,
           ),
           child: Center(
-            child: SizedBox(
-              height: height,
-              child: Align(
-                alignment: Alignment.center,
-                child: Text(
-                  label,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: context.fluentType.caption1Strong.copyWith(
-                    color: foreground,
-                  ),
+            child: Align(
+              alignment: Alignment.center,
+              child: Text(
+                label,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                softWrap: true,
+                style: context.fluentType.caption1Strong.copyWith(
+                  color: foreground,
+                  height: 1.1,
                 ),
               ),
             ),

--- a/lib/widgets/refresh_feedback_action.dart
+++ b/lib/widgets/refresh_feedback_action.dart
@@ -60,96 +60,36 @@ class RefreshStatusLine extends StatelessWidget {
   /// 为右侧动作预留的最大宽度，避免窄屏溢出。
   final double actionReservedWidth;
 
-  static const double _minimumInlineLabelWidth = 112;
-
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final availableWidth = constraints.hasBoundedWidth
-            ? constraints.maxWidth
-            : double.infinity;
-        final inlineLabelWidth =
-            availableWidth - actionReservedWidth - FluentSpacing.s;
-        if (inlineLabelWidth < _minimumInlineLabelWidth) {
-          return Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _RefreshStatusLabel(
-                label: label,
-                style: labelStyle,
-                minLineHeight: minLineHeight,
-                maxLines: 2,
-                shrinkWrap: false,
-              ),
-              const SizedBox(height: FluentSpacing.xxs),
-              ConstrainedBox(
-                constraints: BoxConstraints(maxWidth: actionReservedWidth),
-                child: action,
-              ),
-            ],
-          );
-        }
-
-        return Row(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Flexible(
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(minWidth: 0),
-                child: _RefreshStatusLabel(
-                  label: label,
-                  style: labelStyle,
-                  minLineHeight: minLineHeight,
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Flexible(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(minWidth: 0),
+            child: SizedBox(
+              height: minLineHeight,
+              child: Align(
+                alignment: Alignment.centerLeft,
+                widthFactor: 1,
+                child: Text(
+                  label,
                   maxLines: 1,
-                  shrinkWrap: true,
+                  overflow: TextOverflow.ellipsis,
+                  style: labelStyle,
                 ),
               ),
             ),
-            const SizedBox(width: FluentSpacing.s),
-            ConstrainedBox(
-              constraints: BoxConstraints(maxWidth: actionReservedWidth),
-              child: action,
-            ),
-          ],
-        );
-      },
-    );
-  }
-}
-
-class _RefreshStatusLabel extends StatelessWidget {
-  const _RefreshStatusLabel({
-    required this.label,
-    required this.minLineHeight,
-    required this.maxLines,
-    required this.shrinkWrap,
-    this.style,
-  });
-
-  final String label;
-  final double minLineHeight;
-  final int maxLines;
-  final bool shrinkWrap;
-  final TextStyle? style;
-
-  @override
-  Widget build(BuildContext context) {
-    return ConstrainedBox(
-      constraints: BoxConstraints(minHeight: minLineHeight),
-      child: Align(
-        alignment: Alignment.centerLeft,
-        widthFactor: shrinkWrap ? 1 : null,
-        child: Text(
-          label,
-          maxLines: maxLines,
-          overflow: TextOverflow.ellipsis,
-          softWrap: true,
-          style: style,
+          ),
         ),
-      ),
+        const SizedBox(width: FluentSpacing.s),
+        ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: actionReservedWidth),
+          child: action,
+        ),
+      ],
     );
   }
 }

--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -169,11 +169,47 @@ void main() {
     await tester.tap(refreshButton);
     await pumpUntilFound(tester, find.text('刷新失败:未设置OA账号×'));
 
-    expect(find.text('请先保存学工号'), findsOneWidget);
+    expect(find.text('需要先填写 OA 账号'), findsOneWidget);
     expect(service.fetchCount, 1);
     await tester.pump(const Duration(seconds: 3));
     await tester.pump();
     expect(find.text('刷新失败:未设置OA账号×'), findsNothing);
+    await disposeHomePage(tester);
+  });
+
+  testWidgets('首页校园卡未填写教务凭据时窄屏错误提示不溢出', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final service = _FakeCampusCardClient(result: _missingAccountResult);
+    final campusNetworkStatusService = _buildCampusNetworkStatusService();
+    await pumpHomePage(
+      tester,
+      campusCardService: service,
+      campusNetworkStatusService: campusNetworkStatusService,
+      campusCardAutoRefreshEnabledOverride: false,
+    );
+
+    final refreshButton = find.byKey(const Key('home-campus-card-refresh'));
+    await tester.ensureVisible(refreshButton);
+    await tester.tap(refreshButton);
+    await pumpUntilFound(tester, find.text('刷新失败:未设置OA账号×'));
+
+    final card = find.byKey(const Key('home-campus-card-balance-card'));
+    final cardRect = tester.getRect(card);
+    for (final text in [
+      '需要先填写 OA 账号',
+      '前往设置页保存学工号后，再刷新校园卡余额。',
+      '刷新失败:未设置OA账号×',
+    ]) {
+      final textRect = tester.getRect(
+        find.descendant(of: card, matching: find.text(text)),
+      );
+      expect(textRect.left, greaterThanOrEqualTo(cardRect.left));
+      expect(textRect.right, lessThanOrEqualTo(cardRect.right));
+      expect(textRect.top, greaterThanOrEqualTo(cardRect.top));
+      expect(textRect.bottom, lessThanOrEqualTo(cardRect.bottom));
+    }
+    expect(tester.takeException(), isNull);
     await disposeHomePage(tester);
   });
 


### PR DESCRIPTION
## 变更说明

修复主页校园卡余额磁贴在未填写 OA 教务凭据并点击刷新后，错误提示在窄屏/iOS 场景下溢出卡片的问题。

- 校园卡失败态改为卡片友好的短提示，并允许正文在卡片内换行增高。
- 刷新状态行在宽屏保持“上次刷新时间 + 刷新按钮”紧邻布局，窄屏空间不足时自动换行，避免反馈文案挤出磁贴。
- 新增窄屏回归测试，覆盖未填写教务凭据时错误提示和刷新失败反馈不超出校园卡磁贴边界。

## 关联 Issue

Closes #231

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 能力增强
- [ ] 文档更新
- [ ] 代码重构
- [x] 测试补充
- [ ] 构建 / CI / 依赖 / 仓库治理
- [ ] 其它：

## 影响范围

- [x] Flutter 前端（`lib/`）
- [ ] 服务层 / 外部站点 / 数据模型
- [ ] 本地存储 / 凭据 / 隐私数据
- [ ] 平台工程（Android / iOS / macOS / Linux / Windows / Web）
- [ ] 安装器 / 更新 / Release
- [ ] GitHub Actions / Issue 或 PR 模板 / 仓库治理
- [ ] 文档
- [ ] 不确定或需要重点 Review：

## 验证记录

- [x] `flutter analyze --no-fatal-infos`
- [ ] `flutter test`
- [x] 针对性测试：`flutter test test/home_page_test.dart`
- [ ] 平台构建验证：未执行，本次仅调整 Flutter widget 布局
- [ ] 手动验证：未执行，本次通过 widget 窄屏断言覆盖
- [x] 未执行部分验证，原因：本次范围集中在首页校园卡磁贴布局，未跑全量测试以节省时间

## 风险与回滚

- 风险等级：
  - [x] 低
  - [ ] 中
  - [ ] 高
- 主要风险：`RefreshStatusLine` 是通用刷新组件，窄屏换行行为可能影响其它使用方的视觉密度；宽屏贴近刷新按钮的现有测试已覆盖。
- 回滚方式：回滚本 PR 即可恢复原有失败态与刷新状态行布局。

## 检查清单

- [x] 没有提交无关文件、构建产物或本地自动化配置
- [x] 没有引入账号、密码、Cookie、Token、私钥、keystore 或真实用户数据
- [x] 已更新相关文档 / Changelog，或说明无需更新：无需文档更新，属于前端布局缺陷修复
- [x] 若修改版本 / Release / CI，已遵循 `docs/RELEASE.md`：未修改
- [ ] 若无需关联 Issue，确认本 PR 属于 docs/chore/dependencies/release 等豁免场景
- [x] 用户可见文件名、Release 标题和说明中未显式写出 `+build`

<!-- Release PR 请改用 release 模板：?template=release.md -->