### PR TITLE
fix(auth): 使用应用身份 UA 发送 OA 请求

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -106,6 +106,7 @@ ci:
   - changed-files:
       - any-glob-to-any-file:
           - '.github/workflows/**'
+          - 'scripts/ci/**'
 
 # Release 相关文件变更
 # 注意：`release` 标签保留给人工触发 Release 工作流，不在这里自动添加。

--- a/.github/workflows/user-agent-policy.yml
+++ b/.github/workflows/user-agent-policy.yml
@@ -1,0 +1,30 @@
+# User-Agent 策略 — PR 阶段阻止未说明的非标准 UA 进入运行时代码。
+name: User-Agent Policy
+
+on:
+  pull_request:
+    branches: [develop]
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - 'lib/**'
+      - 'scripts/ci/validate_user_agent_policy.py'
+      - '.github/workflows/user-agent-policy.yml'
+      - 'docs/specs/RepoWorkflow.md'
+      - 'test/**user_agent**'
+      - 'test/github_security_workflow_test.dart'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  user-agent-policy:
+    name: User-Agent Policy
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+
+      - name: 校验 User-Agent 策略
+        run: python scripts/ci/validate_user_agent_policy.py

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,11 @@
 ### 新增
 
 - 新增高级 CodeQL、Gitleaks 密钥扫描与 Flutter 覆盖率 workflow，并将 Dart / Flutter 质量门禁文案整合到现有 CI。
+- 新增 User-Agent Policy PR workflow，阻止未写明例外原因的非标准 UA 进入运行时代码。
+
+### 变更
+
+- OA/CAS 与校园受限 HTTP 请求改用 `SSPU-AllinOne/{version} ({platform}; {os_version})` 应用身份 User-Agent，微信公众号和通用 WebView 保留带注释说明的浏览器 UA 例外。
 
 ## [0.2.8-alpha] - 2026-06-12
 

--- a/docs/specs/RepoWorkflow.md
+++ b/docs/specs/RepoWorkflow.md
@@ -75,6 +75,7 @@ Scope: repo
 - CI 对非草稿 PR 默认校验 PR 标题格式、目标分支、release label 使用、GitHub 治理文件、变更 Dart 文件格式、`flutter analyze --no-fatal-infos` 与 `flutter test`；分支命名按规范推荐但不作为普通 PR 阻断项；`develop -> main` 同步 PR 会跳过变更 Dart 文件格式检查，避免历史差异阻断默认分支治理同步。
 - 安全与质量扫描包含高级 CodeQL、Gitleaks 密钥扫描与 Flutter 覆盖率报告：CodeQL 扫描 GitHub Actions、C/C++ 平台 runner 和 Python 维护脚本；Dart/Flutter 代码由 Dart Format、Flutter Analyze、Flutter Test 与 Coverage workflow 承担，避免使用不支持 Dart 的 CodeQL 语言配置。
 - Coverage workflow 在 PR、`develop` 与 `main` 相关 Dart/测试变更上运行 `flutter test --coverage`，并上传 `coverage/lcov.info` 作为短期 artifact。
+- User-Agent Policy workflow 在 PR 阶段检查运行时代码中的非标准 UA。OA/CAS 与校园受限 HTTP 请求必须默认使用 `SSPU-AllinOne/{version} ({platform}; {os_version})`；确需使用其它 UA 时，必须在相邻代码注释中写明 `UA-POLICY-ALLOW: <原因>`，说明外部平台兼容要求和保留边界。
 - Release workflow 复用逻辑放在 `.github/actions/` composite actions 中，覆盖 Flutter 初始化、arm64 SDK 安装、Windows portable 打包、Linux 多格式产物整理和 Release 元数据生成；治理校验会检查这些 action 存在且被 Release workflow 引用。
 - 本地 Dart/Flutter 静态分析：优先运行 `flutter analyze`，期望 `No issues found!`。
 - 本地测试：优先运行 `flutter test`；若耗时或平台限制导致无法全量运行，应至少运行受影响测试并说明限制。

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,7 @@ import 'app.dart';
 import 'pages/lock_page.dart';
 import 'services/app_exit_service.dart';
 import 'services/app_display_name_service.dart';
+import 'services/app_user_agent_service.dart';
 import 'services/password_service.dart';
 import 'services/campus_network_status_service.dart';
 import 'services/storage_service.dart';
@@ -37,6 +38,7 @@ bool get _supportsDesktopShell =>
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await AppUserAgentService.initialize();
 
   if (_supportsDesktopShell) {
     // 桌面端拦截关闭事件并提供系统托盘入口。

--- a/lib/pages/webview_page.dart
+++ b/lib/pages/webview_page.dart
@@ -179,6 +179,7 @@ class _WebViewPageState extends State<WebViewPage> {
                   initialSettings: InAppWebViewSettings(
                     javaScriptEnabled: true,
                     isInspectable: kDebugMode,
+                    // UA-POLICY-ALLOW: 通用内嵌网页用于学校官网/外部文章展示，需要浏览器 UA 兼容页面渲染。
                     userAgent:
                         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
                         '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',

--- a/lib/pages/wxmp_login_page.dart
+++ b/lib/pages/wxmp_login_page.dart
@@ -369,6 +369,7 @@ class _WxmpLoginPageState extends State<WxmpLoginPage> {
             initialSettings: InAppWebViewSettings(
               javaScriptEnabled: true,
               isInspectable: kDebugMode,
+              // UA-POLICY-ALLOW: 微信公众号扫码登录页依赖浏览器 UA 展示桌面登录流程，不能使用 OA/CAS 应用 UA。
               userAgent:
                   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
                   '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',

--- a/lib/services/academic_eams_gateway.dart
+++ b/lib/services/academic_eams_gateway.dart
@@ -10,19 +10,18 @@ part of 'academic_eams_service.dart';
 
 /// Dio 版本专科教务网关，保持只读 GET / 查询 POST 边界。
 class DioAcademicEamsGateway implements AcademicEamsGateway {
-  DioAcademicEamsGateway({Dio? dio}) : _dio = dio ?? Dio(_baseOptions);
+  DioAcademicEamsGateway({Dio? dio})
+    : _dio = HttpService.buildConfiguredDio(dio, _baseOptions);
 
-  static final BaseOptions _baseOptions = BaseOptions(
+  static BaseOptions get _baseOptions => BaseOptions(
     connectTimeout: const Duration(seconds: 15),
     receiveTimeout: const Duration(seconds: 15),
     sendTimeout: const Duration(seconds: 15),
     responseType: ResponseType.bytes,
-    headers: const {
+    headers: {
       'Accept':
           'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-      'User-Agent':
-          'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) '
-          'Gecko/20100101 Firefox/125.0',
+      'User-Agent': HttpService.userAgent,
     },
   );
 

--- a/lib/services/academic_login_gateway.dart
+++ b/lib/services/academic_login_gateway.dart
@@ -11,21 +11,19 @@ part of 'academic_login_validation_service.dart';
 /// Dio 版 OA 登录网关，手动维护 Cookie 和 302 跳转链路。
 class DioAcademicLoginGateway implements AcademicLoginGateway {
   DioAcademicLoginGateway({Dio? dio, Uri? publicKeyUri})
-    : _dio = dio ?? Dio(_baseOptions),
+    : _dio = HttpService.buildConfiguredDio(dio, _baseOptions),
       publicKeyUri =
           publicKeyUri ?? Uri.parse('https://id.sspu.edu.cn/cas/jwt/publicKey');
 
-  static final BaseOptions _baseOptions = BaseOptions(
+  static BaseOptions get _baseOptions => BaseOptions(
     connectTimeout: const Duration(seconds: 15),
     receiveTimeout: const Duration(seconds: 15),
     sendTimeout: const Duration(seconds: 15),
     responseType: ResponseType.plain,
-    headers: const {
+    headers: {
       'Accept':
           'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-      'User-Agent':
-          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
-          '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      'User-Agent': HttpService.userAgent,
     },
   );
 

--- a/lib/services/app_user_agent_platform.dart
+++ b/lib/services/app_user_agent_platform.dart
@@ -1,0 +1,10 @@
+/*
+ * 应用 User-Agent 平台信息出口 — 根据运行平台选择系统版本读取实现
+ * @Project : SSPU-AllinOne
+ * @File : app_user_agent_platform.dart
+ * @Author : Qintsg
+ * @Date : 2026-06-12
+ */
+
+export 'app_user_agent_platform_stub.dart'
+    if (dart.library.io) 'app_user_agent_platform_io.dart';

--- a/lib/services/app_user_agent_platform_io.dart
+++ b/lib/services/app_user_agent_platform_io.dart
@@ -1,0 +1,23 @@
+/*
+ * 应用 User-Agent 平台信息 IO 实现 — 读取 dart:io 平台与系统版本
+ * @Project : SSPU-AllinOne
+ * @File : app_user_agent_platform_io.dart
+ * @Author : Qintsg
+ * @Date : 2026-06-12
+ */
+
+import 'dart:io' as io;
+
+/// 读取当前运行平台名称。
+///
+/// :returns: dart:io 规范化平台名，例如 windows、macos、linux、android 或 ios。
+String currentAppUserAgentPlatform() {
+  return io.Platform.operatingSystem;
+}
+
+/// 读取当前操作系统版本描述。
+///
+/// :returns: dart:io 提供的操作系统版本字符串。
+String currentAppUserAgentOsVersion() {
+  return io.Platform.operatingSystemVersion;
+}

--- a/lib/services/app_user_agent_platform_stub.dart
+++ b/lib/services/app_user_agent_platform_stub.dart
@@ -1,0 +1,24 @@
+/*
+ * 应用 User-Agent 平台信息降级实现 — Web 等非 IO 平台使用 Flutter 平台摘要
+ * @Project : SSPU-AllinOne
+ * @File : app_user_agent_platform_stub.dart
+ * @Author : Qintsg
+ * @Date : 2026-06-12
+ */
+
+import 'package:flutter/foundation.dart';
+
+/// 读取当前运行平台名称。
+///
+/// :returns: Web 平台返回 web，其它降级场景返回 Flutter 目标平台名。
+String currentAppUserAgentPlatform() {
+  if (kIsWeb) return 'web';
+  return defaultTargetPlatform.name;
+}
+
+/// 读取当前操作系统版本描述。
+///
+/// :returns: 非 IO 平台无法稳定读取系统版本，返回 unknown。
+String currentAppUserAgentOsVersion() {
+  return 'unknown';
+}

--- a/lib/services/app_user_agent_service.dart
+++ b/lib/services/app_user_agent_service.dart
@@ -1,0 +1,120 @@
+/*
+ * 应用 User-Agent 服务 — 统一生成 OA/CAS 请求使用的应用身份标识
+ * @Project : SSPU-AllinOne
+ * @File : app_user_agent_service.dart
+ * @Author : Qintsg
+ * @Date : 2026-06-12
+ */
+
+import 'package:flutter/foundation.dart';
+
+import 'app_info_service.dart';
+import 'app_user_agent_platform.dart';
+
+/// 应用版本信息加载函数，便于测试注入。
+typedef AppUserAgentVersionLoader = Future<AppVersionInfo> Function();
+
+/// 统一生成网络请求使用的应用身份 User-Agent。
+class AppUserAgentService {
+  AppUserAgentService._();
+
+  /// HTTP User-Agent 中的产品名。
+  static const String productName = 'SSPU-AllinOne';
+
+  /// 平台插件不可用时使用的版本号。
+  static const String fallbackVersion = '0.0.0';
+
+  static String _userAgent = build(
+    version: fallbackVersion,
+    platform: currentAppUserAgentPlatform(),
+    osVersion: currentAppUserAgentOsVersion(),
+  );
+
+  /// 当前标准 User-Agent。
+  static String get userAgent => _userAgent;
+
+  /// 从平台包信息初始化标准 User-Agent。
+  ///
+  /// :param loadVersionInfo: 可选版本加载函数，测试中用于绕过平台插件。
+  /// :param platform: 可选平台名，测试中用于固定输出。
+  /// :param osVersion: 可选系统版本，测试中用于固定输出。
+  /// :returns: 初始化后的标准 User-Agent。
+  static Future<String> initialize({
+    AppUserAgentVersionLoader? loadVersionInfo,
+    String? platform,
+    String? osVersion,
+  }) async {
+    var version = fallbackVersion;
+    try {
+      final versionInfo =
+          await (loadVersionInfo ?? AppInfoService.instance.loadVersionInfo)();
+      if (versionInfo.version.trim().isNotEmpty) {
+        version = versionInfo.version;
+      }
+    } catch (_) {
+      version = fallbackVersion;
+    }
+
+    _userAgent = build(
+      version: version,
+      platform: platform ?? currentAppUserAgentPlatform(),
+      osVersion: osVersion ?? currentAppUserAgentOsVersion(),
+    );
+    return _userAgent;
+  }
+
+  /// 按应用约定格式构造 User-Agent。
+  ///
+  /// :param version: 应用版本号。
+  /// :param platform: 平台名。
+  /// :param osVersion: 操作系统版本描述。
+  /// :returns: 形如 `SSPU-AllinOne/{version} ({platform}; {os_version})` 的值。
+  static String build({
+    required String version,
+    required String platform,
+    required String osVersion,
+  }) {
+    final safeVersion = _sanitizeProductVersion(
+      version,
+      fallback: fallbackVersion,
+    );
+    final safePlatform = _sanitizeCommentSegment(platform);
+    final safeOsVersion = _sanitizeCommentSegment(osVersion);
+    return '$productName/$safeVersion ($safePlatform; $safeOsVersion)';
+  }
+
+  /// 测试专用：覆盖当前标准 User-Agent。
+  ///
+  /// :param value: 覆盖值；为空时恢复为当前平台 fallback 值。
+  @visibleForTesting
+  static void debugSetUserAgentForTesting(String? value) {
+    _userAgent =
+        value ??
+        build(
+          version: fallbackVersion,
+          platform: currentAppUserAgentPlatform(),
+          osVersion: currentAppUserAgentOsVersion(),
+        );
+  }
+
+  static String _sanitizeProductVersion(
+    String value, {
+    required String fallback,
+  }) {
+    final normalized = value.trim().replaceAll(
+      RegExp(r'[^A-Za-z0-9._+-]+'),
+      '_',
+    );
+    return normalized.isEmpty ? fallback : normalized;
+  }
+
+  static String _sanitizeCommentSegment(String value) {
+    final normalized = value
+        .replaceAll(RegExp(r'[\r\n\t]+'), ' ')
+        .replaceAll(RegExp(r'[();\\]+'), ' ')
+        .replaceAll(RegExp(r'[^\x20-\x7E]+'), '_')
+        .replaceAll(RegExp(r'\s+'), ' ')
+        .trim();
+    return normalized.isEmpty ? 'unknown' : normalized;
+  }
+}

--- a/lib/services/campus_card_gateway.dart
+++ b/lib/services/campus_card_gateway.dart
@@ -10,19 +10,18 @@ part of 'campus_card_service.dart';
 
 /// Dio 版校园卡网关，手动维护 Cookie 和 302 跳转链路。
 class DioCampusCardGateway implements CampusCardGateway {
-  DioCampusCardGateway({Dio? dio}) : _dio = dio ?? Dio(_baseOptions);
+  DioCampusCardGateway({Dio? dio})
+    : _dio = HttpService.buildConfiguredDio(dio, _baseOptions);
 
-  static final BaseOptions _baseOptions = BaseOptions(
+  static BaseOptions get _baseOptions => BaseOptions(
     connectTimeout: const Duration(seconds: 15),
     receiveTimeout: const Duration(seconds: 15),
     sendTimeout: const Duration(seconds: 15),
     responseType: ResponseType.bytes,
-    headers: const {
+    headers: {
       'Accept':
           'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-      'User-Agent':
-          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
-          '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      'User-Agent': HttpService.userAgent,
     },
   );
 

--- a/lib/services/http_service.dart
+++ b/lib/services/http_service.dart
@@ -10,6 +10,8 @@
 
 import 'package:dio/dio.dart';
 
+import 'app_user_agent_service.dart';
+
 /// HTTP 请求服务（单例）
 /// 封装 dio 实例，提供统一的 GET/POST/PUT/DELETE 方法
 /// 自动附加请求日志、超时处理与错误码映射
@@ -23,18 +25,34 @@ class HttpService {
 
   late final Dio _dio;
 
+  /// OA/CAS 相关请求使用的标准应用 User-Agent。
+  static String get userAgent => AppUserAgentService.userAgent;
+
+  /// 为可替换 Dio 实例套用网关默认配置。
+  ///
+  /// :param dio: 可选外部 Dio，测试或高级场景可注入 adapter / interceptor。
+  /// :param baseOptions: 该网关的默认请求配置。
+  /// :returns: 已配置默认请求选项的 Dio 实例。
+  static Dio buildConfiguredDio(Dio? dio, BaseOptions baseOptions) {
+    if (dio == null) return Dio(baseOptions);
+    dio.options = baseOptions;
+    return dio;
+  }
+
+  /// 测试专用：读取当前默认请求头，不触碰全局 Dio 单例。
+  static Map<String, dynamic> debugDefaultHeadersForTesting() {
+    return Map<String, dynamic>.unmodifiable(_defaultOptions.headers);
+  }
+
   /// 默认请求配置：30 秒超时，JSON 响应
-  static final BaseOptions _defaultOptions = BaseOptions(
+  static BaseOptions get _defaultOptions => BaseOptions(
     connectTimeout: const Duration(seconds: 15),
     receiveTimeout: const Duration(seconds: 30),
     sendTimeout: const Duration(seconds: 15),
     responseType: ResponseType.json,
     headers: {
       'Accept': 'application/json',
-      // 模拟浏览器 UA，避免被目标站点拒绝
-      'User-Agent':
-          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
-          '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      'User-Agent': HttpService.userAgent,
     },
   );
 

--- a/lib/services/sports_attendance_gateway.dart
+++ b/lib/services/sports_attendance_gateway.dart
@@ -10,19 +10,18 @@ part of 'sports_attendance_service.dart';
 
 /// Dio 版体育部查询系统网关，手动维护 Cookie 和 302 跳转链路。
 class DioSportsAttendanceGateway implements SportsAttendanceGateway {
-  DioSportsAttendanceGateway({Dio? dio}) : _dio = dio ?? Dio(_baseOptions);
+  DioSportsAttendanceGateway({Dio? dio})
+    : _dio = HttpService.buildConfiguredDio(dio, _baseOptions);
 
-  static final BaseOptions _baseOptions = BaseOptions(
+  static BaseOptions get _baseOptions => BaseOptions(
     connectTimeout: const Duration(seconds: 15),
     receiveTimeout: const Duration(seconds: 15),
     sendTimeout: const Duration(seconds: 15),
     responseType: ResponseType.bytes,
-    headers: const {
+    headers: {
       'Accept':
           'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-      'User-Agent':
-          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
-          '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      'User-Agent': HttpService.userAgent,
     },
   );
 

--- a/lib/services/student_report_gateway.dart
+++ b/lib/services/student_report_gateway.dart
@@ -10,19 +10,18 @@ part of 'student_report_service.dart';
 
 /// Dio 版学工报表网关，保持只读 GET 请求边界。
 class DioStudentReportGateway implements StudentReportGateway {
-  DioStudentReportGateway({Dio? dio}) : _dio = dio ?? Dio(_baseOptions);
+  DioStudentReportGateway({Dio? dio})
+    : _dio = HttpService.buildConfiguredDio(dio, _baseOptions);
 
-  static final BaseOptions _baseOptions = BaseOptions(
+  static BaseOptions get _baseOptions => BaseOptions(
     connectTimeout: const Duration(seconds: 15),
     receiveTimeout: const Duration(seconds: 15),
     sendTimeout: const Duration(seconds: 15),
     responseType: ResponseType.bytes,
-    headers: const {
+    headers: {
       'Accept':
           'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-      'User-Agent':
-          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
-          '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      'User-Agent': HttpService.userAgent,
     },
   );
 

--- a/lib/services/wxmp_article_service.dart
+++ b/lib/services/wxmp_article_service.dart
@@ -96,7 +96,7 @@ class WxmpArticleService {
   /// 本地关注列表存储键（JSON：{fakeid: {name, alias, avatar}}）
   static const String _keyFollowedMps = 'wxmp_followed_mps';
 
-  /// 标准 User-Agent
+  /// UA-POLICY-ALLOW: 微信公众号平台 API 需要浏览器 UA 兼容登录态与反爬校验，不能使用 OA/CAS 应用 UA。
   static const String _userAgent =
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
       '(KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36';
@@ -116,6 +116,7 @@ class WxmpArticleService {
         responseType: ResponseType.plain,
         headers: {
           'Cookie': cookie,
+          // UA-POLICY-ALLOW: 微信公众号首页用于刷新 token，平台要求浏览器 UA 保持登录态兼容。
           'User-Agent': config.userAgent.isEmpty
               ? _userAgent
               : config.userAgent,
@@ -170,6 +171,7 @@ class WxmpArticleService {
     final config = await _loadConfigOrDefault();
     return {
       'Cookie': cookie ?? '',
+      // UA-POLICY-ALLOW: 微信公众号 JSON API 与扫码登录使用同一浏览器态，不适用 OA/CAS 应用 UA。
       'User-Agent': config.userAgent.isEmpty ? _userAgent : config.userAgent,
       'Accept': 'application/json, text/javascript, */*; q=0.01',
       'Accept-Language': 'zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7',

--- a/lib/services/wxmp_config_service.dart
+++ b/lib/services/wxmp_config_service.dart
@@ -68,6 +68,7 @@ class WxmpConfig {
       cookie: '',
       token: '',
       appId: '',
+      // UA-POLICY-ALLOW: 微信公众号平台接口对浏览器 UA 有兼容要求，默认配置保留平台登录使用的浏览器标识。
       userAgent:
           'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
           '(KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36',

--- a/scripts/ci/validate_user_agent_policy.py
+++ b/scripts/ci/validate_user_agent_policy.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+'''
+User-Agent 策略校验脚本
+@Project : SSPU-AllinOne
+@File : validate_user_agent_policy.py
+@Author : Qintsg
+@Date : 2026-06-12 09:20
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCAN_ROOTS = ("lib",)
+ALLOW_MARKER = "UA-POLICY-ALLOW:"
+COMMENT_PREFIXES = ("//", "///", "/*", "*", "#")
+STANDARD_USER_AGENT_REFERENCES = (
+    "HttpService.userAgent",
+    "AppUserAgentService.userAgent",
+)
+BROWSER_USER_AGENT_PATTERN = re.compile(
+    r"Mozilla/5\.0|AppleWebKit/|Chrome/[0-9]|Firefox/[0-9]|Safari/[0-9]|"
+    r"Gecko/20100101|Edg/[0-9]",
+)
+USER_AGENT_HEADER_PATTERN = re.compile(r"""['"]User-Agent['"]\s*:""")
+USER_AGENT_PROPERTY_PATTERN = re.compile(r"\buserAgent\s*:")
+USER_AGENT_LITERAL_ASSIGNMENT_PATTERN = re.compile(
+    r"\b\w*userAgent\w*\s*=\s*['\"]",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class UserAgentPolicyViolation:
+    """User-Agent 策略违规位置。"""
+
+    path: Path
+    line_number: int
+    line: str
+    reason: str
+
+
+def iter_runtime_source_files() -> list[Path]:
+    """
+    枚举需要检查的运行时代码文件。
+
+    :returns: 按路径排序的源码文件列表。
+    """
+    source_files: list[Path] = []
+    for root_name in SCAN_ROOTS:
+        root = PROJECT_ROOT / root_name
+        if not root.exists():
+            continue
+        source_files.extend(
+            path
+            for path in root.rglob("*")
+            if path.is_file() and path.suffix in {".dart", ".js", ".ts"}
+        )
+    return sorted(source_files)
+
+
+def has_policy_allow_comment(lines: list[str], line_index: int) -> bool:
+    """
+    判断指定行附近是否有 UA 例外说明注释。
+
+    :param lines: 文件内容按行拆分结果。
+    :param line_index: 当前命中行的 0 基索引。
+    :returns: 找到合规例外说明时返回 True。
+    """
+    start = max(0, line_index - 4)
+    for candidate in lines[start : line_index + 1]:
+        stripped = candidate.strip()
+        if not stripped.startswith(COMMENT_PREFIXES):
+            continue
+        marker_index = stripped.find(ALLOW_MARKER)
+        if marker_index < 0:
+            continue
+        reason = stripped[marker_index + len(ALLOW_MARKER) :].strip()
+        if len(reason) >= 12:
+            return True
+    return False
+
+
+def is_comment_line(line: str) -> bool:
+    """
+    判断当前行是否为注释行。
+
+    :param line: 待判断文本行。
+    :returns: 注释行返回 True。
+    """
+    return line.strip().startswith(COMMENT_PREFIXES)
+
+
+def uses_standard_user_agent(line: str) -> bool:
+    """
+    判断当前行是否引用标准应用 User-Agent。
+
+    :param line: 待判断文本行。
+    :returns: 引用标准应用 User-Agent 时返回 True。
+    """
+    return any(reference in line for reference in STANDARD_USER_AGENT_REFERENCES)
+
+
+def user_agent_policy_reason(lines: list[str], line_index: int) -> str | None:
+    """
+    判断指定行是否命中 User-Agent 策略。
+
+    :param lines: 文件内容按行拆分结果。
+    :param line_index: 当前检查行的 0 基索引。
+    :returns: 命中策略时返回违规原因，否则返回 None。
+    """
+    line = lines[line_index]
+    if is_comment_line(line):
+        return None
+
+    if BROWSER_USER_AGENT_PATTERN.search(line) is not None:
+        return (
+            "浏览器样式 User-Agent 必须改用 HttpService.userAgent，"
+            f"或在近邻注释中写明 {ALLOW_MARKER} 例外原因。"
+        )
+
+    if USER_AGENT_HEADER_PATTERN.search(line) is not None:
+        if uses_standard_user_agent(line):
+            return None
+        return (
+            "非标准 User-Agent 请求头必须改用 HttpService.userAgent，"
+            f"或在近邻注释中写明 {ALLOW_MARKER} 例外原因。"
+        )
+
+    if USER_AGENT_LITERAL_ASSIGNMENT_PATTERN.search(line) is not None:
+        return (
+            "代码中定义的非标准 User-Agent 必须有近邻 "
+            f"{ALLOW_MARKER} 例外原因。"
+        )
+
+    property_match = USER_AGENT_PROPERTY_PATTERN.search(line)
+    if property_match is None:
+        return None
+
+    value_part = line[property_match.end() :].strip()
+    if value_part and not value_part.startswith(("'", '"')):
+        return None
+
+    context = "\n".join(lines[line_index : line_index + 4])
+    if any(reference in context for reference in STANDARD_USER_AGENT_REFERENCES):
+        return None
+
+    return (
+        "非标准 userAgent 属性必须改用标准应用 User-Agent，"
+        f"或在近邻注释中写明 {ALLOW_MARKER} 例外原因。"
+    )
+
+
+def validate_file(path: Path) -> list[UserAgentPolicyViolation]:
+    """
+    校验单个文件是否存在未说明的非标准 User-Agent。
+
+    :param path: 待检查源码文件路径。
+    :returns: 违规列表。
+    """
+    lines = path.read_text(encoding="utf-8").splitlines()
+    violations: list[UserAgentPolicyViolation] = []
+    for index, line in enumerate(lines):
+        reason = user_agent_policy_reason(lines, index)
+        if reason is None:
+            continue
+        if has_policy_allow_comment(lines, index):
+            continue
+        violations.append(
+            UserAgentPolicyViolation(
+                path=path.relative_to(PROJECT_ROOT),
+                line_number=index + 1,
+                line=line.strip(),
+                reason=reason,
+            ),
+        )
+    return violations
+
+
+def main() -> int:
+    """
+    程序主入口。
+
+    :returns: 成功返回 0，发现策略违规返回 1。
+    """
+    violations: list[UserAgentPolicyViolation] = []
+    for source_file in iter_runtime_source_files():
+        violations.extend(validate_file(source_file))
+
+    if not violations:
+        print("User-Agent policy is valid.")
+        return 0
+
+    print("User-Agent policy violations found:")
+    for violation in violations:
+        print(f"- {violation.path}:{violation.line_number}: {violation.reason}")
+        print(f"  {violation.line}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/app_user_agent_service_test.dart
+++ b/test/app_user_agent_service_test.dart
@@ -1,0 +1,149 @@
+/*
+ * 应用 User-Agent 服务测试 — 校验 OA/CAS 请求身份标识格式和接入范围
+ * @Project : SSPU-AllinOne
+ * @File : app_user_agent_service_test.dart
+ * @Author : Qintsg
+ * @Date : 2026-06-12
+ */
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sspu_allinone/services/academic_eams_service.dart';
+import 'package:sspu_allinone/services/academic_login_validation_service.dart';
+import 'package:sspu_allinone/services/app_info_service.dart';
+import 'package:sspu_allinone/services/app_user_agent_service.dart';
+import 'package:sspu_allinone/services/campus_card_service.dart';
+import 'package:sspu_allinone/services/http_service.dart';
+import 'package:sspu_allinone/services/sports_attendance_service.dart';
+import 'package:sspu_allinone/services/student_report_service.dart';
+import 'package:sspu_allinone/services/wxmp_config_service.dart';
+
+void main() {
+  const expectedUserAgent = 'SSPU-AllinOne/1.2.3 (windows; Windows 11 23H2)';
+
+  setUp(() async {
+    await AppUserAgentService.initialize(
+      loadVersionInfo: () async =>
+          const AppVersionInfo(version: '1.2.3', buildNumber: '7'),
+      platform: 'windows',
+      osVersion: 'Windows 11 23H2',
+    );
+  });
+
+  tearDown(() {
+    AppUserAgentService.debugSetUserAgentForTesting(null);
+  });
+
+  test('按约定格式生成应用身份 User-Agent', () {
+    expect(HttpService.userAgent, expectedUserAgent);
+    expect(
+      AppUserAgentService.build(
+        version: ' 1.2.3 beta ',
+        platform: 'windows; desktop',
+        osVersion: 'Windows\n11 (23H2)',
+      ),
+      'SSPU-AllinOne/1.2.3_beta (windows desktop; Windows 11 23H2)',
+    );
+  });
+
+  test('HttpService 默认请求头使用统一应用 User-Agent', () async {
+    final headers = HttpService.debugDefaultHeadersForTesting();
+
+    expect(headers['User-Agent'], expectedUserAgent);
+    expect(headers.values.join('\n'), isNot(contains('Mozilla/5.0')));
+  });
+
+  test('OA/CAS 相关 Dio 网关默认使用统一应用 User-Agent', () async {
+    final gatewayDios = <Dio>[
+      _buildDioForAcademicLoginGateway(),
+      _buildDioForAcademicEamsGateway(),
+      _buildDioForCampusCardGateway(),
+      _buildDioForSportsAttendanceGateway(),
+      _buildDioForStudentReportGateway(),
+    ];
+
+    for (final dio in gatewayDios) {
+      final headers = await _captureDioHeaders(dio);
+      expect(headers['User-Agent'], expectedUserAgent);
+      expect(headers.values.join('\n'), isNot(contains('Mozilla/5.0')));
+      expect(headers.values.join('\n'), isNot(contains('Chrome/')));
+      expect(headers.values.join('\n'), isNot(contains('Firefox/')));
+    }
+  });
+
+  test('微信公众号平台默认 User-Agent 保持浏览器标识', () {
+    final config = WxmpConfig.defaults();
+
+    expect(config.userAgent, contains('Mozilla/5.0'));
+    expect(config.userAgent, contains('Chrome/114.0.0.0'));
+    expect(config.userAgent, isNot(contains('SSPU-AllinOne/')));
+  });
+}
+
+Future<Map<String, Object?>> _captureDioHeaders(Dio dio) async {
+  final adapter = _HeaderCaptureAdapter();
+  final originalAdapter = dio.httpClientAdapter;
+  dio.httpClientAdapter = adapter;
+  try {
+    await dio.get<Object>('https://example.edu.cn/probe');
+    return adapter.headers;
+  } finally {
+    dio.httpClientAdapter = originalAdapter;
+  }
+}
+
+Dio _buildDioForAcademicLoginGateway() {
+  final dio = Dio();
+  DioAcademicLoginGateway(dio: dio);
+  return dio;
+}
+
+Dio _buildDioForAcademicEamsGateway() {
+  final dio = Dio();
+  DioAcademicEamsGateway(dio: dio);
+  return dio;
+}
+
+Dio _buildDioForCampusCardGateway() {
+  final dio = Dio();
+  DioCampusCardGateway(dio: dio);
+  return dio;
+}
+
+Dio _buildDioForSportsAttendanceGateway() {
+  final dio = Dio();
+  DioSportsAttendanceGateway(dio: dio);
+  return dio;
+}
+
+Dio _buildDioForStudentReportGateway() {
+  final dio = Dio();
+  DioStudentReportGateway(dio: dio);
+  return dio;
+}
+
+class _HeaderCaptureAdapter implements HttpClientAdapter {
+  Map<String, Object?> headers = const {};
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    headers = Map<String, Object?>.from(options.headers);
+    return ResponseBody.fromString(
+      'ok',
+      200,
+      headers: {
+        Headers.contentTypeHeader: [Headers.textPlainContentType],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/test/github_security_workflow_test.dart
+++ b/test/github_security_workflow_test.dart
@@ -68,4 +68,58 @@ void main() {
     expect(workflow, contains('Flutter Analyze（Dart 静态分析）'));
     expect(workflow, contains('Flutter Test（Dart / Widget 测试）'));
   });
+
+  test('User-Agent Policy workflow 在 PR 阶段运行策略脚本', () {
+    final workflow = _readWorkflow('user-agent-policy.yml');
+
+    expect(workflow, contains('name: User-Agent Policy'));
+    expect(workflow, contains('pull_request:'));
+    expect(workflow, contains('contents: read'));
+    expect(
+      workflow,
+      contains('python scripts/ci/validate_user_agent_policy.py'),
+    );
+  });
+
+  test('User-Agent Policy 脚本接受当前带说明的运行时代码例外', () async {
+    final result = await Process.run('python', [
+      'scripts/ci/validate_user_agent_policy.py',
+    ]);
+
+    expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
+  });
+
+  test('User-Agent Policy 脚本拒绝未说明的非标准 UA', () async {
+    final result = await Process.run('python', [
+      '-c',
+      r'''
+from pathlib import Path
+from scripts.ci import validate_user_agent_policy as policy
+
+samples = [
+    ("standard.dart", ["'User-Agent': HttpService.userAgent,"], 0),
+    ("custom.dart", ["'User-Agent': 'ExternalProbe/1.0',"], 1),
+    (
+        "allowed.dart",
+        [
+            "// UA-POLICY-ALLOW: 外部平台要求固定探测 UA，限定在兼容接口使用。",
+            "'User-Agent': 'ExternalProbe/1.0',",
+        ],
+        0,
+    ),
+]
+
+for name, lines, expected_count in samples:
+    violations = []
+    for index, _ in enumerate(lines):
+        reason = policy.user_agent_policy_reason(lines, index)
+        if reason is not None and not policy.has_policy_allow_comment(lines, index):
+            violations.append(reason)
+    if len(violations) != expected_count:
+        raise SystemExit(f"{name}: expected {expected_count}, got {len(violations)}")
+''',
+    ]);
+
+    expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
+  });
 }


### PR DESCRIPTION
## Summary

- Replace OA/CAS and campus-restricted HTTP User-Agent defaults with the app identity format `SSPU-AllinOne/{version} ({platform}; {os_version})`.
- Keep Wxmp and WebView browser-UA compatibility paths, but require nearby `UA-POLICY-ALLOW` comments for every non-standard UA exception.
- Add a PR User-Agent Policy workflow and regression coverage so future runtime UA changes are checked before merge.

## Validation

- `python scripts/ci/validate_user_agent_policy.py`
- `python scripts/ci/validate_github_governance.py`
- `flutter test test/app_user_agent_service_test.dart test/github_security_workflow_test.dart`
- `flutter test test/http_service_test.dart test/academic_login_validation_service_test.dart test/app_user_agent_service_test.dart test/github_security_workflow_test.dart`
- `flutter test test/academic_eams_service_test.dart test/campus_card_service_test.dart test/sports_attendance_service_test.dart test/student_report_service_test.dart`
- `flutter analyze --no-fatal-infos`
- `git diff --check`

Closes #258
