### PR TITLE
fix(release): 缩短 macOS DMG 卷名

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -380,11 +380,15 @@ jobs:
           cp .github/installer/macos/bg.png "$staging/bg.png"
 
           APP_VERSION="${{ needs.prepare.outputs.public_version }}"
-          APP_BUILD="${{ needs.prepare.outputs.build_number }}"
+          DMG_TITLE="SSPU-AIO v${APP_VERSION}"
+          if [ "${#DMG_TITLE}" -gt 27 ]; then
+            echo "::warning::macOS DMG volume title '${DMG_TITLE}' is longer than appdmg limit; using short product title"
+            DMG_TITLE="SSPU-AIO"
+          fi
 
           cat > "$staging/config.json" << APPDMG_EOF
           {
-            "title": "SSPU-AllinOne v${APP_VERSION} (${APP_BUILD})",
+            "title": "${DMG_TITLE}",
             "icon-size": 80,
             "window": {
               "size": {

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -170,7 +170,7 @@ SSPU-AllinOne-v1.0.0.1-hotfix-linux-x64-appimage.AppImage
 
 Linux 正式发布必须同时覆盖 `x64` 与 `arm64`，并提供 AppImage、deb、rpm、tar.gz 四类产物。
 
-Windows installer 使用 Inno Setup 双模式安装器，x64 与 arm64 行为保持一致：全新安装默认当前用户范围，可在安装向导或命令行显式切换到所有用户范围；安装包文件名和 Release 资产类型仍保持 `windows-{arch}-installer.exe`。安装器可本地化展示应用名，但默认安装路径固定为 `SSPU-AllinOne`。安装器启动时会检测既有安装：不同版本进入升级安装，沿用既有当前用户 / 所有用户范围和目录并跳过目录选择；相同版本会询问是否重装，确认后先调用既有卸载器，卸载器负责询问是否保留用户目录下的 `.sspu-aio/` 应用数据，再回到正常安装流程。安装器许可页使用 `assets/legal/legal_zh.txt`，需要与应用首次启动展示的完整法律与隐私说明保持同步。Android 正式 Release 构建必须提供 `ANDROID_KEYSTORE_BASE64`、`ANDROID_KEYSTORE_PASSWORD`、`ANDROID_KEY_ALIAS`、`ANDROID_KEY_PASSWORD`，缺少任一签名 Secret 都会直接失败，不允许回退到 debug 签名。macOS 正式 Release 构建必须提供 `MACOS_SIGNING_CERTIFICATE_BASE64`、`MACOS_SIGNING_CERTIFICATE_PASSWORD`、`MACOS_NOTARY_APPLE_ID`、`MACOS_NOTARY_TEAM_ID`、`MACOS_NOTARY_PASSWORD`，产物命名为 `macos-universal.dmg`。
+Windows installer 使用 Inno Setup 双模式安装器，x64 与 arm64 行为保持一致：全新安装默认当前用户范围，可在安装向导或命令行显式切换到所有用户范围；安装包文件名和 Release 资产类型仍保持 `windows-{arch}-installer.exe`。安装器可本地化展示应用名，但默认安装路径固定为 `SSPU-AllinOne`。安装器启动时会检测既有安装：不同版本进入升级安装，沿用既有当前用户 / 所有用户范围和目录并跳过目录选择；相同版本会询问是否重装，确认后先调用既有卸载器，卸载器负责询问是否保留用户目录下的 `.sspu-aio/` 应用数据，再回到正常安装流程。安装器许可页使用 `assets/legal/legal_zh.txt`，需要与应用首次启动展示的完整法律与隐私说明保持同步。Android 正式 Release 构建必须提供 `ANDROID_KEYSTORE_BASE64`、`ANDROID_KEYSTORE_PASSWORD`、`ANDROID_KEY_ALIAS`、`ANDROID_KEY_PASSWORD`，缺少任一签名 Secret 都会直接失败，不允许回退到 debug 签名。macOS 正式 Release 构建必须提供 `MACOS_SIGNING_CERTIFICATE_BASE64`、`MACOS_SIGNING_CERTIFICATE_PASSWORD`、`MACOS_NOTARY_APPLE_ID`、`MACOS_NOTARY_TEAM_ID`、`MACOS_NOTARY_PASSWORD`，产物命名为 `macos-universal.dmg`，DMG 卷名需保持在 appdmg 的 27 字符限制内。
 
 Android、iOS、macOS、Linux、portable 与压缩包等当前没有仓库统一控制的安装前 GUI 或 CLI 协议确认页；这些渠道依赖应用首次启动的完整法律与隐私说明弹窗完成一次性确认。
 

--- a/test/macos_release_entitlements_test.dart
+++ b/test/macos_release_entitlements_test.dart
@@ -40,4 +40,23 @@ void main() {
       ),
     );
   });
+
+  test('macOS DMG 卷名保持在 appdmg 长度限制内', () {
+    final releaseWorkflow = File(
+      '.github/workflows/release.yml',
+    ).readAsStringSync();
+
+    expect(
+      releaseWorkflow,
+      isNot(
+        contains('"title": "SSPU-AllinOne v\${APP_VERSION} (\${APP_BUILD})"'),
+      ),
+    );
+    expect(releaseWorkflow, contains('DMG_TITLE="SSPU-AIO v\${APP_VERSION}"'));
+    expect(releaseWorkflow, contains('if [ "\${#DMG_TITLE}" -gt 27 ]; then'));
+    expect(releaseWorkflow, contains('"title": "\${DMG_TITLE}"'));
+
+    const currentPublicVersion = '0.2.8-alpha';
+    expect('SSPU-AIO v$currentPublicVersion'.length, lessThanOrEqualTo(27));
+  });
 }


### PR DESCRIPTION
## 变更说明

修复 v0.2.8-alpha 发布链路中 macOS DMG 生成失败的问题。PR #248 切换到 appdmg 后，DMG volume title 需要满足 appdmg 的 27 字符限制；原标题把完整产品名、公开版本和 build number 拼在一起，`0.2.8-alpha+4` 发布时超过限制并触发断言。

本次将 macOS DMG 卷名改为短标题 `SSPU-AIO v${APP_VERSION}`，并在未来版本号异常变长时回退到 `SSPU-AIO`，同时补充回归测试和发布文档说明。正式 Release 仍产出 Developer ID 签名并公证的 `macos-universal.dmg`。

## 关联 Issue

Fixes #259
Refs #248

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 能力增强
- [x] 文档更新
- [ ] 代码重构
- [x] 测试补充
- [x] 构建 / CI / 依赖 / 仓库治理
- [ ] 其它：

## 影响范围

- [ ] Flutter 前端（`lib/`）
- [ ] 服务层 / 外部站点 / 数据模型
- [ ] 本地存储 / 凭据 / 隐私数据
- [x] 平台工程（Android / iOS / macOS / Linux / Windows）
- [x] 安装器 / 更新 / Release
- [x] GitHub Actions / Issue 或 PR 模板 / 仓库治理
- [x] 文档
- [ ] 不确定或需要重点 Review：

## 验证记录

- [x] `flutter analyze --no-fatal-infos`
- [ ] `flutter test`
- [x] 针对性测试：`flutter test test/macos_release_entitlements_test.dart`
- [ ] 平台构建验证：
- [ ] 手动验证：
- [x] 未执行部分验证，原因：全量 `flutter test` 和完整 Release workflow 留给 PR CI 与合并后的手动 workflow_dispatch；当前改动只触及 release workflow 文本、文档和对应回归测试。

## 风险与回滚

- 风险等级：
  - [x] 低
  - [ ] 中
  - [ ] 高
- 主要风险：macOS DMG Finder 挂载卷名变短，但 Release 资产文件名、manifest、签名/公证流程不变。
- 回滚方式：回滚本 PR；若要重新加长卷名，必须保留 appdmg 27 字符限制检查。

## 检查清单

- [x] 没有提交无关文件、构建产物或本地自动化配置
- [x] 没有引入账号、密码、Cookie、Token、私钥、keystore 或真实用户数据
- [x] 已更新相关文档 / Changelog，或说明无需更新
- [x] 若修改版本 / Release / CI，已遵循 `docs/RELEASE.md`
- [ ] 若无需关联 Issue，确认本 PR 属于 docs/chore/dependencies/release 等豁免场景
- [x] 用户可见文件名、Release 标题和说明中未显式写出 `+build`
