### PR TITLE
fix(apple): 统一 Apple Bundle ID 驼峰命名

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,10 @@
 
 - OA/CAS 与校园受限 HTTP 请求改用 `SSPU-AllinOne/{version} ({platform}; {os_version})` 应用身份 User-Agent，微信公众号和通用 WebView 保留带注释说明的浏览器 UA 例外。
 
+### 修复
+
+- 修正 macOS Bundle ID、RunnerTests 标识和钥匙串访问组大小写，统一使用 `cn.qintsg.sspuAllInOne`。
+
 ## [0.2.8-alpha] - 2026-06-12
 
 ### 发布

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -272,7 +272,7 @@ flutter build appbundle --release
 flutter build ios --release
 ```
 
-iOS Bundle ID 已迁移为 `cn.qintsg.sspuAllinOne`。Bundle ID 变化后，需要在 Apple Developer 账号中准备新的 App ID，并重新生成匹配的 provisioning profile；证书本身不因显示名称变化而重取，但 profile 必须覆盖新的 Bundle ID。
+iOS Bundle ID 已迁移为 `cn.qintsg.sspuAllInOne`。Bundle ID 变化后，需要在 Apple Developer 账号中准备新的 App ID，并重新生成匹配的 provisioning profile；证书本身不因显示名称变化而重取，但 profile 必须覆盖新的 Bundle ID。
 
 iOS 系统快速验证通过 `local_auth` 调用系统能力，`Info.plist` 已配置 `NSFaceIDUsageDescription`。启用该功能仍需先开启应用密码保护并输入当前密码确认。
 

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -497,7 +497,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = cn.qintsg.sspuAllinOne.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = cn.qintsg.sspuAllInOne.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/sspu_allinone.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/sspu_allinone";
@@ -512,7 +512,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = cn.qintsg.sspuAllinOne.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = cn.qintsg.sspuAllInOne.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/sspu_allinone.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/sspu_allinone";
@@ -527,7 +527,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = cn.qintsg.sspuAllinOne.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = cn.qintsg.sspuAllInOne.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/sspu_allinone.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/sspu_allinone";

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = SSPU-AllinOne
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = cn.qintsg.sspuAllinOne
+PRODUCT_BUNDLE_IDENTIFIER = cn.qintsg.sspuAllInOne
 
 // The copyright displayed in application information
 PRODUCT_COPYRIGHT = Copyright © 2026 cn.qintsg. All rights reserved.

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -12,7 +12,7 @@
 	<true/>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>8LDARH2S3X.cn.qintsg.sspuAllinOne</string>
+		<string>8LDARH2S3X.cn.qintsg.sspuAllInOne</string>
 	</array>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -14,7 +14,7 @@
 	<true/>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>8LDARH2S3X.cn.qintsg.sspuAllinOne</string>
+		<string>8LDARH2S3X.cn.qintsg.sspuAllInOne</string>
 	</array>
 </dict>
 </plist>

--- a/test/platform_display_name_config_test.dart
+++ b/test/platform_display_name_config_test.dart
@@ -13,6 +13,10 @@ import 'package:flutter_test/flutter_test.dart';
 
 String _read(String path) => File(path).readAsStringSync();
 
+const _legacyAppleBundleStem =
+    'sspuAll'
+    'inOne';
+
 Map<String, Object?> _readJson(String path) {
   return jsonDecode(_read(path)) as Map<String, Object?>;
 }
@@ -64,6 +68,55 @@ void main() {
         contains('"CFBundleDisplayName" = "工大聚合";'),
       );
     }
+  });
+
+  test('Apple Bundle Identifier 使用标准驼峰命名', () {
+    final iosProject = _read('ios/Runner.xcodeproj/project.pbxproj');
+    final macosProject = _read('macos/Runner.xcodeproj/project.pbxproj');
+    final macosAppInfo = _read('macos/Runner/Configs/AppInfo.xcconfig');
+    final macosDebugEntitlements = _read(
+      'macos/Runner/DebugProfile.entitlements',
+    );
+    final macosReleaseEntitlements = _read('macos/Runner/Release.entitlements');
+
+    for (final content in [
+      iosProject,
+      macosProject,
+      macosAppInfo,
+      macosDebugEntitlements,
+      macosReleaseEntitlements,
+    ]) {
+      expect(content, isNot(contains(_legacyAppleBundleStem)));
+    }
+
+    expect(
+      iosProject,
+      contains('PRODUCT_BUNDLE_IDENTIFIER = cn.qintsg.sspuAllInOne;'),
+    );
+    expect(
+      iosProject,
+      contains(
+        'PRODUCT_BUNDLE_IDENTIFIER = cn.qintsg.sspuAllInOne.RunnerTests;',
+      ),
+    );
+    expect(
+      macosProject,
+      contains(
+        'PRODUCT_BUNDLE_IDENTIFIER = cn.qintsg.sspuAllInOne.RunnerTests;',
+      ),
+    );
+    expect(
+      macosAppInfo,
+      contains('PRODUCT_BUNDLE_IDENTIFIER = cn.qintsg.sspuAllInOne'),
+    );
+    expect(
+      macosDebugEntitlements,
+      contains('8LDARH2S3X.cn.qintsg.sspuAllInOne'),
+    );
+    expect(
+      macosReleaseEntitlements,
+      contains('8LDARH2S3X.cn.qintsg.sspuAllInOne'),
+    );
   });
 
   test('Windows 和 Linux 原生入口按语言环境显示应用名', () {


### PR DESCRIPTION
## 变更说明

- 将 macOS 主应用 Bundle ID 从 `cn.qintsg.sspuAllinOne` 修正为 `cn.qintsg.sspuAllInOne`。
- 同步修正 macOS RunnerTests Bundle ID 与 Debug/Release keychain access group。
- 更新使用文档与 Unreleased 变更记录。
- 增加 Apple Bundle Identifier 回归测试，锁定 iOS/macOS 标识一致性并防止旧大小写回归。

## 根因

issue #273 指出 Apple 平台历史迁移后存在大小写不一致：iOS 已使用标准驼峰 `sspuAllInOne`，但 macOS 主配置、RunnerTests 和钥匙串访问组仍保留旧的 `sspuAllinOne`。

## 影响范围

- macOS 平台工程配置
- macOS keychain access group entitlement
- Apple 平台标识配置回归测试
- 文档与 Changelog

Android `applicationId = cn.qintsg.sspu_allinone` 保持不变。

## 验证记录

- [x] `flutter test test\platform_display_name_config_test.dart`
- [x] `flutter test test\macos_release_entitlements_test.dart`
- [x] `flutter analyze --no-fatal-infos`（仅剩既有 info 级 lint）
- [x] `rg -n "sspuAllinOne"` 无命中
- [x] `git diff --check` 无错误（仅 Windows 本地换行提示）

## 未验证

- 未在 macOS/Xcode 环境执行 `flutter build macos` 或 `flutter build ios`。

Closes #273
