### PR TITLE
feat(academic): 优化体育考勤卡片与详情表格

### DIFF
--- a/lib/pages/academic_page.dart
+++ b/lib/pages/academic_page.dart
@@ -28,6 +28,7 @@ import 'course_schedule_page.dart';
 
 part 'academic_eams_summary_card.dart';
 part 'academic_sports_attendance_card.dart';
+part 'academic_sports_attendance_detail_page.dart';
 part 'academic_student_report_card.dart';
 part 'academic_student_report_summary.dart';
 part 'academic_student_report_detail_page.dart';
@@ -397,6 +398,7 @@ class _AcademicPageState extends State<AcademicPage> {
                   isLoading: _sportsAttendanceRefreshController.isLoading,
                   autoRefreshEnabled:
                       _sportsAttendanceRefreshController.autoRefreshEnabled,
+                  refreshFeedback: _sportsAttendanceRefreshController.feedback,
                   onRefresh: _loadSportsAttendance,
                 ),
                 secondClassroom: AcademicStudentReportCard(

--- a/lib/pages/academic_sports_attendance_card.dart
+++ b/lib/pages/academic_sports_attendance_card.dart
@@ -120,40 +120,17 @@ class _SportsAttendanceCardHeader extends StatelessWidget {
     );
     final detailAction = _buildDetailAction(context);
 
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final compact = constraints.maxWidth < 360;
-        if (compact) {
-          return Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              FluentSurfaceIcon(icon: FluentIcons.running, color: accentColor),
-              const SizedBox(width: FluentSpacing.m),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    title,
-                    const SizedBox(height: FluentSpacing.xs),
-                    Align(alignment: Alignment.centerLeft, child: detailAction),
-                  ],
-                ),
-              ),
-            ],
-          );
-        }
-
-        return Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            FluentSurfaceIcon(icon: FluentIcons.running, color: accentColor),
-            const SizedBox(width: FluentSpacing.m),
-            Expanded(child: title),
-            const SizedBox(width: FluentSpacing.s),
-            detailAction,
-          ],
-        );
-      },
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        FluentSurfaceIcon(icon: FluentIcons.running, color: accentColor),
+        const SizedBox(width: FluentSpacing.m),
+        Expanded(child: title),
+        const SizedBox(width: FluentSpacing.s),
+        Flexible(
+          child: Align(alignment: Alignment.centerRight, child: detailAction),
+        ),
+      ],
     );
   }
 
@@ -171,7 +148,7 @@ class _SportsAttendanceCardHeader extends StatelessWidget {
         children: [
           Icon(FluentIcons.list, size: 14),
           SizedBox(width: 6),
-          Text('查看考勤记录'),
+          Flexible(child: Text('查看考勤记录')),
         ],
       ),
     );

--- a/lib/pages/academic_sports_attendance_card.dart
+++ b/lib/pages/academic_sports_attendance_card.dart
@@ -19,6 +19,9 @@ class AcademicSportsAttendanceCard extends StatelessWidget {
   /// 是否已开启自动刷新。
   final bool autoRefreshEnabled;
 
+  /// 手动刷新结束后的短暂反馈。
+  final RefreshActionFeedback? refreshFeedback;
+
   /// 手动刷新回调。
   final VoidCallback onRefresh;
 
@@ -27,6 +30,7 @@ class AcademicSportsAttendanceCard extends StatelessWidget {
     required this.result,
     required this.isLoading,
     required this.autoRefreshEnabled,
+    required this.refreshFeedback,
     required this.onRefresh,
   });
 
@@ -40,9 +44,8 @@ class AcademicSportsAttendanceCard extends StatelessWidget {
       accentColor: accent,
       child: FluentStretchCardBody(
         header: _SportsAttendanceCardHeader(
-          lastRefreshLabel: _sportsAttendanceLastRefreshLabel(result),
-          isLoading: isLoading,
-          onRefresh: onRefresh,
+          summary: summary,
+          canOpenDetail: result?.isSuccess == true && summary != null,
           accentColor: accent,
         ),
         body: _SportsAttendanceCardContent(
@@ -51,6 +54,12 @@ class AcademicSportsAttendanceCard extends StatelessWidget {
           isLoading: isLoading,
           autoRefreshEnabled: autoRefreshEnabled,
           severityForStatus: _sportsAttendanceSeverity,
+        ),
+        footer: _SportsAttendanceCardFooter(
+          lastRefreshLabel: _sportsAttendanceLastRefreshLabel(result),
+          isLoading: isLoading,
+          refreshFeedback: refreshFeedback,
+          onRefresh: onRefresh,
         ),
       ),
     );
@@ -89,65 +98,122 @@ class AcademicSportsAttendanceCard extends StatelessWidget {
 
 class _SportsAttendanceCardHeader extends StatelessWidget {
   const _SportsAttendanceCardHeader({
-    required this.lastRefreshLabel,
-    required this.isLoading,
-    required this.onRefresh,
+    required this.summary,
+    required this.canOpenDetail,
     required this.accentColor,
   });
 
-  final String lastRefreshLabel;
-  final bool isLoading;
-  final VoidCallback onRefresh;
+  final SportsAttendanceSummary? summary;
+  final bool canOpenDetail;
   final Color accentColor;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.fluentColors;
     final type = context.fluentType;
+    final title = Semantics(
+      header: true,
+      child: Text(
+        '课外活动考勤',
+        style: type.subtitle2.copyWith(color: colors.neutralForeground1),
+      ),
+    );
+    final detailAction = _buildDetailAction(context);
 
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        FluentSurfaceIcon(icon: FluentIcons.running, color: accentColor),
-        const SizedBox(width: FluentSpacing.m),
-        Expanded(
-          child: Column(
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final compact = constraints.maxWidth < 360;
+        if (compact) {
+          return Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Semantics(
-                header: true,
-                child: Text(
-                  '课外活动考勤',
-                  style: type.subtitle2.copyWith(
-                    color: colors.neutralForeground1,
-                  ),
+              FluentSurfaceIcon(icon: FluentIcons.running, color: accentColor),
+              const SizedBox(width: FluentSpacing.m),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    title,
+                    const SizedBox(height: FluentSpacing.xs),
+                    Align(alignment: Alignment.centerLeft, child: detailAction),
+                  ],
                 ),
               ),
-              const SizedBox(height: FluentSpacing.xxs),
-              _buildRefreshLine(context),
             ],
-          ),
-        ),
-      ],
+          );
+        }
+
+        return Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            FluentSurfaceIcon(icon: FluentIcons.running, color: accentColor),
+            const SizedBox(width: FluentSpacing.m),
+            Expanded(child: title),
+            const SizedBox(width: FluentSpacing.s),
+            detailAction,
+          ],
+        );
+      },
     );
   }
 
-  Widget _buildRefreshLine(BuildContext context) {
-    final theme = FluentTheme.of(context);
-    return RefreshStatusLine(
-      label: lastRefreshLabel,
-      labelStyle: theme.typography.caption?.copyWith(
-        color: theme.resources.textFillColorSecondary,
+  Widget _buildDetailAction(BuildContext context) {
+    return FluentButton.primary(
+      onPressed: canOpenDetail && summary != null
+          ? () => Navigator.of(context).push(
+              FluentPageRoute(
+                builder: (_) => SportsAttendanceDetailPage(summary: summary!),
+              ),
+            )
+          : null,
+      child: const Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(FluentIcons.list, size: 14),
+          SizedBox(width: 6),
+          Text('查看考勤记录'),
+        ],
       ),
-      action: RefreshFeedbackAction(
-        key: const Key('academic-sports-refresh'),
-        tooltip: '手动刷新体育考勤',
-        semanticLabel: '手动刷新体育考勤',
-        isLoading: isLoading,
-        onPressed: onRefresh,
-        minTouchSize: 32,
-        size: 28,
-        iconSize: 15,
+    );
+  }
+}
+
+class _SportsAttendanceCardFooter extends StatelessWidget {
+  const _SportsAttendanceCardFooter({
+    required this.lastRefreshLabel,
+    required this.isLoading,
+    required this.refreshFeedback,
+    required this.onRefresh,
+  });
+
+  final String lastRefreshLabel;
+  final bool isLoading;
+  final RefreshActionFeedback? refreshFeedback;
+  final VoidCallback onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = FluentTheme.of(context);
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: RefreshStatusLine(
+        label: lastRefreshLabel,
+        labelStyle: theme.typography.caption?.copyWith(
+          color: theme.resources.textFillColorSecondary,
+        ),
+        actionReservedWidth: refreshFeedback == null ? 32 : 180,
+        action: RefreshFeedbackAction(
+          key: const Key('academic-sports-refresh'),
+          tooltip: '手动刷新体育考勤',
+          semanticLabel: '手动刷新体育考勤',
+          isLoading: isLoading,
+          feedback: refreshFeedback,
+          onPressed: onRefresh,
+          minTouchSize: 32,
+          size: 28,
+          iconSize: 15,
+          maxFeedbackWidth: 180,
+        ),
       ),
     );
   }
@@ -188,8 +254,8 @@ class _SportsAttendanceCardContent extends StatelessWidget {
     if (result == null) {
       return Text(
         autoRefreshEnabled
-            ? '自动刷新已开启，等待下一次读取；也可点击右上角刷新。'
-            : '自动刷新未开启。点击右上角刷新图标可手动读取；体育查询需要校园网或学校 VPN。',
+            ? '自动刷新已开启，等待下一次读取；也可点击卡片底部刷新图标。'
+            : '自动刷新未开启。点击卡片底部刷新图标可手动读取；体育查询需要校园网或学校 VPN。',
       );
     }
 
@@ -215,51 +281,55 @@ class _SportsAttendanceSummaryView extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        FluentMetricCard(
-          label: '总次数',
-          value: '${summary.totalCount}',
-          suffix: '次',
-          icon: FluentIcons.running,
-          tone: FluentStatusChipTone.success,
-        ),
-        const SizedBox(height: FluentSpacing.m),
         Wrap(
-          spacing: FluentSpacing.s,
-          runSpacing: FluentSpacing.s,
+          spacing: FluentSpacing.l,
+          runSpacing: FluentSpacing.m,
+          crossAxisAlignment: WrapCrossAlignment.center,
           children: [
-            _SportsAttendanceCountPill(
-              category: SportsAttendanceCategory.morningExercise,
-              count: summary.morningExerciseCount,
+            ConstrainedBox(
+              constraints: const BoxConstraints(minWidth: 156, maxWidth: 220),
+              child: FluentMetricCard(
+                label: '总次数',
+                value: '${summary.totalCount}',
+                suffix: '次',
+                icon: FluentIcons.running,
+                tone: FluentStatusChipTone.success,
+              ),
             ),
-            _SportsAttendanceCountPill(
-              category: SportsAttendanceCategory.extracurricularActivity,
-              count: summary.extracurricularActivityCount,
-            ),
-            _SportsAttendanceCountPill(
-              category: SportsAttendanceCategory.countAdjustment,
-              count: summary.countAdjustmentCount,
-            ),
-            _SportsAttendanceCountPill(
-              category: SportsAttendanceCategory.sportsCorridor,
-              count: summary.sportsCorridorCount,
-            ),
+            _SportsAttendanceCountWrap(summary: summary),
           ],
         ),
-        const SizedBox(height: FluentSpacing.l),
-        FluentButton.primary(
-          onPressed: () => Navigator.of(context).push(
-            FluentPageRoute(
-              builder: (_) => SportsAttendanceDetailPage(summary: summary),
-            ),
-          ),
-          child: const Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(FluentIcons.list, size: 14),
-              SizedBox(width: 6),
-              Text('查看考勤记录'),
-            ],
-          ),
+      ],
+    );
+  }
+}
+
+class _SportsAttendanceCountWrap extends StatelessWidget {
+  const _SportsAttendanceCountWrap({required this.summary});
+
+  final SportsAttendanceSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: FluentSpacing.s,
+      runSpacing: FluentSpacing.s,
+      children: [
+        _SportsAttendanceCountPill(
+          category: SportsAttendanceCategory.morningExercise,
+          count: summary.morningExerciseCount,
+        ),
+        _SportsAttendanceCountPill(
+          category: SportsAttendanceCategory.extracurricularActivity,
+          count: summary.extracurricularActivityCount,
+        ),
+        _SportsAttendanceCountPill(
+          category: SportsAttendanceCategory.countAdjustment,
+          count: summary.countAdjustmentCount,
+        ),
+        _SportsAttendanceCountPill(
+          category: SportsAttendanceCategory.sportsCorridor,
+          count: summary.sportsCorridorCount,
         ),
       ],
     );
@@ -282,94 +352,6 @@ class _SportsAttendanceCountPill extends StatelessWidget {
       tone: count < 0
           ? FluentStatusChipTone.warning
           : FluentStatusChipTone.brand,
-    );
-  }
-}
-
-/// 体育部课外活动考勤明细二级页面。
-class SportsAttendanceDetailPage extends StatelessWidget {
-  /// 已读取的考勤汇总与明细。
-  final SportsAttendanceSummary summary;
-
-  const SportsAttendanceDetailPage({super.key, required this.summary});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = FluentTheme.of(context);
-    return FluentPage.scrollable(
-      header: FluentPageHeader(
-        title: const Text('课外活动考勤记录'),
-        commandBar: FluentButton.outline(
-          onPressed: () => Navigator.of(context).pop(),
-          child: const Text('返回'),
-        ),
-      ),
-      children: [
-        FluentCard(
-          padding: EdgeInsets.zero,
-          child: Padding(
-            padding: const EdgeInsets.all(FluentSpacing.l),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text('汇总', style: theme.typography.bodyStrong),
-                const SizedBox(height: FluentSpacing.s),
-                Text(
-                  '总次数 ${summary.totalCount} 次，明细 ${summary.records.length} 条。',
-                ),
-              ],
-            ),
-          ),
-        ),
-        const SizedBox(height: FluentSpacing.m),
-        if (summary.records.isEmpty)
-          const FluentInfoBar(
-            title: Text('暂无明细记录'),
-            content: Text('体育部页面返回了汇总次数，但没有可展示的考勤明细。'),
-            severity: FluentInfoSeverity.info,
-          )
-        else
-          ...summary.records.map(_buildRecordCard),
-      ],
-    );
-  }
-
-  /// 构建单条考勤记录卡片，未知字段使用原始单元格兜底。
-  Widget _buildRecordCard(SportsAttendanceRecord record) {
-    final titleParts = [
-      record.category.label,
-      if (record.occurredAt != null) record.occurredAt!,
-    ];
-    final details = [
-      if (record.project != null) '项目：${record.project}',
-      if (record.location != null) '地点：${record.location}',
-      if (record.remark != null) '备注：${record.remark}',
-      if (record.cells.isNotEmpty) '原始记录：${record.cells.join(' / ')}',
-    ];
-
-    return Padding(
-      padding: const EdgeInsets.only(bottom: FluentSpacing.s),
-      child: FluentCard(
-        padding: EdgeInsets.zero,
-        child: Padding(
-          padding: const EdgeInsets.all(FluentSpacing.m),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Expanded(child: Text(titleParts.join(' · '))),
-                  Text('${record.count} 次'),
-                ],
-              ),
-              if (details.isNotEmpty) ...[
-                const SizedBox(height: FluentSpacing.xs),
-                Text(details.join('\n')),
-              ],
-            ],
-          ),
-        ),
-      ),
     );
   }
 }

--- a/lib/pages/academic_sports_attendance_detail_page.dart
+++ b/lib/pages/academic_sports_attendance_detail_page.dart
@@ -1,0 +1,256 @@
+/*
+ * 体育考勤详情页 — 使用表格展示课外活动与晨跑明细
+ * @Project : SSPU-AllinOne
+ * @File : academic_sports_attendance_detail_page.dart
+ * @Author : Qintsg
+ * @Date : 2026-06-12
+ */
+
+part of 'academic_page.dart';
+
+/// 体育部课外活动考勤明细二级页面。
+class SportsAttendanceDetailPage extends StatelessWidget {
+  /// 已读取的考勤汇总与明细。
+  final SportsAttendanceSummary summary;
+
+  const SportsAttendanceDetailPage({super.key, required this.summary});
+
+  @override
+  Widget build(BuildContext context) {
+    return FluentPage.scrollable(
+      header: FluentPageHeader(
+        title: const Text('课外活动考勤记录'),
+        commandBar: FluentButton.outline(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('返回'),
+        ),
+      ),
+      children: [
+        _SportsAttendanceSummaryPanel(summary: summary),
+        const SizedBox(height: FluentSpacing.m),
+        _SportsAttendanceRecordsPanel(summary: summary),
+      ],
+    );
+  }
+}
+
+class _SportsAttendanceSummaryPanel extends StatelessWidget {
+  const _SportsAttendanceSummaryPanel({required this.summary});
+
+  final SportsAttendanceSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    return FluentCard(
+      padding: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.all(FluentSpacing.l),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('汇总表', style: FluentTheme.of(context).typography.bodyStrong),
+            const SizedBox(height: FluentSpacing.m),
+            _AdaptiveSportsAttendanceTable(
+              minWidth: 640,
+              child: _SportsAttendanceTable(
+                headers: const ['总次数', '晨跑次数', '课外活动', '体育长廊', '次数调整', '明细条数'],
+                rows: [
+                  [
+                    '${summary.totalCount} 次',
+                    '${summary.morningExerciseCount} 次',
+                    '${summary.extracurricularActivityCount} 次',
+                    '${summary.sportsCorridorCount} 次',
+                    '${summary.countAdjustmentCount} 次',
+                    '${summary.records.length} 条',
+                  ],
+                ],
+                centerColumns: const {0, 1, 2, 3, 4, 5},
+                columnWidths: const {
+                  0: FlexColumnWidth(),
+                  1: FlexColumnWidth(),
+                  2: FlexColumnWidth(),
+                  3: FlexColumnWidth(),
+                  4: FlexColumnWidth(),
+                  5: FlexColumnWidth(),
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SportsAttendanceRecordsPanel extends StatelessWidget {
+  const _SportsAttendanceRecordsPanel({required this.summary});
+
+  final SportsAttendanceSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    if (summary.records.isEmpty) {
+      return const FluentInfoBar(
+        title: Text('暂无明细记录'),
+        content: Text('体育部页面返回了汇总次数，但没有可展示的考勤明细。'),
+        severity: FluentInfoSeverity.info,
+      );
+    }
+
+    return FluentCard(
+      padding: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.all(FluentSpacing.l),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('明细表', style: FluentTheme.of(context).typography.bodyStrong),
+            const SizedBox(height: FluentSpacing.m),
+            _AdaptiveSportsAttendanceTable(
+              minWidth: 860,
+              child: _SportsAttendanceTable(
+                headers: const ['类别', '日期/时间', '项目', '地点', '备注', '次数', '原始记录'],
+                rows: [
+                  for (final record in summary.records)
+                    [
+                      record.category.label,
+                      record.occurredAt ?? '',
+                      record.project ?? '',
+                      record.location ?? '',
+                      record.remark ?? '',
+                      '${record.count} 次',
+                      record.cells.join(' / '),
+                    ],
+                ],
+                centerColumns: const {0, 5},
+                columnWidths: const {
+                  0: FlexColumnWidth(1.05),
+                  1: FlexColumnWidth(1.45),
+                  2: FlexColumnWidth(1.12),
+                  3: FlexColumnWidth(1.12),
+                  4: FlexColumnWidth(1.25),
+                  5: FlexColumnWidth(0.84),
+                  6: FlexColumnWidth(2.65),
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AdaptiveSportsAttendanceTable extends StatelessWidget {
+  const _AdaptiveSportsAttendanceTable({
+    required this.minWidth,
+    required this.child,
+  });
+
+  final double minWidth;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final tableWidth =
+            constraints.maxWidth.isFinite && constraints.maxWidth > minWidth
+            ? constraints.maxWidth
+            : minWidth;
+        return SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: SizedBox(width: tableWidth, child: child),
+        );
+      },
+    );
+  }
+}
+
+class _SportsAttendanceTable extends StatelessWidget {
+  const _SportsAttendanceTable({
+    required this.headers,
+    required this.rows,
+    this.centerColumns = const {},
+    this.columnWidths,
+  });
+
+  final List<String> headers;
+  final List<List<String>> rows;
+  final Set<int> centerColumns;
+  final Map<int, TableColumnWidth>? columnWidths;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = FluentTheme.of(context);
+    return Table(
+      defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+      border: TableBorder.all(color: context.fluentColors.neutralStroke1),
+      columnWidths:
+          columnWidths ??
+          {
+            for (var index = 0; index < headers.length; index++)
+              index: const FlexColumnWidth(),
+          },
+      children: [
+        TableRow(
+          decoration: BoxDecoration(
+            color: theme.resources.controlAltFillColorSecondary,
+          ),
+          children: [
+            for (var index = 0; index < headers.length; index++)
+              _SportsAttendanceTableCell(
+                headers[index],
+                header: true,
+                alignCenter: true,
+              ),
+          ],
+        ),
+        for (final row in rows)
+          TableRow(
+            children: [
+              for (var index = 0; index < headers.length; index++)
+                _SportsAttendanceTableCell(
+                  index < row.length ? row[index] : '',
+                  alignCenter: centerColumns.contains(index),
+                ),
+            ],
+          ),
+      ],
+    );
+  }
+}
+
+class _SportsAttendanceTableCell extends StatelessWidget {
+  const _SportsAttendanceTableCell(
+    this.text, {
+    this.header = false,
+    this.alignCenter = false,
+  });
+
+  final String text;
+  final bool header;
+  final bool alignCenter;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = FluentTheme.of(context);
+    final style = header ? theme.typography.bodyStrong : theme.typography.body;
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: FluentSpacing.s,
+        vertical: FluentSpacing.s,
+      ),
+      child: Text(
+        _sportsAttendanceEmptyAsDash(text),
+        textAlign: alignCenter ? TextAlign.center : TextAlign.start,
+        style: style?.copyWith(fontWeight: header ? FontWeight.w700 : null),
+      ),
+    );
+  }
+}
+
+String _sportsAttendanceEmptyAsDash(String value) {
+  final normalized = value.trim();
+  return normalized.isEmpty ? '-' : normalized;
+}

--- a/test/academic_page_test.dart
+++ b/test/academic_page_test.dart
@@ -81,6 +81,7 @@ void main() {
 
     expect(find.text('课外活动考勤'), findsOneWidget);
     expect(find.textContaining('体育部查询系统只读汇总'), findsNothing);
+    expect(find.textContaining('展示晨跑'), findsNothing);
     expect(find.text('总次数'), findsOneWidget);
     expect(find.text('早操 2 次'), findsOneWidget);
     expect(find.text('课外活动 3 次'), findsOneWidget);
@@ -91,9 +92,11 @@ void main() {
     final sportsLastRefreshCenter = tester.getCenter(
       find.text('上次刷新：2026-04-30 00:00'),
     );
-    final sportsSummaryTop = tester.getTopLeft(find.text('总次数')).dy;
+    final sportsSummaryBottom = tester.getBottomLeft(find.text('总次数')).dy;
+    final sportsButtonCenter = tester.getCenter(find.text('查看考勤记录'));
     expect(sportsLastRefreshCenter.dy, greaterThan(sportsTitleCenter.dy));
-    expect(sportsLastRefreshCenter.dy, lessThan(sportsSummaryTop));
+    expect(sportsLastRefreshCenter.dy, greaterThan(sportsSummaryBottom));
+    expect((sportsButtonCenter.dy - sportsTitleCenter.dy).abs(), lessThan(20));
     expect(sportsService.requireCampusNetworkValues, [false]);
 
     await tester.ensureVisible(find.text('查看考勤记录'));
@@ -102,7 +105,14 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('课外活动考勤记录'), findsOneWidget);
-    expect(find.textContaining('明细 2 条'), findsOneWidget);
+    expect(find.text('2 条'), findsOneWidget);
+    expect(find.text('总次数'), findsWidgets);
+    expect(find.text('晨跑次数'), findsOneWidget);
+    expect(find.text('类别'), findsOneWidget);
+    expect(find.text('日期/时间'), findsOneWidget);
+    expect(find.text('项目'), findsOneWidget);
+    expect(find.text('地点'), findsOneWidget);
+    expect(find.text('次数'), findsOneWidget);
     expect(find.textContaining('2026-04-01'), findsWidgets);
     expect(find.textContaining('体育长廊'), findsWidgets);
     await disposeAcademicPage(tester);
@@ -372,6 +382,35 @@ void main() {
     expect(find.text('必修'), findsWidgets);
     expect(find.text('通过'), findsWidgets);
     expect(find.text('参与情况'), findsWidgets);
+    expect(tester.takeException(), isNull);
+    await disposeAcademicPage(tester);
+  });
+
+  testWidgets('体育考勤详情页在移动端以横向表格展示且不溢出', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(390, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await pumpAcademicPage(
+      tester,
+      academicEamsService: _FakeAcademicEamsClient(result: _academicEamsResult),
+      sportsAttendanceService: _FakeSportsAttendanceClient(
+        result: _successResult,
+      ),
+      studentReportService: _FakeStudentReportClient(result: _creditResult),
+    );
+
+    await tester.tap(find.byKey(const Key('academic-sports-refresh')));
+    await pumpUntilFound(tester, find.text('8'));
+
+    await tester.ensureVisible(find.text('查看考勤记录'));
+    await tester.tap(find.text('查看考勤记录'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('汇总表'), findsOneWidget);
+    expect(find.text('明细表'), findsOneWidget);
+    expect(find.text('晨跑次数'), findsOneWidget);
+    expect(find.byType(Table), findsWidgets);
+    expect(find.text('2026-04-01 06:50'), findsOneWidget);
     expect(tester.takeException(), isNull);
     await disposeAcademicPage(tester);
   });


### PR DESCRIPTION
## 变更

- 调整课外活动考勤卡片结构，移除旧说明文案，将详情入口放到标题区域，并把刷新状态固定在卡片底部。
- 将课外活动考勤详情页从记录卡片改为汇总表与明细表。
- 表格在宽屏下自适应铺满，在窄屏下保留可读最小宽度并横向滚动。
- 补充页面测试断言，覆盖移动端详情表格不溢出场景。

## Review

- 快速 review：无阻塞问题。
- Architect lane: WATCH，仅提示 part-file 耦合；本次沿用现有教务页 part 模式。
- Code-reviewer lane: 原提示 issue #183 原文含剩余周数/设置项；用户确认剩余周数计算忽略，本 PR 直接关闭 issue。

## 验证

- `dart analyze lib/pages/academic_sports_attendance_detail_page.dart lib/pages/academic_sports_attendance_card.dart lib/pages/academic_page.dart test/academic_page_test.dart`
- `git diff --check`

未运行 `flutter test`：按本轮要求不跑测试。

Closes #183
