### PR TITLE
feat(academic): 新增成绩查询页面解析与卡片效果

### DIFF
--- a/lib/models/academic_eams.dart
+++ b/lib/models/academic_eams.dart
@@ -10,6 +10,7 @@ export 'academic_eams/course_offerings.dart';
 export 'academic_eams/course_table.dart';
 export 'academic_eams/exams.dart';
 export 'academic_eams/free_classrooms.dart';
+export 'academic_eams/grade_process.dart';
 export 'academic_eams/grades.dart';
 export 'academic_eams/profile.dart';
 export 'academic_eams/program_plan.dart';

--- a/lib/models/academic_eams/grade_process.dart
+++ b/lib/models/academic_eams/grade_process.dart
@@ -1,0 +1,164 @@
+/*
+ * 本专科教务过程化成绩模型 — 按学期的平时成绩明细
+ * @Project : SSPU-AllinOne
+ * @File : grade_process.dart
+ * @Author : Qintsg
+ * @Date : 2026-06-15
+ */
+
+import 'exams.dart' show AcademicEamsSemesterOption;
+
+/// 单个平时成绩项（值/占比/描述）。
+class AcademicGradeProcessItem {
+  const AcademicGradeProcessItem({required this.label, required this.value});
+
+  /// 项目名称，例如 平时成绩Ⅰ。
+  final String label;
+
+  /// 原始展示文本，例如 95.0/10%。
+  final String value;
+
+  /// 从 JSON 恢复。
+  factory AcademicGradeProcessItem.fromJson(Map<String, dynamic> json) {
+    return AcademicGradeProcessItem(
+      label: json['label'] as String? ?? '',
+      value: json['value'] as String? ?? '',
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() => {'label': label, 'value': value};
+}
+
+/// 单门课程的过程化成绩记录。
+class AcademicGradeProcessRecord {
+  const AcademicGradeProcessRecord({
+    required this.courseName,
+    required this.items,
+    required this.rawCells,
+    this.courseCode,
+    this.courseSequence,
+    this.category,
+    this.termName,
+    this.credit,
+  });
+
+  /// 课程名称。
+  final String courseName;
+
+  /// 课程代码。
+  final String? courseCode;
+
+  /// 课程序号。
+  final String? courseSequence;
+
+  /// 课程类别。
+  final String? category;
+
+  /// 学年学期。
+  final String? termName;
+
+  /// 学分。
+  final double? credit;
+
+  /// 非占位的平时成绩项。
+  final List<AcademicGradeProcessItem> items;
+
+  /// 原始单元格文本。
+  final List<String> rawCells;
+
+  /// 是否存在可展示的平时成绩。
+  bool get hasProcessItems => items.isNotEmpty;
+
+  /// 从 JSON 恢复。
+  factory AcademicGradeProcessRecord.fromJson(Map<String, dynamic> json) {
+    return AcademicGradeProcessRecord(
+      courseName: json['courseName'] as String? ?? '',
+      items: (json['items'] as List<dynamic>? ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(AcademicGradeProcessItem.fromJson)
+          .toList(),
+      rawCells: (json['rawCells'] as List<dynamic>? ?? const []).cast<String>(),
+      courseCode: json['courseCode'] as String?,
+      courseSequence: json['courseSequence'] as String?,
+      category: json['category'] as String?,
+      termName: json['termName'] as String?,
+      credit: (json['credit'] as num?)?.toDouble(),
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'courseName': courseName,
+      'items': items.map((item) => item.toJson()).toList(),
+      'rawCells': rawCells,
+      'courseCode': courseCode,
+      'courseSequence': courseSequence,
+      'category': category,
+      'termName': termName,
+      'credit': credit,
+    };
+  }
+}
+
+/// 过程化成绩查询快照。
+class AcademicGradeProcessSnapshot {
+  const AcademicGradeProcessSnapshot({
+    required this.records,
+    required this.fetchedAt,
+    required this.sourceUri,
+    this.selectedSemester,
+    this.semesterOptions = const [],
+  });
+
+  /// 仅含有平时成绩的课程记录。
+  final List<AcademicGradeProcessRecord> records;
+
+  /// 本次查询使用的 EAMS 学期。
+  final AcademicEamsSemesterOption? selectedSemester;
+
+  /// EAMS 可选学期列表。
+  final List<AcademicEamsSemesterOption> semesterOptions;
+
+  /// 解析完成时间。
+  final DateTime fetchedAt;
+
+  /// 来源页面地址。
+  final Uri sourceUri;
+
+  /// 从 JSON 恢复。
+  factory AcademicGradeProcessSnapshot.fromJson(Map<String, dynamic> json) {
+    final selectedSemesterJson = json['selectedSemester'];
+    return AcademicGradeProcessSnapshot(
+      records: (json['records'] as List<dynamic>? ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(AcademicGradeProcessRecord.fromJson)
+          .toList(),
+      selectedSemester: selectedSemesterJson is Map<String, dynamic>
+          ? AcademicEamsSemesterOption.fromJson(selectedSemesterJson)
+          : null,
+      semesterOptions: (json['semesterOptions'] as List<dynamic>? ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(AcademicEamsSemesterOption.fromJson)
+          .toList(),
+      fetchedAt:
+          DateTime.tryParse(json['fetchedAt'] as String? ?? '')?.toLocal() ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+      sourceUri: Uri.parse(json['sourceUri'] as String? ?? ''),
+    );
+  }
+
+  /// 转换为可持久化 JSON。
+  Map<String, dynamic> toJson() {
+    return {
+      'records': records.map((record) => record.toJson()).toList(),
+      'selectedSemester': selectedSemester?.toJson(),
+      'semesterOptions': semesterOptions
+          .map((semester) => semester.toJson())
+          .toList(),
+      'fetchedAt': fetchedAt.toUtc().toIso8601String(),
+      'sourceUri': sourceUri.toString(),
+    };
+  }
+}

--- a/lib/models/academic_eams/grades.dart
+++ b/lib/models/academic_eams/grades.dart
@@ -143,4 +143,93 @@ class AcademicGradeSnapshot {
       'sourceUri': sourceUri.toString(),
     };
   }
+
+  /// 当前学期与历史成绩合并去重后的全部记录。
+  ///
+  /// 当前学期成绩页与历史成绩页可能返回同一门课，去重键使用
+  /// 课程代码（优先）或课程名加学年学期，避免重复计入学分/绩点。
+  List<AcademicGradeRecord> get allRecords {
+    final merged = <String, AcademicGradeRecord>{};
+    for (final record in [...currentTermRecords, ...historyRecords]) {
+      merged.putIfAbsent(_recordKey(record), () => record);
+    }
+    return List.unmodifiable(merged.values);
+  }
+
+  /// 去重后出现过的学年学期名，按字典序倒序（最新学期在前）。
+  List<String> get availableTerms {
+    final terms = <String>{
+      for (final record in allRecords)
+        if ((record.termName ?? '').trim().isNotEmpty) record.termName!.trim(),
+    }.toList()..sort((a, b) => b.compareTo(a));
+    return List.unmodifiable(terms);
+  }
+
+  /// 最近一个学年学期名；没有学期信息时返回 null。
+  String? get latestTermName =>
+      availableTerms.isEmpty ? null : availableTerms.first;
+
+  /// 指定学期的成绩；[term] 为 null 或空时返回全部记录。
+  ///
+  /// :param term: 目标学年学期名，例如 2025-2026-2。
+  /// :returns: 该学期的成绩记录列表。
+  List<AcademicGradeRecord> recordsForTerm(String? term) {
+    final normalized = term?.trim() ?? '';
+    if (normalized.isEmpty) return allRecords;
+    return List.unmodifiable(
+      allRecords.where(
+        (record) => (record.termName ?? '').trim() == normalized,
+      ),
+    );
+  }
+
+  /// 指定学期（或全部）可解析学分之和。
+  ///
+  /// :param term: 目标学年学期名，null 表示统计全部。
+  /// :returns: 学分合计，缺少学分的记录按 0 计。
+  double creditsForTerm(String? term) {
+    return recordsForTerm(
+      term,
+    ).fold(0, (sum, record) => sum + (record.credit ?? 0));
+  }
+
+  /// 指定学期（或全部）的学分加权平均绩点。
+  ///
+  /// :param term: 目标学年学期名，null 表示统计全部。
+  /// :returns: 加权平均绩点；缺少绩点或学分而无法计算时返回 null。
+  double? weightedGpaForTerm(String? term) {
+    var totalCredit = 0.0;
+    var weightedPoint = 0.0;
+    for (final record in recordsForTerm(term)) {
+      final credit = record.credit;
+      final gradePoint = record.gradePoint;
+      if (credit == null || gradePoint == null) continue;
+      totalCredit += credit;
+      weightedPoint += credit * gradePoint;
+    }
+    if (totalCredit <= 0) return null;
+    return weightedPoint / totalCredit;
+  }
+
+  /// 按学年学期倒序排列的全部记录；同一学期内保持原始顺序（稳定排序）。
+  List<AcademicGradeRecord> get recordsByTermDesc {
+    final records = allRecords.toList();
+    final originalIndex = <AcademicGradeRecord, int>{
+      for (var i = 0; i < records.length; i++) records[i]: i,
+    };
+    records.sort((a, b) {
+      final termCompare = (b.termName ?? '').trim().compareTo(
+        (a.termName ?? '').trim(),
+      );
+      if (termCompare != 0) return termCompare;
+      return originalIndex[a]!.compareTo(originalIndex[b]!);
+    });
+    return List.unmodifiable(records);
+  }
+
+  static String _recordKey(AcademicGradeRecord record) {
+    final code = (record.courseCode ?? '').trim();
+    final identity = code.isNotEmpty ? code : record.courseName.trim();
+    return '${(record.termName ?? '').trim()}::$identity';
+  }
 }

--- a/lib/models/academic_eams/snapshot.dart
+++ b/lib/models/academic_eams/snapshot.dart
@@ -10,6 +10,7 @@ import 'course_offerings.dart';
 import 'course_table.dart';
 import 'exams.dart';
 import 'free_classrooms.dart';
+import 'grade_process.dart';
 import 'grades.dart';
 import 'profile.dart';
 import 'program_plan.dart';
@@ -25,6 +26,7 @@ class AcademicEamsSnapshot {
     this.profile,
     this.courseTable,
     this.grades,
+    this.gradeProcess,
     this.programPlan,
     this.programCompletion,
     this.exams,
@@ -55,6 +57,9 @@ class AcademicEamsSnapshot {
 
   /// 成绩快照。
   final AcademicGradeSnapshot? grades;
+
+  /// 过程化成绩快照。
+  final AcademicGradeProcessSnapshot? gradeProcess;
 
   /// 培养计划。
   final AcademicProgramPlanSnapshot? programPlan;
@@ -87,6 +92,10 @@ class AcademicEamsSnapshot {
         AcademicCourseTableSnapshot.fromJson,
       ),
       grades: _readObject(json['grades'], AcademicGradeSnapshot.fromJson),
+      gradeProcess: _readObject(
+        json['gradeProcess'],
+        AcademicGradeProcessSnapshot.fromJson,
+      ),
       programPlan: _readObject(
         json['programPlan'],
         AcademicProgramPlanSnapshot.fromJson,
@@ -118,6 +127,7 @@ class AcademicEamsSnapshot {
       'profile': profile?.toPublicCacheJson(),
       'courseTable': courseTable?.toJson(),
       'grades': grades?.toJson(),
+      'gradeProcess': gradeProcess?.toJson(),
       'programPlan': programPlan?.toJson(),
       'programCompletion': programCompletion?.toJson(),
       'exams': exams?.toJson(),

--- a/lib/pages/academic_eams_exam_detail_page.dart
+++ b/lib/pages/academic_eams_exam_detail_page.dart
@@ -110,111 +110,103 @@ class _AcademicEamsExamDetailPageState
         ),
       ),
       children: [
+        _AcademicExamSummaryBanner(
+          scopeLabel: currentTerm?.label ?? '考试安排',
+          examTypeLabel: snapshot?.selectedExamTypeLabel,
+          totalCount: records.length,
+          scheduledCount: records
+              .where((record) => record.hasScheduledExamDate)
+              .length,
+        ),
+        const SizedBox(height: FluentSpacing.m),
         FluentSurface(
           padding: const EdgeInsets.all(FluentSpacing.l),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+          child: Wrap(
+            spacing: FluentSpacing.s,
+            runSpacing: FluentSpacing.s,
+            crossAxisAlignment: WrapCrossAlignment.end,
             children: [
-              FluentSectionHeader(
-                title: '学期',
-                subtitle: currentTerm == null
-                    ? '请选择要查看的考试学期。'
-                    : '${currentTerm.label} · 有考试信息的课程 ${records.length} 门',
-                icon: FluentIcons.calendar,
-                accentColor: context.fluentAccents.academic,
-              ),
-              const SizedBox(height: FluentSpacing.m),
-              Wrap(
-                spacing: FluentSpacing.s,
-                runSpacing: FluentSpacing.s,
-                crossAxisAlignment: WrapCrossAlignment.end,
-                children: [
-                  _AcademicExamDropdownField<int>(
-                    key: const Key('academic-eams-exam-year-select'),
-                    label: '学年',
-                    width: 190,
-                    value: currentTerm?.academicYear,
-                    placeholder: '等待全局学期',
-                    items: [
-                      for (final year in years)
-                        _AcademicExamDropdownItem<int>(
-                          key: Key('academic-eams-exam-year-option-$year'),
-                          value: year,
-                          label: _academicExamYearLabel(year),
-                        ),
-                    ],
-                    onChanged:
-                        _isLoading || currentTerm == null || years.isEmpty
-                        ? null
-                        : (year) => _handleYearChanged(
-                            year,
-                            semesterOptions,
-                            currentTerm,
-                          ),
-                  ),
-                  _AcademicExamDropdownField<AcademicTermSeason>(
-                    key: const Key('academic-eams-exam-season-select'),
-                    label: '学期',
-                    width: 180,
-                    value: currentTerm?.season,
-                    placeholder: '等待全局学期',
-                    items: [
-                      for (final season in seasons)
-                        _AcademicExamDropdownItem<AcademicTermSeason>(
-                          key: Key(
-                            'academic-eams-exam-season-option-${season.name}',
-                          ),
-                          value: season,
-                          label: season.label,
-                        ),
-                    ],
-                    onChanged: _isLoading || currentTerm == null
-                        ? null
-                        : (season) => _handleTermChanged(
-                            currentTerm.copyWith(season: season),
-                          ),
-                  ),
-                  _AcademicExamDropdownField<String>(
-                    key: const Key('academic-eams-exam-type-select'),
-                    label: '考试类型',
-                    width: 180,
-                    value: _examTypeOptions.containsKey(_selectedExamType)
-                        ? _selectedExamType
-                        : _examTypeOptions.keys.first,
-                    placeholder: '考试类型',
-                    items: [
-                      for (final entry in _examTypeOptions.entries)
-                        _AcademicExamDropdownItem<String>(
-                          key: Key(
-                            'academic-eams-exam-type-option-${entry.key}',
-                          ),
-                          value: entry.key,
-                          label: entry.value,
-                        ),
-                    ],
-                    onChanged: _isLoading
-                        ? null
-                        : (type) => setState(() => _selectedExamType = type),
-                  ),
-                  SizedBox(
-                    height: 48,
-                    child: Align(
-                      alignment: Alignment.bottomCenter,
-                      child: FluentButton.primaryIcon(
-                        key: const Key('academic-eams-exam-detail-search'),
-                        onPressed: _isLoading ? null : _loadExamSchedule,
-                        icon: _isLoading
-                            ? const SizedBox(
-                                width: 14,
-                                height: 14,
-                                child: FluentProgressRing(strokeWidth: 2),
-                              )
-                            : const Icon(FluentIcons.search, size: 14),
-                        label: const Text('搜索'),
-                      ),
+              _AcademicExamDropdownField<int>(
+                key: const Key('academic-eams-exam-year-select'),
+                label: '学年',
+                width: 190,
+                value: currentTerm?.academicYear,
+                placeholder: '等待全局学期',
+                items: [
+                  for (final year in years)
+                    _AcademicExamDropdownItem<int>(
+                      key: Key('academic-eams-exam-year-option-$year'),
+                      value: year,
+                      label: _academicExamYearLabel(year),
                     ),
-                  ),
                 ],
+                onChanged: _isLoading || currentTerm == null || years.isEmpty
+                    ? null
+                    : (year) => _handleYearChanged(
+                        year,
+                        semesterOptions,
+                        currentTerm,
+                      ),
+              ),
+              _AcademicExamDropdownField<AcademicTermSeason>(
+                key: const Key('academic-eams-exam-season-select'),
+                label: '学期',
+                width: 180,
+                value: currentTerm?.season,
+                placeholder: '等待全局学期',
+                items: [
+                  for (final season in seasons)
+                    _AcademicExamDropdownItem<AcademicTermSeason>(
+                      key: Key(
+                        'academic-eams-exam-season-option-${season.name}',
+                      ),
+                      value: season,
+                      label: season.label,
+                    ),
+                ],
+                onChanged: _isLoading || currentTerm == null
+                    ? null
+                    : (season) => _handleTermChanged(
+                        currentTerm.copyWith(season: season),
+                      ),
+              ),
+              _AcademicExamDropdownField<String>(
+                key: const Key('academic-eams-exam-type-select'),
+                label: '考试类型',
+                width: 180,
+                value: _examTypeOptions.containsKey(_selectedExamType)
+                    ? _selectedExamType
+                    : _examTypeOptions.keys.first,
+                placeholder: '考试类型',
+                items: [
+                  for (final entry in _examTypeOptions.entries)
+                    _AcademicExamDropdownItem<String>(
+                      key: Key('academic-eams-exam-type-option-${entry.key}'),
+                      value: entry.key,
+                      label: entry.value,
+                    ),
+                ],
+                onChanged: _isLoading
+                    ? null
+                    : (type) => setState(() => _selectedExamType = type),
+              ),
+              SizedBox(
+                height: 48,
+                child: Align(
+                  alignment: Alignment.bottomCenter,
+                  child: FluentButton.primaryIcon(
+                    key: const Key('academic-eams-exam-detail-search'),
+                    onPressed: _isLoading ? null : _loadExamSchedule,
+                    icon: _isLoading
+                        ? const SizedBox(
+                            width: 14,
+                            height: 14,
+                            child: FluentProgressRing(strokeWidth: 2),
+                          )
+                        : const Icon(FluentIcons.search, size: 14),
+                    label: const Text('搜索'),
+                  ),
+                ),
               ),
             ],
           ),
@@ -410,3 +402,64 @@ class _AcademicExamDropdownField<T> extends StatelessWidget {
 }
 
 String _academicExamYearLabel(int year) => '$year-${year + 1} 学年';
+
+/// 考试详情顶部汇总横幅。
+class _AcademicExamSummaryBanner extends StatelessWidget {
+  const _AcademicExamSummaryBanner({
+    required this.scopeLabel,
+    required this.examTypeLabel,
+    required this.totalCount,
+    required this.scheduledCount,
+  });
+
+  final String scopeLabel;
+  final String? examTypeLabel;
+  final int totalCount;
+  final int scheduledCount;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = FluentTheme.of(context);
+    final accent = context.fluentAccents.academic;
+    final type = examTypeLabel ?? '期末考试';
+    final summary = totalCount == 0
+        ? '$scopeLabel · $type · 暂无考试'
+        : scheduledCount == 0
+        ? '$scopeLabel · $type · $totalCount 门待公布时间'
+        : '$scopeLabel · $type · 共 $totalCount 门，$scheduledCount 门已排期';
+    return FluentSurface(
+      accentColor: accent,
+      padding: const EdgeInsets.all(FluentSpacing.l),
+      child: Row(
+        children: [
+          FluentSurfaceIcon(
+            icon: FluentIcons.calendar,
+            color: accent,
+            size: 36,
+          ),
+          const SizedBox(width: FluentSpacing.m),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '考试汇总',
+                  style: theme.typography.caption?.copyWith(
+                    color: theme.resources.textFillColorSecondary,
+                  ),
+                ),
+                const SizedBox(height: FluentSpacing.xxs),
+                Text(
+                  summary,
+                  style: theme.typography.subtitle?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/academic_eams_grade_card.dart
+++ b/lib/pages/academic_eams_grade_card.dart
@@ -1,0 +1,274 @@
+/*
+ * 教务中心本专科成绩卡片 — 仅展示 GPA 与成绩门数概览
+ * @Project : SSPU-AllinOne
+ * @File : academic_eams_grade_card.dart
+ * @Author : Qintsg
+ * @Date : 2026-06-14
+ */
+
+part of 'academic_page.dart';
+
+/// 教务中心本专科成绩子卡片。
+class AcademicEamsGradeCard extends StatelessWidget {
+  /// 最近一次成绩查询结果。
+  final AcademicEamsQueryResult? result;
+
+  /// 当前是否正在读取成绩。
+  final bool isLoading;
+
+  /// 打开成绩详情页。
+  final VoidCallback onOpenDetail;
+
+  const AcademicEamsGradeCard({
+    super.key,
+    required this.result,
+    required this.isLoading,
+    required this.onOpenDetail,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = FluentTheme.of(context);
+    final accent = context.fluentAccents.academic;
+    final snapshot = result?.snapshot?.grades;
+    final borderColor = context.fluentColors.neutralStroke1;
+
+    return Container(
+      key: const Key('academic-eams-grade-card'),
+      decoration: BoxDecoration(
+        color: theme.resources.controlAltFillColorSecondary,
+        borderRadius: context.fluentRadii.mediumBorder,
+        border: Border.all(color: borderColor),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(FluentSpacing.l),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _AcademicGradeCardHeader(
+              isLoading: isLoading,
+              accent: accent,
+              onOpenDetail: onOpenDetail,
+            ),
+            const SizedBox(height: FluentSpacing.m),
+            if (isLoading)
+              const Row(
+                children: [
+                  SizedBox(
+                    width: 18,
+                    height: 18,
+                    child: FluentProgressRing(strokeWidth: 2),
+                  ),
+                  SizedBox(width: FluentSpacing.s),
+                  Text('正在读取成绩...'),
+                ],
+              )
+            else if (result == null)
+              Text('随本专科教务刷新读取成绩，或点击右上角查看详情。', style: theme.typography.body)
+            else if (result!.isSuccess && snapshot != null)
+              _AcademicGradeMetrics(
+                gpa: snapshot.weightedGpaForTerm(null),
+                courseCount: snapshot.allRecords.length,
+              )
+            else
+              FluentInfoBar(
+                title: Text(result!.message),
+                content: Text(result!.detail),
+                severity: _examSeverity(result!.status),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AcademicGradeCardHeader extends StatelessWidget {
+  const _AcademicGradeCardHeader({
+    required this.isLoading,
+    required this.accent,
+    required this.onOpenDetail,
+  });
+
+  final bool isLoading;
+  final Color accent;
+  final VoidCallback onOpenDetail;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = FluentTheme.of(context);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        FluentSurfaceIcon(
+          icon: FluentIcons.certificate,
+          color: accent,
+          size: 36,
+        ),
+        const SizedBox(width: FluentSpacing.m),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '成绩',
+                style: theme.typography.subtitle?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: FluentSpacing.xxs),
+              Text(
+                isLoading ? '正在同步成绩' : '成绩与绩点',
+                style: theme.typography.caption?.copyWith(
+                  color: theme.resources.textFillColorSecondary,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(width: FluentSpacing.s),
+        FluentIconButton(
+          key: const Key('academic-eams-grade-detail'),
+          icon: const Icon(FluentIcons.chevronRight),
+          tooltip: '查看成绩详情',
+          semanticLabel: '查看成绩详情',
+          appearance: FluentIconButtonAppearance.outline,
+          onPressed: onOpenDetail,
+        ),
+      ],
+    );
+  }
+}
+
+class _AcademicGradeMetrics extends StatelessWidget {
+  const _AcademicGradeMetrics({required this.gpa, required this.courseCount});
+
+  /// 全部学期学分加权 GPA。
+  final double? gpa;
+
+  /// 全部学期课程门数。
+  final int courseCount;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = FluentTheme.of(context);
+    final accent = context.fluentAccents.academic;
+    if (courseCount == 0) {
+      return Text(
+        '当前账号暂无可展示的成绩。',
+        style: theme.typography.caption?.copyWith(
+          color: theme.resources.textFillColorSecondary,
+        ),
+      );
+    }
+    return Row(
+      children: [
+        Expanded(
+          child: _AcademicGradeMetricTile(
+            value: gpa == null ? '—' : gpa!.toStringAsFixed(2),
+            label: '平均绩点 GPA',
+            accent: accent,
+          ),
+        ),
+        const SizedBox(width: FluentSpacing.s),
+        Expanded(
+          child: _AcademicGradeMetricTile(
+            value: courseCount.toString(),
+            suffix: '门',
+            label: '成绩门数',
+            accent: accent,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// 成绩卡片单个指标块：醒目数值 + 说明标签。
+class _AcademicGradeMetricTile extends StatelessWidget {
+  const _AcademicGradeMetricTile({
+    required this.value,
+    required this.label,
+    required this.accent,
+    this.suffix = '',
+  });
+
+  final String value;
+  final String label;
+  final Color accent;
+  final String suffix;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = FluentTheme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: FluentSpacing.m,
+        vertical: FluentSpacing.s,
+      ),
+      decoration: BoxDecoration(
+        color: accent.withValues(alpha: 0.08),
+        borderRadius: context.fluentRadii.mediumBorder,
+        border: Border.all(color: accent.withValues(alpha: 0.18)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.baseline,
+            textBaseline: TextBaseline.alphabetic,
+            children: [
+              Flexible(
+                child: Text(
+                  value,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.typography.title?.copyWith(
+                    color: accent,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              if (suffix.isNotEmpty) ...[
+                const SizedBox(width: 2),
+                Text(
+                  suffix,
+                  style: theme.typography.caption?.copyWith(color: accent),
+                ),
+              ],
+            ],
+          ),
+          const SizedBox(height: FluentSpacing.xxs),
+          Text(
+            label,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: theme.typography.caption?.copyWith(
+              color: theme.resources.textFillColorSecondary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 格式化学分：整数不保留小数，其余按原值展示。
+///
+/// :param value: 学分数值。
+/// :returns: 适合展示的学分文本。
+String _formatGradeCredit(double value) {
+  if (value == value.roundToDouble()) return value.toStringAsFixed(0);
+  return value.toString();
+}
+
+/// 成绩文本占位处理：空值回退为占位符。
+///
+/// :param value: 原始成绩字段文本。
+/// :param placeholder: 空值占位符，默认 "-"。
+/// :returns: 适合展示的成绩文本。
+String _gradeText(String? value, {String placeholder = '-'}) {
+  final text = value?.trim() ?? '';
+  return text.isEmpty ? placeholder : text;
+}

--- a/lib/pages/academic_eams_grade_detail_page.dart
+++ b/lib/pages/academic_eams_grade_detail_page.dart
@@ -1,0 +1,498 @@
+/*
+ * 教务中心本专科成绩详情页 — 标题下汇总横幅 + 按学期前端分组的完整成绩
+ * @Project : SSPU-AllinOne
+ * @File : academic_eams_grade_detail_page.dart
+ * @Author : Qintsg
+ * @Date : 2026-06-14
+ */
+
+part of 'academic_page.dart';
+
+typedef AcademicGradeDetailResultChanged =
+    void Function(AcademicEamsQueryResult result);
+
+/// 本专科教务成绩详情页。
+class AcademicEamsGradeDetailPage extends StatefulWidget {
+  /// 本专科教务只读服务，测试中可替换为 fake。
+  final AcademicEamsClient academicEamsService;
+
+  /// 从教务中心卡片带入的初始成绩结果。
+  final AcademicEamsQueryResult? initialResult;
+
+  /// 详情页读取到新结果后回写教务中心摘要。
+  final AcademicGradeDetailResultChanged onResultChanged;
+
+  const AcademicEamsGradeDetailPage({
+    super.key,
+    required this.academicEamsService,
+    required this.initialResult,
+    required this.onResultChanged,
+  });
+
+  @override
+  State<AcademicEamsGradeDetailPage> createState() =>
+      _AcademicEamsGradeDetailPageState();
+}
+
+class _AcademicEamsGradeDetailPageState
+    extends State<AcademicEamsGradeDetailPage> {
+  AcademicEamsQueryResult? _result;
+
+  /// 当前选中学期；null 表示展示全部学期（默认）。
+  String? _selectedTerm;
+  bool _isLoading = false;
+
+  /// "全部学期" 在下拉中的占位值。
+  static const String _allTermsValue = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _result = widget.initialResult;
+    if (widget.initialResult == null) {
+      unawaited(_loadGrades());
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final snapshot = _result?.snapshot?.grades;
+    final terms = snapshot?.availableTerms ?? const <String>[];
+    final currentTerm = _selectedTerm != null && terms.contains(_selectedTerm)
+        ? _selectedTerm
+        : null;
+    final records = snapshot == null
+        ? const <AcademicGradeRecord>[]
+        : currentTerm == null
+        ? snapshot.recordsByTermDesc
+        : snapshot.recordsForTerm(currentTerm);
+    final gpa = snapshot?.weightedGpaForTerm(currentTerm);
+    final credits = snapshot?.creditsForTerm(currentTerm) ?? 0;
+
+    return FluentPage.scrollable(
+      header: FluentPageHeader(
+        title: const Text('成绩详情'),
+        commandBar: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            FluentButton.outline(
+              key: const Key('academic-eams-grade-process-entry'),
+              onPressed: _openProcessGrades,
+              child: const Text('过程化成绩'),
+            ),
+            const SizedBox(width: FluentSpacing.s),
+            FluentButton.outline(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('返回'),
+            ),
+          ],
+        ),
+      ),
+      children: [
+        _AcademicGradeSummaryBanner(
+          scopeLabel: currentTerm ?? '全部学期',
+          courseCount: records.length,
+          credits: credits,
+          gpa: gpa,
+        ),
+        const SizedBox(height: FluentSpacing.m),
+        FluentSurface(
+          padding: const EdgeInsets.all(FluentSpacing.l),
+          child: Wrap(
+            spacing: FluentSpacing.s,
+            runSpacing: FluentSpacing.s,
+            crossAxisAlignment: WrapCrossAlignment.end,
+            children: [
+              _AcademicExamDropdownField<String>(
+                key: const Key('academic-eams-grade-term-select'),
+                label: '学年学期',
+                width: 220,
+                value: currentTerm ?? _allTermsValue,
+                placeholder: '全部学期',
+                items: [
+                  const _AcademicExamDropdownItem<String>(
+                    key: Key('academic-eams-grade-term-option-all'),
+                    value: _allTermsValue,
+                    label: '全部学期',
+                  ),
+                  for (final term in terms)
+                    _AcademicExamDropdownItem<String>(
+                      key: Key('academic-eams-grade-term-option-$term'),
+                      value: term,
+                      label: term,
+                    ),
+                ],
+                onChanged: _isLoading
+                    ? null
+                    : (term) => setState(
+                        () => _selectedTerm = term == _allTermsValue
+                            ? null
+                            : term,
+                      ),
+              ),
+              SizedBox(
+                height: 48,
+                child: Align(
+                  alignment: Alignment.bottomCenter,
+                  child: FluentButton.primaryIcon(
+                    key: const Key('academic-eams-grade-detail-refresh'),
+                    onPressed: _isLoading ? null : _loadGrades,
+                    icon: _isLoading
+                        ? const SizedBox(
+                            width: 14,
+                            height: 14,
+                            child: FluentProgressRing(strokeWidth: 2),
+                          )
+                        : const Icon(FluentIcons.refresh, size: 14),
+                    label: const Text('刷新'),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: FluentSpacing.m),
+        if (_isLoading && _result == null)
+          const FluentSurface(
+            padding: EdgeInsets.all(FluentSpacing.xl),
+            child: Row(
+              children: [
+                SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: FluentProgressRing(strokeWidth: 2),
+                ),
+                SizedBox(width: FluentSpacing.s),
+                Text('正在读取成绩...'),
+              ],
+            ),
+          )
+        else if (_result == null)
+          const FluentInfoBar(
+            title: Text('尚未读取成绩'),
+            content: Text('点击“刷新”即可只读获取当前学期与历史成绩。'),
+            severity: FluentInfoSeverity.info,
+          )
+        else if (!_result!.isSuccess || snapshot == null)
+          FluentInfoBar(
+            title: Text(_result!.message),
+            content: Text(_result!.detail),
+            severity: _examSeverity(_result!.status),
+          )
+        else
+          FluentSurface(
+            padding: const EdgeInsets.all(FluentSpacing.l),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '完整内容',
+                  style: FluentTheme.of(context).typography.bodyStrong,
+                ),
+                const SizedBox(height: FluentSpacing.m),
+                _AcademicGradeTable(records: records),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+
+  void _openProcessGrades() {
+    Navigator.of(context).push(
+      FluentPageRoute(
+        builder: (_) => AcademicEamsGradeProcessPage(
+          academicEamsService: widget.academicEamsService,
+        ),
+      ),
+    );
+  }
+
+  Future<void> _loadGrades() async {
+    if (_isLoading) return;
+    setState(() => _isLoading = true);
+    final result = await widget.academicEamsService.fetchGrades(
+      requireCampusNetwork: false,
+    );
+    if (!mounted) return;
+    setState(() {
+      _result = result;
+      _isLoading = false;
+      final terms = result.snapshot?.grades?.availableTerms ?? const <String>[];
+      if (_selectedTerm != null && !terms.contains(_selectedTerm)) {
+        _selectedTerm = null;
+      }
+    });
+    widget.onResultChanged(result);
+  }
+}
+
+/// 成绩详情顶部汇总横幅。
+class _AcademicGradeSummaryBanner extends StatelessWidget {
+  const _AcademicGradeSummaryBanner({
+    required this.scopeLabel,
+    required this.courseCount,
+    required this.credits,
+    required this.gpa,
+  });
+
+  final String scopeLabel;
+  final int courseCount;
+  final double credits;
+  final double? gpa;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = FluentTheme.of(context);
+    final accent = context.fluentAccents.academic;
+    final summary = courseCount == 0
+        ? '$scopeLabel · 暂无成绩'
+        : '$scopeLabel · $courseCount 门 · ${_formatGradeCredit(credits)} 学分'
+              '${gpa == null ? '' : ' · GPA ${gpa!.toStringAsFixed(2)}'}';
+    return FluentSurface(
+      accentColor: accent,
+      padding: const EdgeInsets.all(FluentSpacing.l),
+      child: Row(
+        children: [
+          FluentSurfaceIcon(
+            icon: FluentIcons.certificate,
+            color: accent,
+            size: 36,
+          ),
+          const SizedBox(width: FluentSpacing.m),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '成绩汇总',
+                  style: theme.typography.caption?.copyWith(
+                    color: theme.resources.textFillColorSecondary,
+                  ),
+                ),
+                const SizedBox(height: FluentSpacing.xxs),
+                Text(
+                  summary,
+                  style: theme.typography.subtitle?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AcademicGradeTable extends StatelessWidget {
+  const _AcademicGradeTable({required this.records});
+
+  static const List<String> _headers = ['课程名称', '学年学期', '学分', '绩点', '总评成绩'];
+
+  final List<AcademicGradeRecord> records;
+
+  @override
+  Widget build(BuildContext context) {
+    if (records.isEmpty) {
+      return Text(
+        '所选学期暂无可展示的成绩。',
+        style: FluentTheme.of(context).typography.caption?.copyWith(
+          color: FluentTheme.of(context).resources.textFillColorSecondary,
+        ),
+      );
+    }
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth < 560) {
+          return _AcademicGradeRecordList(records: records);
+        }
+        return SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              minWidth: constraints.maxWidth < 720 ? 720 : constraints.maxWidth,
+            ),
+            child: Table(
+              defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+              border: TableBorder.all(
+                color: context.fluentColors.neutralStroke1,
+              ),
+              columnWidths: const {
+                0: FlexColumnWidth(2),
+                1: FixedColumnWidth(150),
+                2: FixedColumnWidth(80),
+                3: FixedColumnWidth(80),
+                4: FixedColumnWidth(120),
+              },
+              children: [
+                _headerRow(context),
+                for (final record in records) _recordRow(record),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  TableRow _headerRow(BuildContext context) {
+    return TableRow(
+      decoration: BoxDecoration(
+        color: FluentTheme.of(context).resources.controlAltFillColorSecondary,
+      ),
+      children: [
+        for (final header in _headers)
+          _AcademicGradeTableCell(header, header: true, center: true),
+      ],
+    );
+  }
+
+  TableRow _recordRow(AcademicGradeRecord record) {
+    return TableRow(
+      children: [
+        _AcademicGradeTableCell(record.courseName),
+        _AcademicGradeTableCell(record.termName ?? '', center: true),
+        _AcademicGradeTableCell(
+          record.credit == null ? '' : _formatGradeCredit(record.credit!),
+          center: true,
+        ),
+        _AcademicGradeTableCell(
+          record.gradePoint == null
+              ? ''
+              : record.gradePoint!.toStringAsFixed(1),
+          center: true,
+        ),
+        _AcademicGradeTableCell(record.totalScoreText ?? '', center: true),
+      ],
+    );
+  }
+}
+
+class _AcademicGradeRecordList extends StatelessWidget {
+  const _AcademicGradeRecordList({required this.records});
+
+  final List<AcademicGradeRecord> records;
+
+  @override
+  Widget build(BuildContext context) {
+    final borderColor = context.fluentColors.neutralStroke1;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        border: Border.all(color: borderColor),
+        borderRadius: BorderRadius.circular(context.fluentRadii.medium),
+      ),
+      child: Column(
+        children: [
+          for (var index = 0; index < records.length; index++) ...[
+            _AcademicGradeRecordListItem(record: records[index]),
+            if (index != records.length - 1)
+              Container(height: 1, color: borderColor),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _AcademicGradeRecordListItem extends StatelessWidget {
+  const _AcademicGradeRecordListItem({required this.record});
+
+  final AcademicGradeRecord record;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = FluentTheme.of(context);
+    return Padding(
+      padding: const EdgeInsets.all(FluentSpacing.m),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(record.courseName, style: theme.typography.bodyStrong),
+          const SizedBox(height: FluentSpacing.s),
+          Wrap(
+            spacing: FluentSpacing.l,
+            runSpacing: FluentSpacing.s,
+            children: [
+              _AcademicGradeRecordField(label: '学年学期', value: record.termName),
+              _AcademicGradeRecordField(
+                label: '学分',
+                value: record.credit == null
+                    ? null
+                    : _formatGradeCredit(record.credit!),
+              ),
+              _AcademicGradeRecordField(
+                label: '绩点',
+                value: record.gradePoint?.toStringAsFixed(1),
+              ),
+              _AcademicGradeRecordField(
+                label: '总评成绩',
+                value: record.totalScoreText,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AcademicGradeRecordField extends StatelessWidget {
+  const _AcademicGradeRecordField({required this.label, required this.value});
+
+  final String label;
+  final String? value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = FluentTheme.of(context);
+    return ConstrainedBox(
+      constraints: const BoxConstraints(minWidth: 96, maxWidth: 220),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            label,
+            style: theme.typography.caption?.copyWith(
+              color: theme.resources.textFillColorSecondary,
+            ),
+          ),
+          const SizedBox(height: FluentSpacing.xxs),
+          Text(_gradeText(value), style: theme.typography.body),
+        ],
+      ),
+    );
+  }
+}
+
+class _AcademicGradeTableCell extends StatelessWidget {
+  const _AcademicGradeTableCell(
+    this.text, {
+    this.header = false,
+    this.center = false,
+  });
+
+  final String text;
+  final bool header;
+  final bool center;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = FluentTheme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: FluentSpacing.s,
+        vertical: FluentSpacing.s,
+      ),
+      child: Text(
+        _gradeText(text),
+        textAlign: center ? TextAlign.center : TextAlign.start,
+        style: (header ? theme.typography.bodyStrong : theme.typography.body)
+            ?.copyWith(fontWeight: header ? FontWeight.w700 : null),
+      ),
+    );
+  }
+}

--- a/lib/pages/academic_eams_grade_process_page.dart
+++ b/lib/pages/academic_eams_grade_process_page.dart
@@ -1,0 +1,401 @@
+/*
+ * 教务中心本专科过程化成绩页 — 按学期请求并展示平时成绩明细
+ * @Project : SSPU-AllinOne
+ * @File : academic_eams_grade_process_page.dart
+ * @Author : Qintsg
+ * @Date : 2026-06-15
+ */
+
+part of 'academic_page.dart';
+
+/// 本专科教务过程化成绩页（成绩详情的三级页）。
+class AcademicEamsGradeProcessPage extends StatefulWidget {
+  /// 本专科教务只读服务，测试中可替换为 fake。
+  final AcademicEamsClient academicEamsService;
+
+  /// 进入时的全局学期。
+  final AcademicTermChoice? initialTerm;
+
+  /// 进入时的 EAMS 学期。
+  final AcademicEamsSemesterOption? initialSemester;
+
+  const AcademicEamsGradeProcessPage({
+    super.key,
+    required this.academicEamsService,
+    this.initialTerm,
+    this.initialSemester,
+  });
+
+  @override
+  State<AcademicEamsGradeProcessPage> createState() =>
+      _AcademicEamsGradeProcessPageState();
+}
+
+class _AcademicEamsGradeProcessPageState
+    extends State<AcademicEamsGradeProcessPage> {
+  AcademicEamsQueryResult? _result;
+  AcademicTermChoice? _selectedTerm;
+  AcademicEamsSemesterOption? _selectedSemester;
+  bool _isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedTerm = widget.initialTerm;
+    _selectedSemester = widget.initialSemester;
+    unawaited(_loadProcessGrades());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = FluentTheme.of(context);
+    final accent = context.fluentAccents.academic;
+    final snapshot = _result?.snapshot?.gradeProcess;
+    final records = snapshot?.records ?? const <AcademicGradeProcessRecord>[];
+    final options = _semesterOptions(snapshot);
+    final currentSemester = _currentSemester(snapshot, options);
+
+    return FluentPage.scrollable(
+      header: FluentPageHeader(
+        title: const Text('过程化成绩'),
+        commandBar: FluentButton.outline(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('返回'),
+        ),
+      ),
+      children: [
+        _AcademicGradeProcessBanner(
+          semesterLabel: currentSemester?.label,
+          courseCount: records.length,
+          accent: accent,
+        ),
+        const SizedBox(height: FluentSpacing.m),
+        FluentSurface(
+          padding: const EdgeInsets.all(FluentSpacing.l),
+          child: Wrap(
+            spacing: FluentSpacing.s,
+            runSpacing: FluentSpacing.s,
+            crossAxisAlignment: WrapCrossAlignment.end,
+            children: [
+              _AcademicExamDropdownField<String>(
+                key: const Key('academic-eams-grade-process-semester-select'),
+                label: '学年学期',
+                width: 220,
+                value: currentSemester?.id,
+                placeholder: '选择学期',
+                items: [
+                  for (final option in options)
+                    _AcademicExamDropdownItem<String>(
+                      key: Key(
+                        'academic-eams-grade-process-semester-option-${option.id}',
+                      ),
+                      value: option.id,
+                      label: option.label,
+                    ),
+                ],
+                onChanged: _isLoading || options.isEmpty
+                    ? null
+                    : (id) => _handleSemesterChanged(id, options),
+              ),
+              SizedBox(
+                height: 48,
+                child: Align(
+                  alignment: Alignment.bottomCenter,
+                  child: FluentButton.primaryIcon(
+                    key: const Key('academic-eams-grade-process-search'),
+                    onPressed: _isLoading ? null : _loadProcessGrades,
+                    icon: _isLoading
+                        ? const SizedBox(
+                            width: 14,
+                            height: 14,
+                            child: FluentProgressRing(strokeWidth: 2),
+                          )
+                        : const Icon(FluentIcons.search, size: 14),
+                    label: const Text('搜索'),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: FluentSpacing.m),
+        if (_isLoading && _result == null)
+          const FluentSurface(
+            padding: EdgeInsets.all(FluentSpacing.xl),
+            child: Row(
+              children: [
+                SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: FluentProgressRing(strokeWidth: 2),
+                ),
+                SizedBox(width: FluentSpacing.s),
+                Text('正在读取过程化成绩...'),
+              ],
+            ),
+          )
+        else if (_result != null && (!_result!.isSuccess || snapshot == null))
+          FluentInfoBar(
+            title: Text(_result!.message),
+            content: Text(_result!.detail),
+            severity: _examSeverity(_result!.status),
+          )
+        else if (records.isEmpty)
+          const FluentInfoBar(
+            key: Key('academic-eams-grade-process-empty'),
+            title: Text('暂无过程化成绩'),
+            content: Text('所选学期没有可展示的平时成绩记录。'),
+            severity: FluentInfoSeverity.info,
+          )
+        else
+          FluentSurface(
+            padding: const EdgeInsets.all(FluentSpacing.l),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('完整内容', style: theme.typography.bodyStrong),
+                const SizedBox(height: FluentSpacing.m),
+                _AcademicGradeProcessList(records: records),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+
+  List<AcademicEamsSemesterOption> _semesterOptions(
+    AcademicGradeProcessSnapshot? snapshot,
+  ) {
+    final options = [...?snapshot?.semesterOptions];
+    final selected = snapshot?.selectedSemester ?? _selectedSemester;
+    if (selected != null &&
+        selected.id.isNotEmpty &&
+        !options.any((option) => option.id == selected.id)) {
+      options.insert(0, selected);
+    }
+    return List.unmodifiable(options);
+  }
+
+  AcademicEamsSemesterOption? _currentSemester(
+    AcademicGradeProcessSnapshot? snapshot,
+    List<AcademicEamsSemesterOption> options,
+  ) {
+    final selected = snapshot?.selectedSemester ?? _selectedSemester;
+    if (selected != null) {
+      for (final option in options) {
+        if (option.id == selected.id) return option;
+      }
+      if (selected.id.isNotEmpty) return selected;
+    }
+    return options.isEmpty ? null : options.first;
+  }
+
+  void _handleSemesterChanged(
+    String id,
+    List<AcademicEamsSemesterOption> options,
+  ) {
+    for (final option in options) {
+      if (option.id == id) {
+        setState(() {
+          _selectedSemester = option;
+          _selectedTerm = option.termChoice ?? _selectedTerm;
+        });
+        return;
+      }
+    }
+  }
+
+  Future<void> _loadProcessGrades() async {
+    if (_isLoading) return;
+    setState(() => _isLoading = true);
+    final result = await widget.academicEamsService.fetchGradeProcess(
+      term: _selectedTerm,
+      semester: _selectedSemester,
+      requireCampusNetwork: false,
+    );
+    if (!mounted) return;
+    setState(() {
+      _result = result;
+      _isLoading = false;
+      final selected = result.snapshot?.gradeProcess?.selectedSemester;
+      if (selected != null) {
+        _selectedSemester = selected;
+        _selectedTerm = selected.termChoice ?? _selectedTerm;
+      }
+    });
+  }
+}
+
+/// 过程化成绩顶部汇总横幅。
+class _AcademicGradeProcessBanner extends StatelessWidget {
+  const _AcademicGradeProcessBanner({
+    required this.semesterLabel,
+    required this.courseCount,
+    required this.accent,
+  });
+
+  final String? semesterLabel;
+  final int courseCount;
+  final Color accent;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = FluentTheme.of(context);
+    final scope = semesterLabel ?? '过程化成绩';
+    final summary = courseCount == 0
+        ? '$scope · 暂无平时成绩'
+        : '$scope · $courseCount 门课程有平时成绩';
+    return FluentSurface(
+      accentColor: accent,
+      padding: const EdgeInsets.all(FluentSpacing.l),
+      child: Row(
+        children: [
+          FluentSurfaceIcon(
+            icon: FluentIcons.certificate,
+            color: accent,
+            size: 36,
+          ),
+          const SizedBox(width: FluentSpacing.m),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '过程化成绩',
+                  style: theme.typography.caption?.copyWith(
+                    color: theme.resources.textFillColorSecondary,
+                  ),
+                ),
+                const SizedBox(height: FluentSpacing.xxs),
+                Text(
+                  summary,
+                  style: theme.typography.subtitle?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AcademicGradeProcessList extends StatelessWidget {
+  const _AcademicGradeProcessList({required this.records});
+
+  final List<AcademicGradeProcessRecord> records;
+
+  @override
+  Widget build(BuildContext context) {
+    final borderColor = context.fluentColors.neutralStroke1;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        border: Border.all(color: borderColor),
+        borderRadius: BorderRadius.circular(context.fluentRadii.medium),
+      ),
+      child: Column(
+        children: [
+          for (var index = 0; index < records.length; index++) ...[
+            _AcademicGradeProcessListItem(record: records[index]),
+            if (index != records.length - 1)
+              Container(height: 1, color: borderColor),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _AcademicGradeProcessListItem extends StatelessWidget {
+  const _AcademicGradeProcessListItem({required this.record});
+
+  final AcademicGradeProcessRecord record;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = FluentTheme.of(context);
+    final meta = [
+      if ((record.category ?? '').trim().isNotEmpty) record.category!.trim(),
+      if (record.credit != null) '${_formatGradeCredit(record.credit!)} 学分',
+    ].join(' · ');
+    return Padding(
+      padding: const EdgeInsets.all(FluentSpacing.m),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Text(
+                  record.courseName,
+                  style: theme.typography.bodyStrong,
+                ),
+              ),
+              if (meta.isNotEmpty)
+                Text(
+                  meta,
+                  style: theme.typography.caption?.copyWith(
+                    color: theme.resources.textFillColorSecondary,
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: FluentSpacing.s),
+          Wrap(
+            spacing: FluentSpacing.s,
+            runSpacing: FluentSpacing.s,
+            children: [
+              for (final item in record.items)
+                _AcademicGradeProcessChip(item: item),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AcademicGradeProcessChip extends StatelessWidget {
+  const _AcademicGradeProcessChip({required this.item});
+
+  final AcademicGradeProcessItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = FluentTheme.of(context);
+    final accent = context.fluentAccents.academic;
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: FluentSpacing.s,
+        vertical: FluentSpacing.xs,
+      ),
+      decoration: BoxDecoration(
+        color: accent.withValues(alpha: 0.08),
+        borderRadius: context.fluentRadii.smallBorder,
+        border: Border.all(color: accent.withValues(alpha: 0.18)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            item.label,
+            style: theme.typography.caption?.copyWith(
+              color: theme.resources.textFillColorSecondary,
+            ),
+          ),
+          const SizedBox(width: FluentSpacing.xs),
+          Text(
+            item.value,
+            style: theme.typography.caption?.copyWith(
+              color: accent,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/academic_eams_summary_card.dart
+++ b/lib/pages/academic_eams_summary_card.dart
@@ -37,6 +37,12 @@ class AcademicEamsSummaryCard extends StatelessWidget {
   /// 本专科教务内嵌考试安排子卡片。
   final Widget examSchedule;
 
+  /// 当前成绩查询结果，用于让摘要指标跟随内嵌成绩子卡片。
+  final AcademicEamsQueryResult? gradeResult;
+
+  /// 本专科教务内嵌成绩子卡片。
+  final Widget gradeCard;
+
   const AcademicEamsSummaryCard({
     super.key,
     required this.result,
@@ -48,6 +54,8 @@ class AcademicEamsSummaryCard extends StatelessWidget {
     required this.onOpenCourseSchedule,
     required this.examResult,
     required this.examSchedule,
+    required this.gradeResult,
+    required this.gradeCard,
   });
 
   @override
@@ -90,6 +98,7 @@ class AcademicEamsSummaryCard extends StatelessWidget {
             _AcademicEamsSnapshotView(
               snapshot: snapshot,
               examSnapshot: examResult?.snapshot?.exams ?? snapshot.exams,
+              gradeSnapshot: gradeResult?.snapshot?.grades ?? snapshot.grades,
               status: result!.status,
               onOpenCourseSchedule: onOpenCourseSchedule,
             ),
@@ -101,7 +110,7 @@ class AcademicEamsSummaryCard extends StatelessWidget {
             ),
           ],
           const SizedBox(height: FluentSpacing.l),
-          _AcademicEamsSubcardWrap(children: [examSchedule]),
+          _AcademicEamsSubcardWrap(children: [examSchedule, gradeCard]),
           const SizedBox(height: FluentSpacing.m),
           Align(
             alignment: Alignment.centerRight,
@@ -198,12 +207,14 @@ class _AcademicEamsSnapshotView extends StatelessWidget {
   const _AcademicEamsSnapshotView({
     required this.snapshot,
     required this.examSnapshot,
+    required this.gradeSnapshot,
     required this.status,
     required this.onOpenCourseSchedule,
   });
 
   final AcademicEamsSnapshot snapshot;
   final AcademicExamSnapshot? examSnapshot;
+  final AcademicGradeSnapshot? gradeSnapshot;
   final AcademicEamsQueryStatus status;
   final VoidCallback onOpenCourseSchedule;
 
@@ -212,9 +223,7 @@ class _AcademicEamsSnapshotView extends StatelessWidget {
     final theme = FluentTheme.of(context);
     final profile = snapshot.profile;
     final courseCount = snapshot.courseTable?.entries.length ?? 0;
-    final gradeCount =
-        (snapshot.grades?.historyRecords.length ?? 0) +
-        (snapshot.grades?.currentTermRecords.length ?? 0);
+    final gradeCount = gradeSnapshot?.allRecords.length ?? 0;
     // 统计全部考试记录，避免考试时间未公布时摘要误显示为 0。
     final examCount = examSnapshot?.records.length ?? 0;
     final completion = snapshot.programCompletion;

--- a/lib/pages/academic_page.dart
+++ b/lib/pages/academic_page.dart
@@ -31,6 +31,9 @@ import 'course_schedule_page.dart';
 part 'academic_eams_summary_card.dart';
 part 'academic_eams_exam_card.dart';
 part 'academic_eams_exam_detail_page.dart';
+part 'academic_eams_grade_card.dart';
+part 'academic_eams_grade_detail_page.dart';
+part 'academic_eams_grade_process_page.dart';
 part 'academic_sports_attendance_card.dart';
 part 'academic_sports_attendance_detail_page.dart';
 part 'academic_student_report_card.dart';
@@ -109,6 +112,9 @@ class _AcademicPageState extends State<AcademicPage> {
   _academicEamsRefreshController;
   late final CardAutoRefreshController<AcademicEamsQueryResult>
   _academicExamRefreshController;
+  AcademicEamsQueryResult? _academicGradeResult;
+  late final CardAutoRefreshController<AcademicEamsQueryResult>
+  _academicGradeRefreshController;
 
   SportsAttendanceQueryResult? _sportsAttendanceResult;
   late final CardAutoRefreshController<SportsAttendanceQueryResult>
@@ -150,6 +156,14 @@ class _AcademicPageState extends State<AcademicPage> {
           checkedAt: () => _academicExamResult?.checkedAt,
           failureReason: _academicEamsRefreshFailureReason,
         )..addListener(_handleRefreshControllerChanged);
+    _academicGradeRefreshController =
+        CardAutoRefreshController<AcademicEamsQueryResult>(
+          refreshTask: _fetchAcademicGradeForController,
+          isSuccess: (result) => result.isSuccess,
+          applyResult: _applyAcademicGradeResult,
+          checkedAt: () => _academicGradeResult?.checkedAt,
+          failureReason: _academicEamsRefreshFailureReason,
+        )..addListener(_handleRefreshControllerChanged);
     _sportsAttendanceRefreshController =
         CardAutoRefreshController<SportsAttendanceQueryResult>(
           refreshTask: _fetchSportsAttendanceForController,
@@ -182,12 +196,14 @@ class _AcademicPageState extends State<AcademicPage> {
     if (!mounted) return;
     _academicEamsRefreshController.clearTransientState();
     _academicExamRefreshController.clearTransientState();
+    _academicGradeRefreshController.clearTransientState();
     _sportsAttendanceRefreshController.clearTransientState();
     _studentReportRefreshController.clearTransientState();
     setState(() {
       _academicEamsResult = null;
       _academicExamResult = null;
       _academicExamSelectedSemester = null;
+      _academicGradeResult = null;
       _sportsAttendanceResult = null;
       _studentReportResult = null;
     });
@@ -218,7 +234,15 @@ class _AcademicPageState extends State<AcademicPage> {
       setState(() => _academicEamsResult = cachedResult);
     }
     await _loadAcademicExamCacheAndDefaultTerm();
+    await _loadAcademicGradeCache();
     await _loadAcademicEamsAutoRefreshSettings();
+  }
+
+  /// 读取成绩缓存以便先展示本地数据，再按刷新策略决定是否联网。
+  Future<void> _loadAcademicGradeCache() async {
+    final cachedResult = await _academicEamsService.readLatestCachedGrades();
+    if (!mounted || cachedResult == null) return;
+    setState(() => _academicGradeResult = cachedResult);
   }
 
   /// 读取考试安排缓存，并把卡片学期默认到全局查询学期。
@@ -264,6 +288,7 @@ class _AcademicPageState extends State<AcademicPage> {
       final examResult = _academicExamResult;
       _academicEamsLastRefreshHadExamFailure =
           !silent && examResult != null && !examResult.isSuccess;
+      await _academicGradeRefreshController.runRefresh(silent: silent);
     }
     return result;
   }
@@ -298,6 +323,29 @@ class _AcademicPageState extends State<AcademicPage> {
             selectedSemester.termChoice ?? _academicExamSelectedTerm;
       }
     });
+  }
+
+  Future<AcademicEamsQueryResult> _fetchAcademicGradeForController({
+    required bool silent,
+  }) {
+    return _academicEamsService.fetchGrades(requireCampusNetwork: silent);
+  }
+
+  void _applyAcademicGradeResult(AcademicEamsQueryResult result) {
+    if (!mounted) return;
+    setState(() => _academicGradeResult = result);
+  }
+
+  void _openAcademicGradeDetail() {
+    Navigator.of(context).push(
+      FluentPageRoute(
+        builder: (_) => AcademicEamsGradeDetailPage(
+          academicEamsService: _academicEamsService,
+          initialResult: _academicGradeResult,
+          onResultChanged: _applyAcademicGradeResult,
+        ),
+      ),
+    );
   }
 
   void _openAcademicExamDetail() {
@@ -503,6 +551,9 @@ class _AcademicPageState extends State<AcademicPage> {
     _academicExamRefreshController
       ..removeListener(_handleRefreshControllerChanged)
       ..dispose();
+    _academicGradeRefreshController
+      ..removeListener(_handleRefreshControllerChanged)
+      ..dispose();
     _sportsAttendanceRefreshController
       ..removeListener(_handleRefreshControllerChanged)
       ..dispose();
@@ -551,6 +602,12 @@ class _AcademicPageState extends State<AcademicPage> {
                     isLoading: _academicExamRefreshController.isLoading,
                     selectedTerm: _academicExamSelectedTerm,
                     onOpenDetail: _openAcademicExamDetail,
+                  ),
+                  gradeResult: _academicGradeResult,
+                  gradeCard: AcademicEamsGradeCard(
+                    result: _academicGradeResult,
+                    isLoading: _academicGradeRefreshController.isLoading,
+                    onOpenDetail: _openAcademicGradeDetail,
                   ),
                 ),
                 sports: AcademicSportsAttendanceCard(

--- a/lib/services/academic_eams_grade_flow.dart
+++ b/lib/services/academic_eams_grade_flow.dart
@@ -1,0 +1,301 @@
+/*
+ * 本专科教务成绩查询流程 — 拉取当前学期与历史成绩并聚合为可缓存快照
+ * @Project : SSPU-AllinOne
+ * @File : academic_eams_grade_flow.dart
+ * @Author : Qintsg
+ * @Date : 2026-06-14
+ */
+
+part of 'academic_eams_service.dart';
+
+extension _AcademicEamsGradeFlow on AcademicEamsService {
+  /// 拉取并聚合成绩查询结果。
+  ///
+  /// 一次性读取当前学期成绩页与历史成绩页并合并为成绩快照；学期切换交由
+  /// 前端按学年学期分组完成，无需逐学期重复请求。
+  ///
+  /// :param homeSnapshot: 已解析的 EAMS 首页快照，用于兜底来源地址。
+  /// :param featureUris: 已发现的只读功能入口地址。
+  /// :param featureSnapshots: 复用的功能页快照缓存表。
+  /// :param warnings: 流程中累积的降级原因。
+  /// :param campusNetworkStatus: 当前校园网状态，用于结果提示。
+  /// :returns: 含成绩快照的查询结果。
+  Future<AcademicEamsQueryResult> _buildGradesOnlyResult({
+    required AcademicEamsHttpSnapshot homeSnapshot,
+    required Map<_AcademicFeature, Uri> featureUris,
+    required Map<_AcademicFeature, AcademicEamsHttpSnapshot> featureSnapshots,
+    required List<String> warnings,
+    required CampusNetworkStatus? campusNetworkStatus,
+  }) async {
+    await _fetchOptionalFeature(
+      _AcademicFeature.gradeCurrent,
+      featureUris,
+      featureSnapshots,
+      warnings,
+    );
+    await _fetchOptionalFeature(
+      _AcademicFeature.gradeHistory,
+      featureUris,
+      featureSnapshots,
+      warnings,
+    );
+    // 当前成绩为壳页，需 followup 到 person!search.action；历史成绩页直接解析。
+    await _resolveGradeFeatureSnapshot(
+      _AcademicFeature.gradeCurrent,
+      featureSnapshots,
+      warnings,
+    );
+    await _resolveGradeFeatureSnapshot(
+      _AcademicFeature.gradeHistory,
+      featureSnapshots,
+      warnings,
+    );
+
+    final hasGradePages =
+        featureSnapshots.containsKey(_AcademicFeature.gradeCurrent) ||
+        featureSnapshots.containsKey(_AcademicFeature.gradeHistory);
+    final grades = _parseGrades(
+      featureSnapshots[_AcademicFeature.gradeCurrent],
+      featureSnapshots[_AcademicFeature.gradeHistory],
+    );
+
+    if (grades == null && !hasGradePages) {
+      return _buildResult(
+        AcademicEamsQueryStatus.readOnlyEntryUnavailable,
+        message: '未识别到成绩查询入口',
+        detail: warnings.isEmpty
+            ? 'EAMS 只读菜单中没有可验证的成绩查询入口。'
+            : warnings.join('；'),
+        finalUri: homeSnapshot.finalUri,
+        campusNetworkStatus: campusNetworkStatus,
+      );
+    }
+
+    // 页面可访问但解析不到记录时，按空成绩快照降级展示而非报失败。
+    final sourceUri =
+        featureSnapshots[_AcademicFeature.gradeHistory]?.finalUri ??
+        featureSnapshots[_AcademicFeature.gradeCurrent]?.finalUri ??
+        homeSnapshot.finalUri;
+    final resolvedGrades =
+        grades ??
+        AcademicGradeSnapshot(
+          currentTermRecords: const [],
+          historyRecords: const [],
+          fetchedAt: DateTime.now(),
+          sourceUri: sourceUri,
+        );
+
+    final snapshot = AcademicEamsSnapshot(
+      fetchedAt: resolvedGrades.fetchedAt,
+      sourceUri: resolvedGrades.sourceUri,
+      warnings: List.unmodifiable(warnings),
+      hasCourseOfferingEntry: featureUris.containsKey(
+        _AcademicFeature.courseOfferingsEntry,
+      ),
+      hasFreeClassroomEntry: featureUris.containsKey(
+        _AcademicFeature.freeClassroomEntry,
+      ),
+      grades: resolvedGrades,
+    );
+
+    final hasRecords = resolvedGrades.allRecords.isNotEmpty;
+    return _buildResult(
+      warnings.isEmpty
+          ? AcademicEamsQueryStatus.success
+          : AcademicEamsQueryStatus.partialSuccess,
+      message: hasRecords ? '成绩读取成功' : '暂无可展示的成绩',
+      detail: hasRecords ? '已读取当前学期与历史成绩，可在详情页按学期查看。' : '成绩查询已执行，但未发现可展示的成绩记录。',
+      finalUri: resolvedGrades.sourceUri,
+      campusNetworkStatus: campusNetworkStatus,
+      snapshot: snapshot,
+    );
+  }
+
+  /// 解析单个成绩功能页快照，处理壳页 followup 与降级移除。
+  ///
+  /// :param feature: 成绩功能枚举（当前成绩或历史成绩）。
+  /// :param featureSnapshots: 功能页快照缓存表。
+  /// :param warnings: 流程中累积的降级原因。
+  /// :returns: 无返回值；解析结果写回 [featureSnapshots]。
+  Future<void> _resolveGradeFeatureSnapshot(
+    _AcademicFeature feature,
+    Map<_AcademicFeature, AcademicEamsHttpSnapshot> featureSnapshots,
+    List<String> warnings,
+  ) async {
+    final resolved = await _resolveFeatureSnapshot(
+      feature,
+      featureSnapshots[feature],
+      warnings,
+    );
+    if (resolved != null) {
+      featureSnapshots[feature] = resolved;
+    } else {
+      featureSnapshots.remove(feature);
+    }
+  }
+
+  /// 拉取指定学期的过程化成绩（平时成绩明细）。
+  ///
+  /// 过程化成绩为 EAMS 独立页面：成绩壳页提供学期日历，按学期 POST
+  /// `person!processGrade.action` 获取该学期平时成绩表格。
+  ///
+  /// :param homeSnapshot: 已解析的 EAMS 首页快照，用于兜底来源地址。
+  /// :param featureUris: 已发现的只读功能入口地址。
+  /// :param warnings: 流程中累积的降级原因。
+  /// :param campusNetworkStatus: 当前校园网状态，用于结果提示。
+  /// :param targetTerm: 目标全局学期。
+  /// :param targetSemester: 目标 EAMS 学期。
+  /// :returns: 含过程化成绩快照的查询结果。
+  Future<AcademicEamsQueryResult> _buildGradeProcessResult({
+    required AcademicEamsHttpSnapshot homeSnapshot,
+    required Map<_AcademicFeature, Uri> featureUris,
+    required List<String> warnings,
+    required CampusNetworkStatus? campusNetworkStatus,
+    AcademicTermChoice? targetTerm,
+    AcademicEamsSemesterOption? targetSemester,
+  }) async {
+    final shellUri = featureUris[_AcademicFeature.gradeCurrent];
+    if (shellUri == null) {
+      return _buildResult(
+        AcademicEamsQueryStatus.readOnlyEntryUnavailable,
+        message: '未识别到成绩查询入口',
+        detail: warnings.isEmpty
+            ? 'EAMS 只读菜单中没有可验证的成绩查询入口。'
+            : warnings.join('；'),
+        finalUri: homeSnapshot.finalUri,
+        campusNetworkStatus: campusNetworkStatus,
+      );
+    }
+
+    final shell = await _gateway.fetchPage(shellUri, timeout);
+    if (_isAuthenticationRequired(shell) || _isUnavailable(shell)) {
+      return _buildResult(
+        AcademicEamsQueryStatus.systemUnavailable,
+        message: '过程化成绩页面不可用',
+        detail: '成绩页面返回登录页或不可用状态。',
+        finalUri: shell.finalUri,
+        campusNetworkStatus: campusNetworkStatus,
+      );
+    }
+
+    final options = await _resolveExamSemesterOptions(shell, warnings);
+    final selected = _selectExamSemester(
+      options: options,
+      fallbackSemesterId: _resolveAcademicSemesterId(shell.body),
+      targetTerm: targetTerm,
+      targetSemester: targetSemester,
+    );
+
+    final actionUri = shell.finalUri.resolve('person!processGrade.action');
+    AcademicEamsHttpSnapshot dataSnapshot;
+    try {
+      dataSnapshot = await _gateway.submitForm(
+        formUri: actionUri,
+        method: 'POST',
+        fields: {'projectType': 'MAJOR', 'semester.id': selected.id},
+        timeout: timeout,
+      );
+    } on DioException {
+      return _buildResult(
+        AcademicEamsQueryStatus.networkError,
+        message: '过程化成绩读取失败',
+        detail: '提交过程化成绩查询时网络失败。',
+        finalUri: actionUri,
+        campusNetworkStatus: campusNetworkStatus,
+      );
+    } on TimeoutException {
+      return _buildResult(
+        AcademicEamsQueryStatus.networkError,
+        message: '过程化成绩读取超时',
+        detail: '提交过程化成绩查询超时。',
+        finalUri: actionUri,
+        campusNetworkStatus: campusNetworkStatus,
+      );
+    }
+
+    final records = _parseGradeProcessRecords(dataSnapshot.body);
+    final processSnapshot = AcademicGradeProcessSnapshot(
+      records: records,
+      selectedSemester: selected,
+      semesterOptions: options,
+      fetchedAt: DateTime.now(),
+      sourceUri: dataSnapshot.finalUri,
+    );
+    final snapshot = AcademicEamsSnapshot(
+      fetchedAt: processSnapshot.fetchedAt,
+      sourceUri: processSnapshot.sourceUri,
+      warnings: List.unmodifiable(warnings),
+      hasCourseOfferingEntry: featureUris.containsKey(
+        _AcademicFeature.courseOfferingsEntry,
+      ),
+      hasFreeClassroomEntry: featureUris.containsKey(
+        _AcademicFeature.freeClassroomEntry,
+      ),
+      gradeProcess: processSnapshot,
+    );
+    return _buildResult(
+      warnings.isEmpty
+          ? AcademicEamsQueryStatus.success
+          : AcademicEamsQueryStatus.partialSuccess,
+      message: records.isEmpty ? '所选学期暂无过程化成绩' : '过程化成绩读取成功',
+      detail: records.isEmpty ? '已读取所选学期，但未发现可展示的平时成绩。' : '已读取所选学期的平时成绩明细。',
+      finalUri: processSnapshot.sourceUri,
+      campusNetworkStatus: campusNetworkStatus,
+      snapshot: snapshot,
+    );
+  }
+}
+
+/// 解析过程化成绩表格，仅保留含平时成绩的课程记录。
+///
+/// :param body: 过程化成绩页面 HTML 正文。
+/// :returns: 过程化成绩记录列表。
+List<AcademicGradeProcessRecord> _parseGradeProcessRecords(String body) {
+  final document = html_parser.parse(body);
+  for (final table in _parseTables(document)) {
+    final headers = table.headers;
+    final lowerHeaders = headers.map((header) => header.toLowerCase()).toList();
+    if (!_containsAny(lowerHeaders, ['课程名称', '课程', 'course name']) ||
+        !headers.any((header) => header.contains('平时成绩'))) {
+      continue;
+    }
+    final processColumns = <int>[];
+    for (var i = 0; i < headers.length; i++) {
+      if (headers[i].contains('平时成绩')) processColumns.add(i);
+    }
+    final records = <AcademicGradeProcessRecord>[];
+    for (final row in table.rows) {
+      final rowMap = _rowToMap(headers, row);
+      final courseName = _pickValue(rowMap, ['课程名称', '课程', 'Course Name']);
+      if (courseName == null || courseName.isEmpty) continue;
+      final items = <AcademicGradeProcessItem>[];
+      for (final column in processColumns) {
+        if (column >= row.length) continue;
+        final raw = row[column].replaceAll(RegExp(r'\s+'), '');
+        if (raw.isEmpty || raw == '无' || raw == '-' || raw == '--') continue;
+        final label = headers[column].split('/').first.trim();
+        items.add(
+          AcademicGradeProcessItem(
+            label: label.isEmpty ? '平时成绩' : label,
+            value: raw,
+          ),
+        );
+      }
+      if (items.isEmpty) continue;
+      records.add(
+        AcademicGradeProcessRecord(
+          courseName: courseName,
+          courseCode: _pickValue(rowMap, ['课程代码', '课程编号', 'Course Code']),
+          courseSequence: _pickValue(rowMap, ['课程序号']),
+          category: _pickValue(rowMap, ['课程类别', '类别', '课程性质']),
+          termName: _pickValue(rowMap, ['学年学期', '学期']),
+          credit: _parseDouble(_pickValue(rowMap, ['学分', 'Credit'])),
+          items: items,
+          rawCells: row,
+        ),
+      );
+    }
+    if (records.isNotEmpty) return List.unmodifiable(records);
+  }
+  return const <AcademicGradeProcessRecord>[];
+}

--- a/lib/services/academic_eams_overview_flow.dart
+++ b/lib/services/academic_eams_overview_flow.dart
@@ -133,6 +133,10 @@ extension _AcademicEamsOverviewFlow on AcademicEamsService {
           ? StorageKeys.academicEamsCourseTableCacheCollection
           : scope == _AcademicFetchScope.examScheduleOnly
           ? StorageKeys.academicEamsExamScheduleCacheCollection
+          : scope == _AcademicFetchScope.gradesOnly
+          ? StorageKeys.academicEamsGradeCacheCollection
+          : scope == _AcademicFetchScope.gradeProcessOnly
+          ? StorageKeys.academicEamsGradeProcessCacheCollection
           : StorageKeys.academicEamsOverviewCacheCollection,
       accountKey: accountKey,
       fetchedAt: snapshot.fetchedAt,
@@ -361,6 +365,27 @@ extension _AcademicEamsOverviewFlow on AcademicEamsService {
         finalUri: exams.sourceUri,
         campusNetworkStatus: campusNetworkStatus,
         snapshot: snapshot,
+      );
+    }
+
+    if (scope == _AcademicFetchScope.gradesOnly) {
+      return _buildGradesOnlyResult(
+        homeSnapshot: homeSnapshot,
+        featureUris: featureUris,
+        featureSnapshots: featureSnapshots,
+        warnings: warnings,
+        campusNetworkStatus: campusNetworkStatus,
+      );
+    }
+
+    if (scope == _AcademicFetchScope.gradeProcessOnly) {
+      return _buildGradeProcessResult(
+        homeSnapshot: homeSnapshot,
+        featureUris: featureUris,
+        warnings: warnings,
+        campusNetworkStatus: campusNetworkStatus,
+        targetTerm: examTerm,
+        targetSemester: examSemester,
       );
     }
 

--- a/lib/services/academic_eams_service.dart
+++ b/lib/services/academic_eams_service.dart
@@ -34,6 +34,7 @@ part 'academic_eams_page_parser_forms.dart';
 part 'academic_eams_page_parser_overview.dart';
 part 'academic_eams_page_parser_profile.dart';
 part 'academic_eams_page_parser_tables.dart';
+part 'academic_eams_grade_flow.dart';
 part 'academic_eams_search_flow.dart';
 part 'academic_eams_shell_followups.dart';
 
@@ -56,6 +57,12 @@ abstract class AcademicEamsClient {
   /// 读取最近一次本地考试安排缓存。
   Future<AcademicEamsQueryResult?> readLatestCachedExamSchedule();
 
+  /// 读取最近一次本地成绩缓存。
+  Future<AcademicEamsQueryResult?> readLatestCachedGrades();
+
+  /// 读取最近一次本地过程化成绩缓存。
+  Future<AcademicEamsQueryResult?> readLatestCachedGradeProcess();
+
   /// 读取教务摘要，尽量覆盖个人信息、课表、成绩、考试和培养计划。
   Future<AcademicEamsQueryResult> fetchOverview({
     bool requireCampusNetwork = true,
@@ -73,6 +80,23 @@ abstract class AcademicEamsClient {
     AcademicTermChoice? term,
     AcademicEamsSemesterOption? semester,
     String? examTypeId,
+    bool requireCampusNetwork = true,
+  });
+
+  /// 读取成绩查询结果。
+  ///
+  /// 一次性拉取当前学期与历史成绩，学期切换由前端按学年学期分组实现，
+  /// 不再逐学期重复请求。
+  Future<AcademicEamsQueryResult> fetchGrades({
+    bool requireCampusNetwork = true,
+  });
+
+  /// 读取指定学期的过程化成绩（平时成绩明细）。
+  ///
+  /// 过程化成绩为 EAMS 中按学期独立请求的页面，需逐学期查询。
+  Future<AcademicEamsQueryResult> fetchGradeProcess({
+    AcademicTermChoice? term,
+    AcademicEamsSemesterOption? semester,
     bool requireCampusNetwork = true,
   });
 }
@@ -128,7 +152,13 @@ typedef AcademicEamsOaLoginRefresher =
       bool requireCampusNetwork,
     });
 
-enum _AcademicFetchScope { overview, courseTableOnly, examScheduleOnly }
+enum _AcademicFetchScope {
+  overview,
+  courseTableOnly,
+  examScheduleOnly,
+  gradesOnly,
+  gradeProcessOnly,
+}
 
 enum _AcademicFeature {
   studentProfile,
@@ -276,6 +306,30 @@ class AcademicEamsService implements AcademicEamsClient {
     );
   }
 
+  @override
+  Future<AcademicEamsQueryResult> fetchGrades({
+    bool requireCampusNetwork = true,
+  }) async {
+    return _fetchSnapshot(
+      _AcademicFetchScope.gradesOnly,
+      requireCampusNetwork: requireCampusNetwork,
+    );
+  }
+
+  @override
+  Future<AcademicEamsQueryResult> fetchGradeProcess({
+    AcademicTermChoice? term,
+    AcademicEamsSemesterOption? semester,
+    bool requireCampusNetwork = true,
+  }) async {
+    return _fetchSnapshot(
+      _AcademicFetchScope.gradeProcessOnly,
+      requireCampusNetwork: requireCampusNetwork,
+      examTerm: term,
+      examSemester: semester,
+    );
+  }
+
   /// 只读查询开课列表；仅提交搜索表单，不执行选课或其它写操作。
   Future<AcademicEamsQueryResult> searchCourseOfferings(
     AcademicCourseOfferingSearchCriteria criteria,
@@ -409,6 +463,26 @@ class AcademicEamsService implements AcademicEamsClient {
     );
   }
 
+  /// 读取最近一次本地成绩缓存。
+  @override
+  Future<AcademicEamsQueryResult?> readLatestCachedGrades() async {
+    return _readLatestCachedResult(
+      collection: StorageKeys.academicEamsGradeCacheCollection,
+      message: '已显示本地成绩缓存',
+      detail: '显示最近一次成功读取并保存的本专科教务成绩。',
+    );
+  }
+
+  /// 读取最近一次本地过程化成绩缓存。
+  @override
+  Future<AcademicEamsQueryResult?> readLatestCachedGradeProcess() async {
+    return _readLatestCachedResult(
+      collection: StorageKeys.academicEamsGradeProcessCacheCollection,
+      message: '已显示本地过程化成绩缓存',
+      detail: '显示最近一次成功读取并保存的本专科教务过程化成绩。',
+    );
+  }
+
   Future<AcademicEamsQueryResult?> _readLatestCachedResult({
     required String collection,
     required String message,
@@ -434,6 +508,7 @@ class AcademicEamsService implements AcademicEamsClient {
             profile: secureProfile,
             courseTable: snapshot.courseTable,
             grades: snapshot.grades,
+            gradeProcess: snapshot.gradeProcess,
             programPlan: snapshot.programPlan,
             programCompletion: snapshot.programCompletion,
             exams: snapshot.exams,

--- a/lib/services/storage_keys.dart
+++ b/lib/services/storage_keys.dart
@@ -142,6 +142,14 @@ class StorageKeys {
   static const String academicEamsExamScheduleCacheCollection =
       'cache_academic_eams_exam_schedule';
 
+  /// 本专科教务成绩业务快照缓存集合。
+  static const String academicEamsGradeCacheCollection =
+      'cache_academic_eams_grade';
+
+  /// 本专科教务过程化成绩业务快照缓存集合。
+  static const String academicEamsGradeProcessCacheCollection =
+      'cache_academic_eams_grade_process';
+
   /// 教务处校历缓存集合。
   static const String academicCalendarCollection = 'cache_academic_calendar';
 

--- a/test/academic_eams_service_test.dart
+++ b/test/academic_eams_service_test.dart
@@ -779,6 +779,83 @@ void main() {
     expect(result.snapshot?.programPlan, isNull);
   });
 
+  test('独立成绩读取合并当前与历史成绩并按学期分组', () async {
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      oaPassword: 'oa-pass',
+    );
+    await AcademicCredentialsService.instance.saveOaLoginSession(
+      academicEamsSessionSnapshot,
+    );
+    final service = buildAcademicEamsServiceForTest(
+      gateway: FakeAcademicEamsGateway(),
+      campusReachable: true,
+    );
+
+    final result = await service.fetchGrades();
+
+    expect(result.status, AcademicEamsQueryStatus.success);
+    final grades = result.snapshot?.grades;
+    expect(grades, isNotNull);
+    expect(grades!.allRecords.length, 2);
+    expect(grades.availableTerms, ['2025-2026-2', '2025-2026-1']);
+    expect(grades.recordsForTerm('2025-2026-2').single.courseName, '高等数学');
+    expect(grades.creditsForTerm(null), 7);
+    // 成绩查询只解析成绩，不附带课表或考试。
+    expect(result.snapshot?.courseTable, isNull);
+    expect(result.snapshot?.exams, isNull);
+  });
+
+  test('成绩读取成功后写入本地成绩缓存', () async {
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      oaPassword: 'oa-pass',
+    );
+    await AcademicCredentialsService.instance.saveOaLoginSession(
+      academicEamsSessionSnapshot,
+    );
+    final service = buildAcademicEamsServiceForTest(
+      gateway: FakeAcademicEamsGateway(),
+      campusReachable: true,
+    );
+
+    await service.fetchGrades();
+    final cached = await service.readLatestCachedGrades();
+
+    expect(cached?.status, AcademicEamsQueryStatus.success);
+    expect(cached?.snapshot?.grades?.allRecords.length, 2);
+  });
+
+  test('过程化成绩按学期请求并解析平时成绩明细', () async {
+    await AcademicCredentialsService.instance.saveCredentials(
+      oaAccount: '20260001',
+      oaPassword: 'oa-pass',
+    );
+    await AcademicCredentialsService.instance.saveOaLoginSession(
+      academicEamsSessionSnapshot,
+    );
+    final service = buildAcademicEamsServiceForTest(
+      gateway: FakeAcademicEamsGateway(),
+      campusReachable: true,
+    );
+
+    final result = await service.fetchGradeProcess();
+
+    expect(result.status, AcademicEamsQueryStatus.success);
+    final process = result.snapshot?.gradeProcess;
+    expect(process, isNotNull);
+    expect(process!.records.length, 2);
+    final linearAlgebra = process.records.firstWhere(
+      (record) => record.courseName == '线性代数',
+    );
+    expect(linearAlgebra.items.length, 1);
+    expect(linearAlgebra.items.single.label, '平时成绩Ⅰ');
+    expect(linearAlgebra.items.single.value, '100.0/15%');
+    // 仅解析过程化成绩，不附带课表或考试。
+    expect(result.snapshot?.courseTable, isNull);
+    expect(result.snapshot?.exams, isNull);
+  });
+
   test('开课检索会提交只读查询表单并解析列表', () async {
     await AcademicCredentialsService.instance.saveCredentials(
       oaAccount: '20260001',

--- a/test/academic_eams_service_test_support.dart
+++ b/test/academic_eams_service_test_support.dart
@@ -175,6 +175,9 @@ class FakeAcademicEamsGateway implements AcademicEamsGateway {
     if (formUri.path.contains('freeClassroom!search.action')) {
       return academicEamsFreeClassroomResultSnapshot;
     }
+    if (formUri.path.contains('person!processGrade.action')) {
+      return academicEamsGradeProcessSnapshot;
+    }
     return AcademicEamsHttpSnapshot(
       finalUri: formUri,
       statusCode: 404,
@@ -371,6 +374,35 @@ academicEamsHistoryGradeSnapshot = AcademicEamsHttpSnapshot(
     <table>
       <tr><th>课程名称</th><th>成绩</th><th>学分</th><th>学年学期</th></tr>
       <tr><td>程序设计基础</td><td>85</td><td>4</td><td>2025-2026-1</td></tr>
+    </table>
+  </body>
+</html>
+''',
+);
+
+final AcademicEamsHttpSnapshot
+academicEamsGradeProcessSnapshot = AcademicEamsHttpSnapshot(
+  finalUri: Uri.parse(
+    'https://jx.sspu.edu.cn/eams/teach/grade/course/person!processGrade.action',
+  ),
+  statusCode: 200,
+  body: '''
+<html>
+  <body>
+    <table>
+      <tr>
+        <th>学年学期</th><th>课程代码</th><th>课程序号</th><th>课程名称</th>
+        <th>课程类别</th><th>学分</th>
+        <th>平时成绩Ⅰ/占比（描述）</th><th>平时成绩Ⅱ/占比（描述）</th>
+      </tr>
+      <tr>
+        <td>2025-2026-春季</td><td>b1020108</td><td>3006</td><td>线性代数</td>
+        <td>公共基础课</td><td>3</td><td>100.0/15%</td><td>无</td>
+      </tr>
+      <tr>
+        <td>2025-2026-春季</td><td>b2012231</td><td>2758</td><td>数据结构与算法</td>
+        <td>专业基础课</td><td>4</td><td>95.0/10%</td><td>无</td>
+      </tr>
     </table>
   </body>
 </html>

--- a/test/academic_grade_snapshot_test.dart
+++ b/test/academic_grade_snapshot_test.dart
@@ -1,0 +1,166 @@
+/*
+ * 成绩快照模型测试 — 校验跨当前/历史合并去重、学期分组与绩点加权
+ * @Project : SSPU-AllinOne
+ * @File : academic_grade_snapshot_test.dart
+ * @Author : Qintsg
+ * @Date : 2026-06-14
+ */
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sspu_allinone/models/academic_eams/grades.dart';
+
+AcademicGradeRecord _record({
+  required String courseName,
+  String? courseCode,
+  String? termName,
+  String scoreText = '',
+  double? credit,
+  double? gradePoint,
+  String? processScoreText,
+}) {
+  return AcademicGradeRecord(
+    courseName: courseName,
+    courseCode: courseCode,
+    termName: termName,
+    scoreText: scoreText,
+    credit: credit,
+    gradePoint: gradePoint,
+    processScoreText: processScoreText,
+    rawCells: const [],
+  );
+}
+
+AcademicGradeSnapshot _snapshot({
+  required List<AcademicGradeRecord> current,
+  required List<AcademicGradeRecord> history,
+}) {
+  return AcademicGradeSnapshot(
+    currentTermRecords: current,
+    historyRecords: history,
+    fetchedAt: DateTime(2026, 6, 14),
+    sourceUri: Uri.parse('https://jx.sspu.edu.cn/eams/grade'),
+  );
+}
+
+void main() {
+  test('availableTerms 去重并按学年学期倒序', () {
+    final snapshot = _snapshot(
+      current: [
+        _record(courseName: '高等数学', termName: '2025-2026-2', credit: 3),
+      ],
+      history: [
+        _record(courseName: '程序设计基础', termName: '2025-2026-1', credit: 4),
+        _record(courseName: '大学英语', termName: '2025-2026-1', credit: 2),
+      ],
+    );
+
+    expect(snapshot.availableTerms, ['2025-2026-2', '2025-2026-1']);
+    expect(snapshot.latestTermName, '2025-2026-2');
+  });
+
+  test('allRecords 按课程代码与学期跨当前/历史去重', () {
+    final snapshot = _snapshot(
+      current: [
+        _record(
+          courseName: '高等数学',
+          courseCode: 'MATH101',
+          termName: '2025-2026-2',
+          credit: 3,
+        ),
+      ],
+      history: [
+        _record(
+          courseName: '高等数学',
+          courseCode: 'MATH101',
+          termName: '2025-2026-2',
+          credit: 3,
+        ),
+        _record(
+          courseName: '程序设计基础',
+          courseCode: 'CS100',
+          termName: '2025-2026-1',
+          credit: 4,
+        ),
+      ],
+    );
+
+    expect(snapshot.allRecords.length, 2);
+    expect(snapshot.creditsForTerm(null), 7);
+  });
+
+  test('recordsForTerm 过滤指定学期，空参返回全部', () {
+    final snapshot = _snapshot(
+      current: [
+        _record(courseName: '高等数学', termName: '2025-2026-2', credit: 3),
+      ],
+      history: [
+        _record(courseName: '程序设计基础', termName: '2025-2026-1', credit: 4),
+      ],
+    );
+
+    expect(snapshot.recordsForTerm('2025-2026-1').single.courseName, '程序设计基础');
+    expect(snapshot.recordsForTerm(null).length, 2);
+    expect(snapshot.recordsForTerm('').length, 2);
+    expect(snapshot.recordsForTerm('2099-2100-1'), isEmpty);
+  });
+
+  test('weightedGpaForTerm 按学分加权且忽略缺绩点记录', () {
+    final snapshot = _snapshot(
+      current: [
+        _record(
+          courseName: '高等数学',
+          termName: '2025-2026-2',
+          credit: 3,
+          gradePoint: 4.0,
+        ),
+        _record(
+          courseName: '大学英语',
+          termName: '2025-2026-2',
+          credit: 1,
+          gradePoint: 2.0,
+        ),
+        _record(
+          courseName: '体育',
+          termName: '2025-2026-2',
+          credit: 2,
+          gradePoint: null,
+        ),
+      ],
+      history: const [],
+    );
+
+    // (3*4.0 + 1*2.0) / (3 + 1) = 3.5，缺绩点的体育不计入加权。
+    expect(snapshot.weightedGpaForTerm('2025-2026-2'), closeTo(3.5, 1e-9));
+    // 学分汇总仍计入缺绩点课程的学分。
+    expect(snapshot.creditsForTerm('2025-2026-2'), 6);
+  });
+
+  test('recordsByTermDesc 按学期倒序且学期内保持原顺序', () {
+    final snapshot = _snapshot(
+      current: [_record(courseName: '高等数学', termName: '2025-2026-2')],
+      history: [
+        _record(courseName: '程序设计基础', termName: '2025-2026-1'),
+        _record(courseName: '大学英语', termName: '2025-2026-1'),
+        _record(courseName: '线性代数', termName: '2026-2027-1'),
+      ],
+    );
+
+    expect(snapshot.recordsByTermDesc.map((r) => r.courseName).toList(), [
+      '线性代数',
+      '高等数学',
+      '程序设计基础',
+      '大学英语',
+    ]);
+  });
+
+  test('无绩点数据时 weightedGpaForTerm 返回 null', () {
+    final snapshot = _snapshot(
+      current: [
+        _record(courseName: '高等数学', termName: '2025-2026-2', credit: 3),
+      ],
+      history: const [],
+    );
+
+    expect(snapshot.weightedGpaForTerm(null), isNull);
+  });
+}

--- a/test/academic_page_test.dart
+++ b/test/academic_page_test.dart
@@ -577,6 +577,70 @@ void main() {
     await disposeAcademicPage(tester);
   });
 
+  testWidgets('本专科教务成绩卡片只展示GPA与门数并可进入详情和过程化成绩页', (tester) async {
+    final academicService = _FakeAcademicEamsClient(
+      result: _academicEamsResult,
+    );
+    await pumpAcademicPage(
+      tester,
+      academicEamsService: academicService,
+      sportsAttendanceService: _FakeSportsAttendanceClient(
+        result: _successResult,
+      ),
+      studentReportService: _FakeStudentReportClient(result: _creditResult),
+    );
+
+    final refresh = find.byKey(const Key('academic-eams-refresh'));
+    await tester.ensureVisible(refresh);
+    await tester.tap(refresh);
+    final gradeCard = find.byKey(const Key('academic-eams-grade-card'));
+    await pumpUntilFound(
+      tester,
+      find.descendant(of: gradeCard, matching: find.text('成绩门数')),
+    );
+
+    final primaryCard = find.byType(AcademicEamsSummaryCard);
+    expect(
+      find.descendant(of: primaryCard, matching: gradeCard),
+      findsOneWidget,
+    );
+    // 卡片仅展示 GPA 与成绩门数指标块，不再列课程预览。
+    expect(
+      find.descendant(of: gradeCard, matching: find.textContaining('GPA')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: gradeCard, matching: find.text('高等数学')),
+      findsNothing,
+    );
+    expect(academicService.gradeFetchCount, 1);
+
+    final detailButton = find.byKey(const Key('academic-eams-grade-detail'));
+    await tester.ensureVisible(detailButton);
+    await tester.tap(detailButton);
+    await tester.pumpAndSettle();
+
+    expect(find.text('成绩详情'), findsOneWidget);
+    expect(
+      find.byKey(const Key('academic-eams-grade-term-select')),
+      findsOneWidget,
+    );
+    // 默认查看全部学期。
+    expect(find.text('全部学期'), findsWidgets);
+    expect(find.text('高等数学'), findsWidgets);
+
+    // 命令栏进入过程化成绩三级页（按学期独立请求平时成绩明细）。
+    final processEntry = find.byKey(
+      const Key('academic-eams-grade-process-entry'),
+    );
+    expect(processEntry, findsOneWidget);
+    await tester.tap(processEntry);
+    await pumpUntilFound(tester, find.text('平时成绩Ⅰ'));
+    expect(find.text('高等数学D1'), findsWidgets);
+    expect(academicService.gradeProcessFetchCount, 1);
+    await disposeAcademicPage(tester);
+  });
+
   testWidgets('本专科教务考试卡片预览并在详情页切换学期', (tester) async {
     final academicService = _FakeAcademicEamsClient(
       result: _academicEamsResult,
@@ -707,7 +771,7 @@ void main() {
     );
     // 下拉解析出的真实 semester.id 会随查询传入，便于学期接口失败时复用。
     expect(academicService.examSemesterValues.last?.id, '1041');
-    expect(find.textContaining('有考试信息的课程 2 门'), findsOneWidget);
+    expect(find.textContaining('考试汇总'), findsOneWidget);
 
     await tester.tap(find.byKey(const Key('academic-eams-exam-season-select')));
     await tester.pumpAndSettle();

--- a/test/academic_page_test_support.dart
+++ b/test/academic_page_test_support.dart
@@ -76,6 +76,9 @@ class _FakeAcademicEamsClient implements AcademicEamsClient {
   final List<AcademicTermChoice?> examTermValues = [];
   final List<AcademicEamsSemesterOption?> examSemesterValues = [];
   final List<String?> examTypeValues = [];
+  int gradeFetchCount = 0;
+  final List<bool> gradeRequireCampusNetworkValues = [];
+  int gradeProcessFetchCount = 0;
 
   @override
   Future<AcademicEamsQueryResult?> readLatestCachedCourseTable() async {
@@ -134,6 +137,35 @@ class _FakeAcademicEamsClient implements AcademicEamsClient {
     examSemesterValues.add(semester);
     examTypeValues.add(examTypeId);
     return examResultResolver?.call(term, semester) ?? result;
+  }
+
+  @override
+  Future<AcademicEamsQueryResult> fetchGrades({
+    bool requireCampusNetwork = true,
+  }) async {
+    gradeFetchCount++;
+    gradeRequireCampusNetworkValues.add(requireCampusNetwork);
+    return result;
+  }
+
+  @override
+  Future<AcademicEamsQueryResult?> readLatestCachedGrades() async {
+    return null;
+  }
+
+  @override
+  Future<AcademicEamsQueryResult> fetchGradeProcess({
+    AcademicTermChoice? term,
+    AcademicEamsSemesterOption? semester,
+    bool requireCampusNetwork = true,
+  }) async {
+    gradeProcessFetchCount++;
+    return _gradeProcessResult;
+  }
+
+  @override
+  Future<AcademicEamsQueryResult?> readLatestCachedGradeProcess() async {
+    return null;
   }
 }
 
@@ -425,6 +457,51 @@ final AcademicEamsQueryResult _academicEamsResult = AcademicEamsQueryResult(
       ],
       fetchedAt: DateTime(2026, 5, 2),
       sourceUri: Uri.parse('https://jx.sspu.edu.cn/eams/stdExamTable.action'),
+    ),
+  ),
+);
+
+final AcademicEamsQueryResult _gradeProcessResult = AcademicEamsQueryResult(
+  status: AcademicEamsQueryStatus.success,
+  message: '过程化成绩读取成功',
+  detail: '已读取所选学期的平时成绩明细。',
+  checkedAt: DateTime(2026, 6, 15),
+  entranceUri: Uri.parse(
+    'https://oa.sspu.edu.cn/interface/Entrance.jsp?id=bzkjw',
+  ),
+  finalUri: Uri.parse(
+    'https://jx.sspu.edu.cn/eams/teach/grade/course/person!processGrade.action',
+  ),
+  snapshot: AcademicEamsSnapshot(
+    fetchedAt: DateTime(2026, 6, 15),
+    sourceUri: Uri.parse(
+      'https://jx.sspu.edu.cn/eams/teach/grade/course/person!processGrade.action',
+    ),
+    warnings: const [],
+    hasCourseOfferingEntry: false,
+    hasFreeClassroomEntry: false,
+    gradeProcess: AcademicGradeProcessSnapshot(
+      records: const [
+        AcademicGradeProcessRecord(
+          courseName: '高等数学D1',
+          termName: '2025-2026-1',
+          category: '公共基础课',
+          credit: 5,
+          items: [AcademicGradeProcessItem(label: '平时成绩Ⅰ', value: '95.0/10%')],
+          rawCells: [],
+        ),
+      ],
+      selectedSemester: AcademicEamsSemesterOption(
+        id: '1042',
+        label: '2025-2026-2',
+      ),
+      semesterOptions: [
+        AcademicEamsSemesterOption(id: '1042', label: '2025-2026-2'),
+      ],
+      fetchedAt: DateTime(2026, 6, 15),
+      sourceUri: Uri.parse(
+        'https://jx.sspu.edu.cn/eams/teach/grade/course/person!processGrade.action',
+      ),
     ),
   ),
 );

--- a/test/course_schedule_page_test.dart
+++ b/test/course_schedule_page_test.dart
@@ -264,6 +264,32 @@ class _FakeAcademicEamsClient implements AcademicEamsClient {
   }) async {
     return result;
   }
+
+  @override
+  Future<AcademicEamsQueryResult> fetchGrades({
+    bool requireCampusNetwork = true,
+  }) async {
+    return result;
+  }
+
+  @override
+  Future<AcademicEamsQueryResult?> readLatestCachedGrades() async {
+    return null;
+  }
+
+  @override
+  Future<AcademicEamsQueryResult> fetchGradeProcess({
+    AcademicTermChoice? term,
+    AcademicEamsSemesterOption? semester,
+    bool requireCampusNetwork = true,
+  }) async {
+    return result;
+  }
+
+  @override
+  Future<AcademicEamsQueryResult?> readLatestCachedGradeProcess() async {
+    return null;
+  }
 }
 
 class _FakeAcademicCalendarClient implements AcademicCalendarClient {

--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -800,6 +800,32 @@ class _FakeAcademicEamsClient implements AcademicEamsClient {
   }) async {
     throw UnimplementedError();
   }
+
+  @override
+  Future<AcademicEamsQueryResult> fetchGrades({
+    bool requireCampusNetwork = true,
+  }) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AcademicEamsQueryResult?> readLatestCachedGrades() async {
+    return null;
+  }
+
+  @override
+  Future<AcademicEamsQueryResult> fetchGradeProcess({
+    AcademicTermChoice? term,
+    AcademicEamsSemesterOption? semester,
+    bool requireCampusNetwork = true,
+  }) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AcademicEamsQueryResult?> readLatestCachedGradeProcess() async {
+    return null;
+  }
 }
 
 const AcademicEamsProfile _studentProfile = AcademicEamsProfile(


### PR DESCRIPTION
## 变更说明

围绕成绩查询链路补齐成绩与过程化成绩的只读查询、数据模型、卡片/详情页展示和测试覆盖，整体优化成绩页的扫描效率与信息密度。

## 关联 Issue

Closes #177

## Breaking Change

- [x] 无 Breaking Change

## 验证记录

### 代码变更（lib/、	est/、平台代码）

- [x] lutter analyze --no-fatal-infos
- [x] lutter test
- [ ] 平台构建验证：
- [x] 手动验证：已完成相关测试覆盖与本地检查

### CI / 文档 / 仓库治理

- [x] 治理校验：python scripts/ci/validate_github_governance.py
- [x] 文档已同步更新

### 未执行验证

- 原因：平台桌面/移动构建未在本次变更中执行

## 检查清单

- [x] 没有提交无关文件、构建产物或本地自动化配置
- [x] 没有引入账号、密码、Cookie、Token、私钥、keystore 或真实用户数据
- [x] 已更新相关文档 / Changelog，或说明无需更新
- [x] PR 标题符合 	ype(scope): 中文摘要 格式