### PR TITLE
fix(release): 指定 Release Tag 目标提交

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -632,6 +632,7 @@ jobs:
         uses: softprops/action-gh-release@v3.0.0
         with:
           tag_name: ${{ needs.prepare.outputs.tag }}
+          target_commitish: ${{ github.sha }}
           name: ${{ needs.prepare.outputs.release_title }}
           body_path: dist/release-notes.md
           prerelease: ${{ needs.prepare.outputs.prerelease }}

--- a/test/release_workflow_test.dart
+++ b/test/release_workflow_test.dart
@@ -11,6 +11,22 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('GitHub Release Tag 指向当前 workflow 提交而不是默认分支', () {
+    final releaseWorkflow = File(
+      '.github/workflows/release.yml',
+    ).readAsStringSync();
+    final publishStep = RegExp(
+      r'softprops/action-gh-release@v3\.0\.0[\s\S]*?files: dist/\*',
+    ).firstMatch(releaseWorkflow)?.group(0);
+
+    expect(publishStep, isNotNull);
+    expect(
+      publishStep,
+      contains('tag_name: \${{ needs.prepare.outputs.tag }}'),
+    );
+    expect(publishStep, contains('target_commitish: \${{ github.sha }}'));
+  });
+
   test('Windows arm64 Release 使用 arm64 JDK 避免 jni 链接混架构', () {
     final releaseWorkflow = File(
       '.github/workflows/release.yml',


### PR DESCRIPTION
## 变更说明

修复 v0.2.8-alpha 发布成功后发现的 Release Tag 指向错误问题。手动从 `develop` 触发 alpha 发布时，`softprops/action-gh-release` 在 tag 不存在且未指定 `target_commitish` 的情况下会按仓库默认分支创建 tag；这导致刚发布出的 `v0.2.8-alpha` 资产虽然完整，但 tag 指向了 `main` 而不是本次 workflow 的 `develop` head。

已删除错误的 `v0.2.8-alpha` Release 与远端 tag，本 PR 显式设置 `target_commitish: ${{ github.sha }}`，确保后续 alpha/beta/rc 从非默认分支发布时 tag 指向实际触发发布的提交。

## 关联 Issue

Fixes #259
Refs #248

## 变更类型

- [x] Bug 修复
- [ ] 新功能 / 能力增强
- [ ] 文档更新
- [ ] 代码重构
- [x] 测试补充
- [x] 构建 / CI / 依赖 / 仓库治理
- [ ] 其它：

## 影响范围

- [ ] Flutter 前端（`lib/`）
- [ ] 服务层 / 外部站点 / 数据模型
- [ ] 本地存储 / 凭据 / 隐私数据
- [ ] 平台工程（Android / iOS / macOS / Linux / Windows）
- [x] 安装器 / 更新 / Release
- [x] GitHub Actions / Issue 或 PR 模板 / 仓库治理
- [ ] 文档
- [ ] 不确定或需要重点 Review：

## 验证记录

- [x] `flutter analyze --no-fatal-infos`
- [ ] `flutter test`
- [x] 针对性测试：`flutter test test/release_workflow_test.dart`
- [ ] 平台构建验证：
- [x] 手动验证：Release run `27368273071` 已确认所有资产构建与发布成功，但发布后校验发现 tag 指向默认分支；错误 Release/tag 已删除。
- [x] 未执行部分验证，原因：完整发布流程将在合并后重新 workflow_dispatch 验证。

## 风险与回滚

- 风险等级：
  - [x] 低
  - [ ] 中
  - [ ] 高
- 主要风险：`target_commitish` 改为当前 workflow 提交后，Release tag 会绑定触发发布的实际提交；这是 alpha/beta/rc 从 develop 发布的预期行为。
- 回滚方式：回滚本 PR；但回滚会恢复非默认分支发布时 tag 可能指向默认分支的问题。

## 检查清单

- [x] 没有提交无关文件、构建产物或本地自动化配置
- [x] 没有引入账号、密码、Cookie、Token、私钥、keystore 或真实用户数据
- [x] 已更新相关文档 / Changelog，或说明无需更新：本次为 release workflow 行为修复，并有测试覆盖
- [x] 若修改版本 / Release / CI，已遵循 `docs/RELEASE.md`
- [ ] 若无需关联 Issue，确认本 PR 属于 docs/chore/dependencies/release 等豁免场景
- [x] 用户可见文件名、Release 标题和说明中未显式写出 `+build`
