### PR TITLE
chore(android): 迁移 app 工程到 Built-in Kotlin

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -2,8 +2,7 @@ import java.util.Properties
 
 plugins {
     id("com.android.application")
-    id("kotlin-android")
-    // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
+    // The Flutter Gradle Plugin must be applied after the Android Gradle plugin.
     id("dev.flutter.flutter-gradle-plugin")
 }
 
@@ -21,10 +20,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     defaultConfig {
@@ -61,6 +56,12 @@ android {
                 "proguard-rules.pro",
             )
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,6 +1,5 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-# This builtInKotlin flag was added automatically by Flutter migrator
-android.builtInKotlin=false
-# This newDsl flag was added automatically by Flutter migrator
-android.newDsl=false
+# 显式启用 AGP / Flutter Built-in Kotlin 与新 DSL，避免 Flutter migrator 回写禁用标记。
+android.builtInKotlin=true
+android.newDsl=true

--- a/test/android_built_in_kotlin_test.dart
+++ b/test/android_built_in_kotlin_test.dart
@@ -1,0 +1,34 @@
+/*
+ * Android Built-in Kotlin 迁移配置回归测试
+ * @Project : SSPU-AllinOne
+ * @File : android_built_in_kotlin_test.dart
+ * @Author : Qintsg
+ * @Date : 2026-06-12
+ */
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+String _read(String path) => File(path).readAsStringSync();
+
+void main() {
+  test('app 模块不再直接应用 Kotlin Gradle Plugin', () {
+    final appGradle = _read('android/app/build.gradle.kts');
+
+    expect(appGradle, isNot(contains('id("kotlin-android")')));
+    expect(appGradle, isNot(contains('id("org.jetbrains.kotlin.android")')));
+    expect(appGradle, isNot(contains('kotlinOptions')));
+    expect(appGradle, contains('compilerOptions'));
+    expect(appGradle, contains('JvmTarget.JVM_17'));
+  });
+
+  test('Flutter migrator 的临时 Built-in Kotlin 兼容开关已显式启用', () {
+    final gradleProperties = _read('android/gradle.properties');
+
+    expect(gradleProperties, contains('android.builtInKotlin=true'));
+    expect(gradleProperties, contains('android.newDsl=true'));
+    expect(gradleProperties, isNot(contains('android.builtInKotlin=false')));
+    expect(gradleProperties, isNot(contains('android.newDsl=false')));
+  });
+}


### PR DESCRIPTION
## 变更说明

将 Android app 模块迁移到 Flutter / AGP Built-in Kotlin 路线：

- 移除 `android/app/build.gradle.kts` 中 app 级 `kotlin-android` 插件声明。
- 移除旧 `kotlinOptions`，改用 `kotlin { compilerOptions { jvmTarget = JvmTarget.JVM_17 } }`。
- 将 `android.builtInKotlin` / `android.newDsl` 显式设为 `true`，避免 Flutter 3.44 migrator 在构建时继续写回禁用兼容层。
- 新增文本级回归测试，锁定 app 模块不再直接应用 KGP 且 Gradle 属性保持显式 opt-in。

Android debug 构建中 app 工程自身的 Built-in Kotlin 迁移 warning 已消失。当前仍剩余插件级 warning：`package_info_plus 10.1.0` 的 Android 插件包自身仍 `apply plugin: 'kotlin-android'`，且该版本已经是当前可解析最新版，因此本 PR 将其记录为上游插件迁移阻塞。

## 关联 Issue

Fixes #216

## 变更类型

- [ ] Bug 修复
- [ ] 新功能 / 能力增强
- [ ] 文档更新
- [ ] 代码重构
- [x] 测试补充
- [x] 构建 / CI / 依赖 / 仓库治理
- [ ] 其它：

## 影响范围

- [ ] Flutter 前端（`lib/`）
- [ ] 服务层 / 外部站点 / 数据模型
- [ ] 本地存储 / 凭据 / 隐私数据
- [x] 平台工程（Android / iOS / macOS / Linux / Windows）
- [ ] 安装器 / 更新 / Release
- [ ] GitHub Actions / Issue 或 PR 模板 / 仓库治理
- [ ] 文档
- [x] 不确定或需要重点 Review：`package_info_plus` 插件级 KGP warning 仍依赖上游迁移

## 验证记录

- [x] `flutter analyze --no-fatal-infos`
  - 通过；仅保留既有 info 级 `prefer_initializing_formals` 提示。
- [x] `flutter test`
- [x] 针对性测试：`flutter test test/android_built_in_kotlin_test.dart`
- [x] 平台构建验证：`flutter build apk --debug`
  - 通过，产物：`build\app\outputs\flutter-apk\app-debug.apk`
  - app 工程 KGP warning 已消失；剩余 `package_info_plus` 插件级 KGP warning。
- [x] 手动验证：确认 `package_info_plus 10.1.0` 为当前可解析最新版，且缓存包 `android/build.gradle` 仍声明 `apply plugin: 'kotlin-android'`。
- [ ] 未执行部分验证，原因：Android release signing build 依赖签名材料，本 PR 只验证 debug Gradle 迁移路径。

## 风险与回滚

- 风险等级：
  - [ ] 低
  - [x] 中
  - [ ] 高
- 主要风险：显式启用 Built-in Kotlin / new DSL 可能暴露尚未迁移的上游 Android 插件问题；当前 debug 构建已通过，但 `package_info_plus` 仍有插件级 warning。
- 回滚方式：还原本 PR 的 Android Gradle 配置与测试文件；若必须短期回退，可恢复 app 级 `kotlin-android` / `kotlinOptions` 并将 `android.builtInKotlin=false`、`android.newDsl=false` 写回 `gradle.properties`。

## 检查清单

- [x] 没有提交无关文件、构建产物或本地自动化配置
- [x] 没有引入账号、密码、Cookie、Token、私钥、keystore 或真实用户数据
- [x] 已更新相关文档 / Changelog，或说明无需更新
- [x] 若修改版本 / Release / CI，已遵循 `docs/RELEASE.md`
- [x] 若无需关联 Issue，确认本 PR 属于 docs/chore/dependencies/release 等豁免场景
- [x] 用户可见文件名、Release 标题和说明中未显式写出 `+build`
