### PR TITLE
fix(settings): 修复 iOS 凭据保存滚动崩溃

### DIFF
--- a/lib/pages/settings_page_layout.dart
+++ b/lib/pages/settings_page_layout.dart
@@ -199,6 +199,7 @@ mixin _SettingsPageLayout on State<SettingsPage>, _SettingsPageActions {
   /// 带动画的滚动内容区。
   Widget _buildScrollableContent(EdgeInsets padding) {
     return SingleChildScrollView(
+      primary: false,
       padding: padding,
       child: _buildContentPanel(context)
           .animate(key: ValueKey(_selectedTab))

--- a/lib/widgets/app_feedback.dart
+++ b/lib/widgets/app_feedback.dart
@@ -62,22 +62,24 @@ void showFluentInfoBar(
   }
 
   entry = OverlayEntry(
-    builder: (context) => SafeArea(
-      child: Align(
-        alignment: Alignment.bottomCenter,
-        child: Padding(
-          padding: const EdgeInsetsDirectional.symmetric(
-            horizontal: 16,
-            vertical: 24,
-          ),
-          child: PhysicalModel(
-            color: Colors.transparent,
-            elevation: 8,
-            child: FluentInfoBar(
-              title: title,
-              content: content,
-              severity: severity,
-              action: actionBuilder?.call(close),
+    builder: (context) => PrimaryScrollController.none(
+      child: SafeArea(
+        child: Align(
+          alignment: Alignment.bottomCenter,
+          child: Padding(
+            padding: const EdgeInsetsDirectional.symmetric(
+              horizontal: 16,
+              vertical: 24,
+            ),
+            child: PhysicalModel(
+              color: Colors.transparent,
+              elevation: 8,
+              child: FluentInfoBar(
+                title: title,
+                content: content,
+                severity: severity,
+                action: actionBuilder?.call(close),
+              ),
             ),
           ),
         ),

--- a/test/settings_security_section_test.dart
+++ b/test/settings_security_section_test.dart
@@ -163,6 +163,80 @@ void main() {
     await tester.pump();
   });
 
+  testWidgets('iOS 保存教务凭据时反馈浮层不复用路由主滚动控制器', (tester) async {
+    FlutterSecureStorage.setMockInitialValues({});
+    final previousTargetPlatform = debugDefaultTargetPlatformOverride;
+    final sharedController = ScrollController();
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    await configureNarrowView(tester);
+
+    try {
+      await tester.pumpWidget(
+        FluentApp(
+          home: PrimaryScrollController(
+            controller: sharedController,
+            child: Stack(
+              children: [
+                const Positioned.fill(
+                  child: SingleChildScrollView(
+                    child: SizedBox(
+                      height: 1200,
+                      child: Text('同路由主滚动内容'),
+                    ),
+                  ),
+                ),
+                Positioned.fill(
+                  child: SingleChildScrollView(
+                    primary: false,
+                    child: SettingsSecuritySection(
+                      isPasswordEnabled: false,
+                      onPasswordProtectionChanged: (_) {},
+                      onChangePassword: () {},
+                      isQuickAuthEnabled: false,
+                      isQuickAuthAvailable: false,
+                      isQuickAuthBusy: false,
+                      onQuickAuthChanged: (_) {},
+                      onLock: null,
+                      onClearMessageCache: () {},
+                      onClearAllData: () {},
+                      academicOaSessionPrewarmService:
+                          _RecordingAcademicOaSessionPrewarmService(),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      await pumpUntilFound(tester, find.text('保存教务凭据'));
+      expect(find.text('保存教务凭据'), findsOneWidget);
+
+      expect(sharedController.positions, hasLength(1));
+
+      final editableFields = find.byType(EditableText, skipOffstage: false);
+      await tester.enterText(editableFields.at(0), '20260001');
+      await tester.enterText(editableFields.at(1), 'oa-pass');
+      await tester.ensureVisible(find.text('保存教务凭据'));
+      await tester.tap(find.text('保存教务凭据'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('教务凭据已保存'), findsOneWidget);
+      expect(sharedController.positions, hasLength(1));
+
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pump(const Duration(milliseconds: 100));
+    } finally {
+      debugDefaultTargetPlatformOverride = previousTargetPlatform;
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      await resetView(tester);
+      sharedController.dispose();
+    }
+  });
+
   testWidgets('系统快速验证在可用时显示开关，不可用时显示密码兜底提示', (tester) async {
     FlutterSecureStorage.setMockInitialValues({});
 

--- a/test/settings_security_section_test.dart
+++ b/test/settings_security_section_test.dart
@@ -179,10 +179,7 @@ void main() {
               children: [
                 const Positioned.fill(
                   child: SingleChildScrollView(
-                    child: SizedBox(
-                      height: 1200,
-                      child: Text('同路由主滚动内容'),
-                    ),
+                    child: SizedBox(height: 1200, child: Text('同路由主滚动内容')),
                   ),
                 ),
                 Positioned.fill(


### PR DESCRIPTION
## Summary
- Fixes #232 by preventing the settings page scroll view from inheriting the route-level `PrimaryScrollController` on iOS.
- Isolates transient feedback overlays with `PrimaryScrollController.none` so future scrollable feedback content cannot reuse page scroll state.
- Adds an iOS regression test covering credential save feedback while another route-level primary scroll view is attached.

## Root Cause
On iOS, vertical scroll views without an explicit controller can automatically inherit the nearest `PrimaryScrollController`. When the credential-save flow rebuilt the settings UI and displayed the success feedback overlay, multiple scroll positions could be attached to the same route-level controller, triggering Flutter's `The provided ScrollController is attached to more than one ScrollPosition` assertion.

## Validation
- `flutter test test/settings_security_section_test.dart`
- `flutter analyze --no-fatal-infos`

## Quick Review
- Reviewed the diff without rerunning tests per request.
- No blocking issues found: the fix is scoped to scroll-controller inheritance and feedback overlay isolation.
