### PR TITLE
fix(release): 修复 Apple Xcode 版本号显示

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -390,6 +390,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = cn.qintsg.sspuAllInOne;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -569,6 +570,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = cn.qintsg.sspuAllInOne;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -591,6 +593,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = cn.qintsg.sspuAllInOne;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -10,5 +10,9 @@ PRODUCT_NAME = SSPU-AllinOne
 // The application's bundle identifier
 PRODUCT_BUNDLE_IDENTIFIER = cn.qintsg.sspuAllInOne
 
+// The application's version and build number shown by Xcode.
+MARKETING_VERSION = $(FLUTTER_BUILD_NAME)
+CURRENT_PROJECT_VERSION = $(FLUTTER_BUILD_NUMBER)
+
 // The copyright displayed in application information
 PRODUCT_COPYRIGHT = Copyright © 2026 cn.qintsg. All rights reserved.

--- a/test/platform_display_name_config_test.dart
+++ b/test/platform_display_name_config_test.dart
@@ -119,6 +119,32 @@ void main() {
     );
   });
 
+  test('Apple Xcode 版本号跟随 Flutter 构建元数据', () {
+    final iosProject = _read('ios/Runner.xcodeproj/project.pbxproj');
+    final macosAppInfo = _read('macos/Runner/Configs/AppInfo.xcconfig');
+
+    expect(
+      RegExp(
+        r'MARKETING_VERSION = "\$\(FLUTTER_BUILD_NAME\)";',
+      ).allMatches(iosProject).length,
+      3,
+    );
+    expect(
+      RegExp(
+        r'CURRENT_PROJECT_VERSION = "\$\(FLUTTER_BUILD_NUMBER\)";',
+      ).allMatches(iosProject).length,
+      3,
+    );
+    expect(
+      macosAppInfo,
+      contains('MARKETING_VERSION = \$(FLUTTER_BUILD_NAME)'),
+    );
+    expect(
+      macosAppInfo,
+      contains('CURRENT_PROJECT_VERSION = \$(FLUTTER_BUILD_NUMBER)'),
+    );
+  });
+
   test('Windows 和 Linux 原生入口按语言环境显示应用名', () {
     expect(
       _read('windows/runner/main.cpp'),


### PR DESCRIPTION
## 变更

- iOS Runner 目标 Debug / Release / Profile 的 `MARKETING_VERSION` 改为引用 `$(FLUTTER_BUILD_NAME)`。
- macOS Runner 的 `AppInfo.xcconfig` 增加 `MARKETING_VERSION` 与 `CURRENT_PROJECT_VERSION`，分别引用 Flutter 生成的版本号和构建号。
- 增加平台配置测试，防止 Apple Xcode Version / Build 配置回退。

## 原因

修复 #210：iOS/macOS 在 Xcode 的 Runner -> General -> Identity 中无法显示与应用内一致的版本号和构建号。

## 验证

- `flutter test test/platform_display_name_config_test.dart`
- `dart analyze test/platform_display_name_config_test.dart`
- `git diff --check`

Closes #210
