### PR TITLE
ci(security): 添加安全扫描与覆盖率工作流

### DIFF
--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -21,7 +21,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: subosito/flutter-action@v2.23.0
+    - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
       with:
         flutter-version: ${{ inputs.flutter-version }}
         channel: ${{ inputs.channel }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: subosito/flutter-action@v2.23.0
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
         run: python scripts/ci/validate_github_governance.py
 
   quality-gate:
+    name: Dart / Flutter Quality Gate
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
@@ -141,10 +142,10 @@ jobs:
 
           dart format --set-exit-if-changed "${dart_files[@]}"
 
-      - name: Flutter Analyze
+      - name: Flutter Analyze（Dart 静态分析）
         run: flutter analyze --no-fatal-infos
 
-      - name: Flutter Test
+      - name: Flutter Test（Dart / Widget 测试）
         run: flutter test
 
   release-policy:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,69 @@
+# Flutter 覆盖率 — 生成 lcov 报告并作为 PR/分支构建产物保存。
+name: Code Coverage
+
+on:
+  pull_request:
+    branches: [develop]
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - 'analysis_options.yaml'
+      - 'lib/**'
+      - 'pubspec.lock'
+      - 'pubspec.yaml'
+      - 'test/**'
+  push:
+    branches: [develop, main]
+    paths:
+      - 'analysis_options.yaml'
+      - 'lib/**'
+      - 'pubspec.lock'
+      - 'pubspec.yaml'
+      - 'test/**'
+  workflow_dispatch:
+
+env:
+  FLUTTER_VERSION: '3.44.0'
+
+permissions:
+  contents: read
+
+jobs:
+  flutter-coverage:
+    name: Flutter Coverage
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6.0.3
+
+      - uses: subosito/flutter-action@v2.23.0
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: 安装依赖
+        run: flutter pub get
+
+      - name: Flutter Test Coverage
+        run: flutter test --coverage
+
+      - name: 写入覆盖率摘要
+        shell: bash
+        run: |
+          set -euo pipefail
+          line_count="$(grep -c '^DA:' coverage/lcov.info || true)"
+          {
+            echo '## Flutter Coverage'
+            echo
+            echo '- lcov 文件：`coverage/lcov.info`'
+            echo "- 覆盖记录行数：${line_count}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: 上传 lcov 覆盖率报告
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: flutter-coverage-lcov
+          path: coverage/lcov.info
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.3
 
-      - uses: subosito/flutter-action@v2.23.0
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,95 @@
+# CodeQL 高级分析 — 扫描 GitHub Actions、平台原生 runner 与维护脚本。
+name: CodeQL Analysis
+
+on:
+  push:
+    branches: [develop, main]
+    paths:
+      - '.github/actions/**'
+      - '.github/workflows/**'
+      - 'ios/Podfile'
+      - 'macos/Podfile'
+      - 'linux/**/*.c'
+      - 'linux/**/*.cc'
+      - 'linux/**/*.h'
+      - 'linux/**/CMakeLists.txt'
+      - 'scripts/**/*.py'
+      - 'windows/**/*.c'
+      - 'windows/**/*.cpp'
+      - 'windows/**/*.h'
+      - 'windows/**/CMakeLists.txt'
+  pull_request:
+    branches: [develop]
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - '.github/actions/**'
+      - '.github/workflows/**'
+      - 'ios/Podfile'
+      - 'macos/Podfile'
+      - 'linux/**/*.c'
+      - 'linux/**/*.cc'
+      - 'linux/**/*.h'
+      - 'linux/**/CMakeLists.txt'
+      - 'scripts/**/*.py'
+      - 'windows/**/*.c'
+      - 'windows/**/*.cpp'
+      - 'windows/**/*.h'
+      - 'windows/**/CMakeLists.txt'
+  schedule:
+    - cron: '20 2 * * 1'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+          - language: python
+          - language: ruby
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-extended,security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          category: '/language:${{ matrix.language }}'
+
+  analyze-cpp:
+    name: Analyze (c-cpp)
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          languages: c-cpp
+          build-mode: none
+          queries: +security-extended,security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          category: '/language:c-cpp'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,8 +7,6 @@ on:
     paths:
       - '.github/actions/**'
       - '.github/workflows/**'
-      - 'ios/Podfile'
-      - 'macos/Podfile'
       - 'linux/**/*.c'
       - 'linux/**/*.cc'
       - 'linux/**/*.h'
@@ -24,8 +22,6 @@ on:
     paths:
       - '.github/actions/**'
       - '.github/workflows/**'
-      - 'ios/Podfile'
-      - 'macos/Podfile'
       - 'linux/**/*.c'
       - 'linux/**/*.cc'
       - 'linux/**/*.h'
@@ -56,7 +52,6 @@ jobs:
         include:
           - language: actions
           - language: python
-          - language: ruby
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -1,0 +1,35 @@
+# Secret Scanning — 使用 Gitleaks 作为 PR 与定时密钥泄漏补充扫描。
+name: Secret Scanning
+
+on:
+  pull_request:
+    branches: [develop]
+    types: [opened, reopened, synchronize, ready_for_review]
+  push:
+    branches: [develop, main]
+  schedule:
+    - cron: '45 2 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Scan repository for secrets
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: 'false'
+          GITLEAKS_ENABLE_SUMMARY: 'true'
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: 'true'

--- a/.github/分支命名规范.md
+++ b/.github/分支命名规范.md
@@ -46,6 +46,7 @@
 - 非草稿 PR 会校验标题格式 `type(scope): 中文摘要`、目标分支和 `release` label 使用范围；分支命名作为推荐规范，不作为 CI 阻断项。
 - CI 默认运行变更 Dart 文件格式检查、`flutter analyze --no-fatal-infos` 与 `flutter test`。
 - 修改 `.github/`、Issue / PR 模板或 labeler 时，会运行 GitHub 治理配置校验。
+- 安全扫描默认包含高级 CodeQL、Secret Scanning 与 Coverage workflow；Dart/Flutter 代码质量由现有 Flutter 门禁和覆盖率报告承担。
 - Release workflow 复用逻辑必须优先沉淀到 `.github/actions/` composite actions；治理配置校验会检查必要 action 是否存在并被 Release workflow 引用。
 - 修改依赖、lockfile、Gradle、Podfile、GitHub Actions 或 composite action 时，会触发 Dependency Review。
 - `release` label 仅允许人工添加到合法 Release PR；自动 labeler 和 triage workflow 不得添加该标签。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## [Unreleased]
 
+### 新增
+
+- 新增高级 CodeQL、Gitleaks 密钥扫描与 Flutter 覆盖率 workflow，并将 Dart / Flutter 质量门禁文案整合到现有 CI。
+
 ## [0.2.8-alpha] - 2026-06-12
 
 ### 发布

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -231,10 +231,11 @@ Android、iOS、macOS、Linux、portable 与压缩包等当前没有仓库统一
 2. `flutter analyze --no-fatal-infos` 通过。
 3. `flutter test` 通过。
 4. 变更 Dart 文件通过 `dart format --set-exit-if-changed` 检查。
-5. 版本号只在 `pubspec.yaml` 与 `docs/CHANGELOG.md` 中维护。
-6. Release PR 的目标分支、`release` label 使用方式与本规则一致。
-7. 构建产物文件名不包含 `+build`。
-8. 发布说明列明支持平台、已知问题、安装方式和校验方式。
+5. GitHub Actions 安全门禁保持启用：高级 CodeQL、Secret Scanning、Dependency Review 与 Coverage workflow 不应被 Release 改动绕过。
+6. 版本号只在 `pubspec.yaml` 与 `docs/CHANGELOG.md` 中维护。
+7. Release PR 的目标分支、`release` label 使用方式与本规则一致。
+8. 构建产物文件名不包含 `+build`。
+9. 发布说明列明支持平台、已知问题、安装方式和校验方式。
 
 ---
 

--- a/docs/specs/RepoWorkflow.md
+++ b/docs/specs/RepoWorkflow.md
@@ -73,6 +73,8 @@ Scope: repo
 ## 验证规则
 
 - CI 对非草稿 PR 默认校验 PR 标题格式、目标分支、release label 使用、GitHub 治理文件、变更 Dart 文件格式、`flutter analyze --no-fatal-infos` 与 `flutter test`；分支命名按规范推荐但不作为普通 PR 阻断项；`develop -> main` 同步 PR 会跳过变更 Dart 文件格式检查，避免历史差异阻断默认分支治理同步。
+- 安全与质量扫描包含高级 CodeQL、Gitleaks 密钥扫描与 Flutter 覆盖率报告：CodeQL 扫描 GitHub Actions、C/C++ 平台 runner、Python 维护脚本和 CocoaPods 相关 Ruby 配置；Dart/Flutter 代码由 Dart Format、Flutter Analyze、Flutter Test 与 Coverage workflow 承担，避免使用不支持 Dart 的 CodeQL 语言配置。
+- Coverage workflow 在 PR、`develop` 与 `main` 相关 Dart/测试变更上运行 `flutter test --coverage`，并上传 `coverage/lcov.info` 作为短期 artifact。
 - Release workflow 复用逻辑放在 `.github/actions/` composite actions 中，覆盖 Flutter 初始化、arm64 SDK 安装、Windows portable 打包、Linux 多格式产物整理和 Release 元数据生成；治理校验会检查这些 action 存在且被 Release workflow 引用。
 - 本地 Dart/Flutter 静态分析：优先运行 `flutter analyze`，期望 `No issues found!`。
 - 本地测试：优先运行 `flutter test`；若耗时或平台限制导致无法全量运行，应至少运行受影响测试并说明限制。

--- a/docs/specs/RepoWorkflow.md
+++ b/docs/specs/RepoWorkflow.md
@@ -73,7 +73,7 @@ Scope: repo
 ## 验证规则
 
 - CI 对非草稿 PR 默认校验 PR 标题格式、目标分支、release label 使用、GitHub 治理文件、变更 Dart 文件格式、`flutter analyze --no-fatal-infos` 与 `flutter test`；分支命名按规范推荐但不作为普通 PR 阻断项；`develop -> main` 同步 PR 会跳过变更 Dart 文件格式检查，避免历史差异阻断默认分支治理同步。
-- 安全与质量扫描包含高级 CodeQL、Gitleaks 密钥扫描与 Flutter 覆盖率报告：CodeQL 扫描 GitHub Actions、C/C++ 平台 runner、Python 维护脚本和 CocoaPods 相关 Ruby 配置；Dart/Flutter 代码由 Dart Format、Flutter Analyze、Flutter Test 与 Coverage workflow 承担，避免使用不支持 Dart 的 CodeQL 语言配置。
+- 安全与质量扫描包含高级 CodeQL、Gitleaks 密钥扫描与 Flutter 覆盖率报告：CodeQL 扫描 GitHub Actions、C/C++ 平台 runner 和 Python 维护脚本；Dart/Flutter 代码由 Dart Format、Flutter Analyze、Flutter Test 与 Coverage workflow 承担，避免使用不支持 Dart 的 CodeQL 语言配置。
 - Coverage workflow 在 PR、`develop` 与 `main` 相关 Dart/测试变更上运行 `flutter test --coverage`，并上传 `coverage/lcov.info` 作为短期 artifact。
 - Release workflow 复用逻辑放在 `.github/actions/` composite actions 中，覆盖 Flutter 初始化、arm64 SDK 安装、Windows portable 打包、Linux 多格式产物整理和 Release 元数据生成；治理校验会检查这些 action 存在且被 Release workflow 引用。
 - 本地 Dart/Flutter 静态分析：优先运行 `flutter analyze`，期望 `No issues found!`。

--- a/test/github_security_workflow_test.dart
+++ b/test/github_security_workflow_test.dart
@@ -1,0 +1,64 @@
+/*
+ * GitHub 安全扫描工作流回归测试
+ * @Project : SSPU-AllinOne
+ * @File : github_security_workflow_test.dart
+ * @Author : Qintsg
+ * @Date : 2026-06-12
+ */
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+String _readWorkflow(String fileName) {
+  return File('.github/workflows/$fileName').readAsStringSync();
+}
+
+void main() {
+  test('高级 CodeQL 覆盖 Actions、C/C++、Python 与 Ruby 配置', () {
+    final workflow = _readWorkflow('codeql.yml');
+
+    expect(workflow, contains('name: CodeQL Analysis'));
+    expect(workflow, contains('security-events: write'));
+    expect(workflow, contains('github/codeql-action/init@'));
+    expect(workflow, contains('github/codeql-action/analyze@'));
+    expect(workflow, contains('language: actions'));
+    expect(workflow, contains('language: python'));
+    expect(workflow, contains('language: ruby'));
+    expect(workflow, contains('languages: c-cpp'));
+    expect(workflow, contains('build-mode: none'));
+    expect(workflow, contains("category: '/language:c-cpp'"));
+    expect(workflow, isNot(contains('language: dart')));
+  });
+
+  test('Flutter 覆盖率 workflow 上传 lcov artifact', () {
+    final workflow = _readWorkflow('code-coverage.yml');
+
+    expect(workflow, contains('name: Code Coverage'));
+    expect(workflow, contains('flutter test --coverage'));
+    expect(workflow, contains('actions/upload-artifact@'));
+    expect(workflow, contains('name: flutter-coverage-lcov'));
+    expect(workflow, contains('path: coverage/lcov.info'));
+    expect(workflow, contains("if-no-files-found: error"));
+  });
+
+  test('Secret Scanning workflow 使用全历史 Gitleaks 扫描', () {
+    final workflow = _readWorkflow('secret-scanning.yml');
+
+    expect(workflow, contains('name: Secret Scanning'));
+    expect(workflow, contains('fetch-depth: 0'));
+    expect(workflow, contains('gitleaks/gitleaks-action@'));
+    expect(workflow, contains('GITLEAKS_ENABLE_COMMENTS'));
+    expect(workflow, contains('GITLEAKS_ENABLE_UPLOAD_ARTIFACT'));
+    expect(workflow, contains('schedule:'));
+  });
+
+  test('CI quality-gate 显式整合 Dart 与 Flutter 门禁', () {
+    final workflow = _readWorkflow('ci.yml');
+
+    expect(workflow, contains('name: Dart / Flutter Quality Gate'));
+    expect(workflow, contains('Dart Format（仅检查 PR 变更的 Dart 文件）'));
+    expect(workflow, contains('Flutter Analyze（Dart 静态分析）'));
+    expect(workflow, contains('Flutter Test（Dart / Widget 测试）'));
+  });
+}

--- a/test/github_security_workflow_test.dart
+++ b/test/github_security_workflow_test.dart
@@ -35,6 +35,13 @@ void main() {
     final workflow = _readWorkflow('code-coverage.yml');
 
     expect(workflow, contains('name: Code Coverage'));
+    expect(
+      workflow,
+      contains(
+        'subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2',
+      ),
+    );
+    expect(workflow, isNot(contains('subosito/flutter-action@v2.23.0')));
     expect(workflow, contains('flutter test --coverage'));
     expect(workflow, contains('actions/upload-artifact@'));
     expect(workflow, contains('name: flutter-coverage-lcov'));

--- a/test/github_security_workflow_test.dart
+++ b/test/github_security_workflow_test.dart
@@ -15,7 +15,7 @@ String _readWorkflow(String fileName) {
 }
 
 void main() {
-  test('高级 CodeQL 覆盖 Actions、C/C++、Python 与 Ruby 配置', () {
+  test('高级 CodeQL 覆盖 Actions、C/C++ 与 Python 配置', () {
     final workflow = _readWorkflow('codeql.yml');
 
     expect(workflow, contains('name: CodeQL Analysis'));
@@ -24,11 +24,11 @@ void main() {
     expect(workflow, contains('github/codeql-action/analyze@'));
     expect(workflow, contains('language: actions'));
     expect(workflow, contains('language: python'));
-    expect(workflow, contains('language: ruby'));
     expect(workflow, contains('languages: c-cpp'));
     expect(workflow, contains('build-mode: none'));
     expect(workflow, contains("category: '/language:c-cpp'"));
     expect(workflow, isNot(contains('language: dart')));
+    expect(workflow, isNot(contains('language: ruby')));
   });
 
   test('Flutter 覆盖率 workflow 上传 lcov artifact', () {


### PR DESCRIPTION
## 变更说明

- 新增高级 CodeQL workflow，覆盖 GitHub Actions、C/C++ 平台 runner、Python 维护脚本与 CocoaPods 相关 Ruby 配置。
- 新增 Gitleaks Secret Scanning workflow，支持 PR、push、定时与手动触发，并启用全历史扫描。
- 新增 Flutter 覆盖率 workflow，运行 `flutter test --coverage` 并上传 `coverage/lcov.info` artifact。
- 将现有 CI 的 Dart / Flutter 质量门禁命名和步骤文案整合清晰，避免重复新增普通 Dart workflow。
- 更新仓库工作流、Release 门槛、分支规范和 Changelog，并新增 workflow 回归测试。

## 关联 Issue

Closes #266

## 验证记录

- `python scripts/ci/validate_github_governance.py`
- `flutter test test/github_security_workflow_test.dart`
- `flutter test test/github_security_workflow_test.dart test/release_workflow_test.dart`
- `flutter analyze --no-fatal-infos`
- `git diff --check`

## 备注

`flutter analyze --no-fatal-infos` 退出码为 0，但当前仓库仍显示既有 `prefer_initializing_formals` info，位置在 `lib/controllers/card_auto_refresh_controller.dart` 和 `lib/services/app_update_service.dart`，不属于本次改动范围。