### PR TITLE
fix(release): 对齐 Windows arm64 JDK 架构

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,7 +216,7 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
-          architecture: x64
+          architecture: arm64
 
       - uses: ./.github/actions/setup-flutter-arm64
         with:

--- a/test/release_workflow_test.dart
+++ b/test/release_workflow_test.dart
@@ -1,0 +1,29 @@
+/*
+ * Release 工作流配置回归测试
+ * @Project : SSPU-AllinOne
+ * @File : release_workflow_test.dart
+ * @Author : Qintsg
+ * @Date : 2026-06-12
+ */
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Windows arm64 Release 使用 arm64 JDK 避免 jni 链接混架构', () {
+    final releaseWorkflow = File(
+      '.github/workflows/release.yml',
+    ).readAsStringSync();
+    final windowsArm64Job = RegExp(
+      r'build-windows-arm64:[\s\S]*?(?=\n  build-macos:)',
+    ).firstMatch(releaseWorkflow)?.group(0);
+
+    expect(windowsArm64Job, isNotNull);
+    expect(windowsArm64Job, contains('runs-on: windows-11-arm'));
+    expect(windowsArm64Job, contains('actions/setup-java@v5.2.0'));
+    expect(windowsArm64Job, contains("java-version: '21'"));
+    expect(windowsArm64Job, contains('architecture: arm64'));
+    expect(windowsArm64Job, isNot(contains('architecture: x64')));
+  });
+}


### PR DESCRIPTION
## 变更说明

修复 v0.2.8-alpha 手动发布 run `27367214922` 中 Windows arm64 资产构建失败的问题。macOS 签名 DMG、DMG 生成与公证已经在该 run 中通过；新的失败点是 `windows-11-arm` runner 的 Windows arm64 构建使用了 `architecture: x64` 的 JDK，导致 `jni` 插件链接 x64 `jvm.lib`，最终在 ARM64 目标下出现 `LNK4272` / `LNK1120`。

本次将 Windows arm64 release job 的 `actions/setup-java` 架构改为 `arm64`，并新增 release workflow 回归测试，锁定 arm64 runner、Java 版本和 JDK 架构必须一致。

## 关联 Issue

Fixes #259
Refs #248

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 能力增强
- [ ] 文档更新
- [ ] 代码重构
- [x] 测试补充
- [x] 构建 / CI / 依赖 / 仓库治理
- [ ] 其它：

## 影响范围

- [ ] Flutter 前端（`lib/`）
- [ ] 服务层 / 外部站点 / 数据模型
- [ ] 本地存储 / 凭据 / 隐私数据
- [x] 平台工程（Android / iOS / macOS / Linux / Windows）
- [x] 安装器 / 更新 / Release
- [x] GitHub Actions / Issue 或 PR 模板 / 仓库治理
- [ ] 文档
- [ ] 不确定或需要重点 Review：

## 验证记录

- [x] `flutter analyze --no-fatal-infos`
- [ ] `flutter test`
- [x] 针对性测试：`flutter test test/release_workflow_test.dart`
- [ ] 平台构建验证：
- [x] 手动验证：GitHub Release run `27367214922` 已确认 macOS 签名、DMG 生成、公证通过，Windows arm64 失败原因为 JDK/JNI 架构不一致。
- [x] 未执行部分验证，原因：完整 Windows arm64 构建与发布流程需由合并后的 Release workflow 重新执行。

## 风险与回滚

- 风险等级：
  - [x] 低
  - [ ] 中
  - [ ] 高
- 主要风险：Windows arm64 job 的 JDK 改为 arm64 后，依赖 action/runner 需要能提供 Temurin 21 arm64；该配置与 runner/目标架构一致，是 jni 链接的必要条件。
- 回滚方式：回滚本 PR；但回滚会恢复当前已确认的 Windows arm64 `jvm.lib` 混架构链接失败。

## 检查清单

- [x] 没有提交无关文件、构建产物或本地自动化配置
- [x] 没有引入账号、密码、Cookie、Token、私钥、keystore 或真实用户数据
- [x] 已更新相关文档 / Changelog，或说明无需更新：`docs/CHANGELOG.md` 已包含 Windows arm64 JDK 架构修复记录
- [x] 若修改版本 / Release / CI，已遵循 `docs/RELEASE.md`
- [ ] 若无需关联 Issue，确认本 PR 属于 docs/chore/dependencies/release 等豁免场景
- [x] 用户可见文件名、Release 标题和说明中未显式写出 `+build`
