### PR TITLE
feat(ios): iOS文章阅读切换为Safari阅读器视图

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -31,13 +31,11 @@ import '../services/storage_service.dart';
 import '../services/student_report_service.dart';
 import '../theme/fluent_tokens.dart';
 import '../utils/query_result_messages.dart';
-import '../utils/webview_env.dart';
+import '../utils/app_web_launcher.dart';
 import '../widgets/campus_network_status_indicator.dart';
 import '../widgets/refresh_feedback_action.dart';
 import '../widgets/responsive_layout.dart';
 import 'course_schedule_page.dart';
-import 'webview_page.dart';
-
 part 'home_campus_card_balance_card.dart';
 part 'home_campus_card_detail_page.dart';
 part 'home_student_profile_card.dart';
@@ -887,18 +885,13 @@ class _HomePageState extends State<HomePage> {
     final theme = FluentTheme.of(context);
     return FluentHoverButton(
       onPressed: () async {
-        // 标记已读并跳转内嵌 WebView。
+        // 标记已读并在 iOS 使用 Safari View Controller 打开。
         MessageStateService.instance.markAsRead(msg.id);
-        final webViewEnvironment = await ensureGlobalWebViewEnvironment();
         if (!context.mounted) return;
-        Navigator.of(context).push(
-          FluentPageRoute(
-            builder: (_) => WebViewPage(
-              url: msg.url,
-              initialTitle: msg.title,
-              webViewEnvironment: webViewEnvironment,
-            ),
-          ),
+        await openAppWebUrl(
+          context,
+          url: msg.url,
+          title: msg.title,
         );
       },
       builder: (context, states) {

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -888,11 +888,7 @@ class _HomePageState extends State<HomePage> {
         // 标记已读并在 iOS 使用 Safari View Controller 打开。
         MessageStateService.instance.markAsRead(msg.id);
         if (!context.mounted) return;
-        await openAppWebUrl(
-          context,
-          url: msg.url,
-          title: msg.title,
-        );
+        await openAppWebUrl(context, url: msg.url, title: msg.title);
       },
       builder: (context, states) {
         final isHovered = states.isHovered;

--- a/lib/pages/info_page.dart
+++ b/lib/pages/info_page.dart
@@ -213,11 +213,7 @@ class _InfoPageState extends State<InfoPage> {
   Future<void> _openMessage(MessageItem message) async {
     await _stateService.markAsRead(message.id);
     if (mounted) {
-      await openAppWebUrl(
-        context,
-        url: message.url,
-        title: message.title,
-      );
+      await openAppWebUrl(context, url: message.url, title: message.title);
       setState(() {});
     }
   }

--- a/lib/pages/info_page.dart
+++ b/lib/pages/info_page.dart
@@ -21,8 +21,7 @@ import '../widgets/app_feedback.dart';
 import '../widgets/message_tile.dart';
 import '../widgets/responsive_layout.dart';
 import '../services/message_state_service.dart';
-import '../utils/webview_env.dart';
-import 'webview_page.dart';
+import '../utils/app_web_launcher.dart';
 
 part 'info_page_filters.dart';
 part 'info_page_controls.dart';
@@ -213,16 +212,11 @@ class _InfoPageState extends State<InfoPage> {
   /// WebView 初始化失败时自动 fallback 到外部浏览器
   Future<void> _openMessage(MessageItem message) async {
     await _stateService.markAsRead(message.id);
-    final webViewEnvironment = await ensureGlobalWebViewEnvironment();
     if (mounted) {
-      Navigator.of(context).push(
-        FluentPageRoute(
-          builder: (_) => WebViewPage(
-            url: message.url,
-            initialTitle: message.title,
-            webViewEnvironment: webViewEnvironment,
-          ),
-        ),
+      await openAppWebUrl(
+        context,
+        url: message.url,
+        title: message.title,
       );
       setState(() {});
     }

--- a/lib/utils/app_web_launcher.dart
+++ b/lib/utils/app_web_launcher.dart
@@ -1,0 +1,80 @@
+/*
+ * 应用网页打开工具 — iOS 普通网页优先使用系统 Safari View Controller
+ * @Project : SSPU-AllinOne
+ * @File : app_web_launcher.dart
+ * @Author : KsuserKqy
+ * @Date : 2026-06-10
+ */
+
+import '../design/fluent_ui.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+import '../pages/webview_page.dart';
+import '../widgets/app_feedback.dart';
+import 'webview_env.dart';
+
+/// 应用内普通网页入口。
+///
+/// iOS 使用系统 SFSafariViewController（通过 flutter_inappwebview 的
+/// ChromeSafariBrowser），并以 page sheet 从当前页面底部拉起，避免为只读文章页
+/// 加载完整 Flutter WebView。
+/// iOS 打开失败时仅在当前页提示，不 push Flutter 新页面。
+/// 需要读取 Cookie / 注入 JS 的流程仍应直接使用 WebViewPage 或专用 WebView 页面。
+Future<void> openAppWebUrl(
+  BuildContext context, {
+  required String url,
+  required String title,
+}) async {
+  final uri = Uri.tryParse(url.trim());
+  final isSupportedWebUrl =
+      uri != null &&
+      uri.host.isNotEmpty &&
+      (uri.scheme == 'http' || uri.scheme == 'https');
+
+  if (!kIsWeb &&
+      defaultTargetPlatform == TargetPlatform.iOS &&
+      isSupportedWebUrl) {
+    try {
+      await ChromeSafariBrowser().open(
+        url: WebUri(uri.toString()),
+        settings: ChromeSafariBrowserSettings(
+          dismissButtonStyle: DismissButtonStyle.CLOSE,
+          presentationStyle: ModalPresentationStyle.PAGE_SHEET,
+          transitionStyle: ModalTransitionStyle.COVER_VERTICAL,
+        ),
+      );
+      return;
+    } catch (error) {
+      debugPrint('[AppWebLauncher] Safari View Controller 打开失败: $error');
+    }
+    if (!context.mounted) return;
+    showAppFeedback(
+      context,
+      message: '无法打开链接',
+      severity: AppFeedbackSeverity.warning,
+    );
+    return;
+  }
+
+  if (!kIsWeb && defaultTargetPlatform == TargetPlatform.iOS) {
+    if (!context.mounted) return;
+    showAppFeedback(
+      context,
+      message: '链接无效，无法打开',
+      severity: AppFeedbackSeverity.warning,
+    );
+    return;
+  }
+
+  final webViewEnvironment = await ensureGlobalWebViewEnvironment();
+  if (!context.mounted) return;
+  Navigator.of(context).push(
+    FluentPageRoute(
+      builder: (_) => WebViewPage(
+        url: url,
+        initialTitle: title,
+        webViewEnvironment: webViewEnvironment,
+      ),
+    ),
+  );
+}

--- a/test/app_web_launcher_test.dart
+++ b/test/app_web_launcher_test.dart
@@ -223,6 +223,11 @@ class _TestInAppWebViewPlatform extends InAppWebViewPlatform {
   PlatformChromeSafariBrowser createPlatformChromeSafariBrowserStatic() {
     return chromeSafariBrowser;
   }
+
+  @override
+  PlatformWebViewEnvironment createPlatformWebViewEnvironmentStatic() {
+    return _TestPlatformWebViewEnvironment();
+  }
 }
 
 class _TestPlatformInAppWebViewWidget extends PlatformInAppWebViewWidget {
@@ -304,4 +309,14 @@ class _TestPlatformChromeSafariBrowser extends PlatformChromeSafariBrowser {
 
   @override
   bool isOpened() => openedUrl != null && !shouldThrowOnOpen;
+}
+
+class _TestPlatformWebViewEnvironment extends PlatformWebViewEnvironment {
+  _TestPlatformWebViewEnvironment()
+    : super.implementation(const PlatformWebViewEnvironmentCreationParams());
+
+  @override
+  Future<String?> getAvailableVersion({String? browserExecutableFolder}) async {
+    return null;
+  }
 }

--- a/test/app_web_launcher_test.dart
+++ b/test/app_web_launcher_test.dart
@@ -1,0 +1,307 @@
+/*
+ * 应用网页打开工具测试 — 校验 iOS Safari View Controller 与跨平台 WebView 分流
+ * @Project : SSPU-AllinOne
+ * @File : app_web_launcher_test.dart
+ * @Author : KsuserKqy
+ * @Date : 2026-06-10
+ */
+
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sspu_allinone/design/fluent_ui.dart';
+import 'package:sspu_allinone/pages/webview_page.dart';
+import 'package:sspu_allinone/utils/app_web_launcher.dart';
+
+void main() {
+  late InAppWebViewPlatform? previousWebViewPlatform;
+  late _TestInAppWebViewPlatform testWebViewPlatform;
+
+  setUp(() {
+    previousWebViewPlatform = InAppWebViewPlatform.instance;
+    testWebViewPlatform = _TestInAppWebViewPlatform();
+    InAppWebViewPlatform.instance = testWebViewPlatform;
+  });
+
+  tearDown(() {
+    if (previousWebViewPlatform != null) {
+      InAppWebViewPlatform.instance = previousWebViewPlatform!;
+    }
+  });
+
+  testWidgets('iOS 普通网页使用 Safari View Controller 打开', (tester) async {
+    final previousTargetPlatform = debugDefaultTargetPlatformOverride;
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+    try {
+      await tester.pumpWidget(
+        FluentApp(
+          home: Builder(
+            builder: (context) => FluentButton(
+              onPressed: () => openAppWebUrl(
+                context,
+                url: 'https://example.com/news',
+                title: '网页标题',
+              ),
+              child: const Text('打开网页'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('打开网页'));
+      await tester.pump();
+
+      expect(
+        testWebViewPlatform.chromeSafariBrowser.openedUrl?.toString(),
+        'https://example.com/news',
+      );
+      expect(
+        testWebViewPlatform.chromeSafariBrowser.openSettings?.presentationStyle,
+        ModalPresentationStyle.PAGE_SHEET,
+      );
+      expect(
+        testWebViewPlatform.chromeSafariBrowser.openSettings?.transitionStyle,
+        ModalTransitionStyle.COVER_VERTICAL,
+      );
+      expect(find.byType(WebViewPage), findsNothing);
+    } finally {
+      await tester.pump(const Duration(milliseconds: 120));
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      debugDefaultTargetPlatformOverride = previousTargetPlatform;
+    }
+  });
+
+  testWidgets('非 iOS 普通网页继续进入 WebViewPage', (tester) async {
+    final previousTargetPlatform = debugDefaultTargetPlatformOverride;
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+
+    try {
+      await tester.pumpWidget(
+        FluentApp(
+          home: Builder(
+            builder: (context) => FluentButton(
+              onPressed: () => openAppWebUrl(
+                context,
+                url: 'https://example.com/news',
+                title: '网页标题',
+              ),
+              child: const Text('打开网页'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('打开网页'));
+      await tester.pumpAndSettle();
+
+      expect(testWebViewPlatform.chromeSafariBrowser.openedUrl, isNull);
+      expect(find.byType(WebViewPage), findsOneWidget);
+      expect(
+        find.byKey(const Key('fake-app-web-launcher-webview')),
+        findsOneWidget,
+      );
+    } finally {
+      await tester.pump(const Duration(milliseconds: 120));
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      debugDefaultTargetPlatformOverride = previousTargetPlatform;
+    }
+  });
+
+  testWidgets('iOS Safari View Controller 打开失败时不进入 WebViewPage', (
+    tester,
+  ) async {
+    final previousTargetPlatform = debugDefaultTargetPlatformOverride;
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    testWebViewPlatform.chromeSafariBrowser.shouldThrowOnOpen = true;
+
+    try {
+      await tester.pumpWidget(
+        FluentApp(
+          home: Builder(
+            builder: (context) => FluentButton(
+              onPressed: () => openAppWebUrl(
+                context,
+                url: 'https://example.com/news',
+                title: '网页标题',
+              ),
+              child: const Text('打开网页'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('打开网页'));
+      await tester.pumpAndSettle();
+
+      expect(
+        testWebViewPlatform.chromeSafariBrowser.openedUrl?.toString(),
+        'https://example.com/news',
+      );
+      expect(
+        testWebViewPlatform.chromeSafariBrowser.openSettings?.presentationStyle,
+        ModalPresentationStyle.PAGE_SHEET,
+      );
+      expect(find.byType(WebViewPage), findsNothing);
+      expect(find.text('无法打开链接'), findsOneWidget);
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pump();
+    } finally {
+      await tester.pump(const Duration(milliseconds: 120));
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      debugDefaultTargetPlatformOverride = previousTargetPlatform;
+    }
+  });
+
+  testWidgets('iOS 无效网页链接留在原页面并显示反馈', (tester) async {
+    final previousTargetPlatform = debugDefaultTargetPlatformOverride;
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+    try {
+      await tester.pumpWidget(
+        FluentApp(
+          home: Builder(
+            builder: (context) => FluentButton(
+              onPressed: () => openAppWebUrl(
+                context,
+                url: 'https://wywh.sspu.edu.cnjavascript:void(0);',
+                title: '无效链接',
+              ),
+              child: const Text('打开网页'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('打开网页'));
+      await tester.pumpAndSettle();
+
+      expect(testWebViewPlatform.chromeSafariBrowser.openedUrl, isNull);
+      expect(find.byType(WebViewPage), findsNothing);
+      expect(find.text('链接无效，无法打开'), findsOneWidget);
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pump();
+    } finally {
+      await tester.pump(const Duration(milliseconds: 120));
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      debugDefaultTargetPlatformOverride = previousTargetPlatform;
+    }
+  });
+}
+
+class _TestInAppWebViewPlatform extends InAppWebViewPlatform {
+  final _TestPlatformInAppWebViewController controller =
+      _TestPlatformInAppWebViewController();
+  final _TestPlatformChromeSafariBrowser chromeSafariBrowser =
+      _TestPlatformChromeSafariBrowser();
+
+  @override
+  PlatformInAppWebViewController createPlatformInAppWebViewController(
+    PlatformInAppWebViewControllerCreationParams params,
+  ) {
+    return controller;
+  }
+
+  @override
+  PlatformInAppWebViewWidget createPlatformInAppWebViewWidget(
+    PlatformInAppWebViewWidgetCreationParams params,
+  ) {
+    return _TestPlatformInAppWebViewWidget(params, controller);
+  }
+
+  @override
+  PlatformChromeSafariBrowser createPlatformChromeSafariBrowser(
+    PlatformChromeSafariBrowserCreationParams params,
+  ) {
+    return chromeSafariBrowser;
+  }
+
+  @override
+  PlatformChromeSafariBrowser createPlatformChromeSafariBrowserStatic() {
+    return chromeSafariBrowser;
+  }
+}
+
+class _TestPlatformInAppWebViewWidget extends PlatformInAppWebViewWidget {
+  _TestPlatformInAppWebViewWidget(super.params, this.controller)
+    : super.implementation();
+
+  final _TestPlatformInAppWebViewController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final appController = params.controllerFromPlatform?.call(controller);
+    if (appController is InAppWebViewController &&
+        !controller.callbacksDispatched) {
+      controller.callbacksDispatched = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        params.onWebViewCreated?.call(appController);
+        params.onTitleChanged?.call(appController, '网页标题');
+        params.onLoadStop?.call(appController, WebUri('https://example.com'));
+      });
+    }
+    return const SizedBox.expand(key: Key('fake-app-web-launcher-webview'));
+  }
+
+  @override
+  T controllerFromPlatform<T>(PlatformInAppWebViewController controller) {
+    return params.controllerFromPlatform!.call(controller) as T;
+  }
+
+  @override
+  void dispose() {}
+}
+
+class _TestPlatformInAppWebViewController
+    extends PlatformInAppWebViewController {
+  _TestPlatformInAppWebViewController()
+    : super.implementation(
+        const PlatformInAppWebViewControllerCreationParams(id: 'test-webview'),
+      );
+
+  bool callbacksDispatched = false;
+
+  @override
+  Future<bool> canGoBack() async => false;
+
+  @override
+  Future<bool> canGoForward() async => false;
+
+  @override
+  Future<WebUri?> getUrl() async => WebUri('https://example.com');
+}
+
+class _TestPlatformChromeSafariBrowser extends PlatformChromeSafariBrowser {
+  _TestPlatformChromeSafariBrowser()
+    : super.implementation(const PlatformChromeSafariBrowserCreationParams());
+
+  WebUri? openedUrl;
+  ChromeSafariBrowserSettings? openSettings;
+  bool shouldThrowOnOpen = false;
+
+  @override
+  String get id => 'test-chrome-safari-browser';
+
+  @override
+  Future<void> open({
+    WebUri? url,
+    Map<String, String>? headers,
+    List<WebUri>? otherLikelyURLs,
+    WebUri? referrer,
+    // ignore: deprecated_member_use, deprecated_member_use_from_same_package
+    ChromeSafariBrowserClassOptions? options,
+    ChromeSafariBrowserSettings? settings,
+  }) async {
+    openedUrl = url;
+    openSettings = settings;
+    if (shouldThrowOnOpen) {
+      throw Exception('open failed');
+    }
+  }
+
+  @override
+  bool isOpened() => openedUrl != null && !shouldThrowOnOpen;
+}


### PR DESCRIPTION
## 变更说明

新增 `app_web_launcher.dart` 工具函数，在 iOS 平台使用系统 Safari View Controller（通过 flutter_inappwebview 的 ChromeSafariBrowser）打开普通网页，以 page sheet 从当前页面底部拉起，替代原先的完整 Flutter WebView，提升文章阅读加载性能和用户体验。

已将信息中心（`info_page.dart`）和首页（`home_page.dart`）的消息/文章阅读入口接入 `openAppWebUrl()`，非 iOS 平台保持原有 WebViewPage 打开方式不变。

## 关联 Issue

Closes #230

## 变更类型

- [x] 新功能 / 能力增强

## 影响范围

- [x] Flutter 前端（`lib/utils/app_web_launcher.dart`, `lib/pages/info_page.dart`, `lib/pages/home_page.dart`）
- [x] 平台工程（iOS）

## 验证记录

- [x] `flutter analyze` — No issues found
- [ ] `flutter test`（本地 Flutter tester 连接问题，待 CI 验证）
- [x] 针对性测试：`test/app_web_launcher_test.dart` 包含 4 个单元测试用例：
  - iOS 普通网页使用 Safari View Controller 打开
  - 非 iOS 普通网页继续进入 WebViewPage
  - iOS Safari View Controller 打开失败时不进入 WebViewPage
  - iOS 无效网页链接留在原页面并显示反馈
- [ ] 平台构建验证：
- [ ] 手动验证：

## 风险与回滚

- 风险等级：
  - [x] 低
- 主要风险：仅替换消息/文章阅读入口的打开方式，工具函数内已处理非 iOS 回退和失败降级
- 回滚方式：revert 即可

## 检查清单

- [x] 没有提交无关文件、构建产物或本地自动化配置
- [x] 没有引入账号、密码、Cookie、Token、私钥、keystore 或真实用户数据
- [x] 已更新相关文档 / Changelog，或说明无需更新（无需更新）
- [x] 用户可见文件名、Release 标题和说明中未显式写出 `+build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)