### PR TITLE
release: v0.4.0-beta 清源设计系统重构预发布（重新构建）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
           } > android/key.properties
 
       - name: 构建 Android APK（按 ABI 拆分）
-        run: flutter build apk --release --split-per-abi --target-platform android-arm,android-arm64,android-x64,android-x86
+        run: flutter build apk --release --split-per-abi --target-platform android-arm,android-arm64,android-x64
 
       - name: 整理 Android 产物
         shell: bash
@@ -166,8 +166,6 @@ jobs:
             "dist/SSPU-AllinOne-v${{ needs.prepare.outputs.version }}-android-arm64-v8a.apk"
           cp build/app/outputs/flutter-apk/app-x86_64-release.apk \
             "dist/SSPU-AllinOne-v${{ needs.prepare.outputs.version }}-android-x86_64.apk"
-          cp build/app/outputs/flutter-apk/app-x86-release.apk \
-            "dist/SSPU-AllinOne-v${{ needs.prepare.outputs.version }}-android-x86.apk"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -176,7 +174,6 @@ jobs:
             dist/SSPU-AllinOne-v${{ needs.prepare.outputs.version }}-android-armeabi-v7a.apk
             dist/SSPU-AllinOne-v${{ needs.prepare.outputs.version }}-android-arm64-v8a.apk
             dist/SSPU-AllinOne-v${{ needs.prepare.outputs.version }}-android-x86_64.apk
-            dist/SSPU-AllinOne-v${{ needs.prepare.outputs.version }}-android-x86.apk
 
   build-windows:
     needs: prepare
@@ -293,12 +290,6 @@ jobs:
   build-macos:
     needs: prepare
     runs-on: macos-latest
-    env:
-      MACOS_SIGNING_CERTIFICATE_BASE64: ${{ secrets.MACOS_SIGNING_CERTIFICATE_BASE64 }}
-      MACOS_SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_SIGNING_CERTIFICATE_PASSWORD }}
-      MACOS_NOTARY_APPLE_ID: ${{ secrets.MACOS_NOTARY_APPLE_ID }}
-      MACOS_NOTARY_TEAM_ID: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
-      MACOS_NOTARY_PASSWORD: ${{ secrets.MACOS_NOTARY_PASSWORD }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -306,54 +297,10 @@ jobs:
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
 
-      - name: 导入 macOS 签名证书
-        id: signing
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          missing_secrets=()
-          for secret_name in \
-            MACOS_SIGNING_CERTIFICATE_BASE64 \
-            MACOS_SIGNING_CERTIFICATE_PASSWORD \
-            MACOS_NOTARY_APPLE_ID \
-            MACOS_NOTARY_TEAM_ID \
-            MACOS_NOTARY_PASSWORD; do
-            if [[ -z "${!secret_name:-}" ]]; then
-              missing_secrets+=("$secret_name")
-            fi
-          done
-
-          if [[ "${#missing_secrets[@]}" -gt 0 ]]; then
-            printf 'macOS 签名与公证 Secrets 缺失：%s。\n' "${missing_secrets[*]}" >&2
-            echo "当前公开 Release 必须产出 Developer ID 签名并公证的 macOS DMG，不能降级为 unsigned 产物。" >&2
-            exit 1
-          fi
-
-          TEMP_KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
-          TEMP_KEYCHAIN="macos-signing.keychain-db"
-          security create-keychain -p "$TEMP_KEYCHAIN_PASSWORD" "$TEMP_KEYCHAIN"
-          security set-keychain-settings -lut 21600 "$TEMP_KEYCHAIN"
-          security unlock-keychain -p "$TEMP_KEYCHAIN_PASSWORD" "$TEMP_KEYCHAIN"
-
-          printf '%s' "$MACOS_SIGNING_CERTIFICATE_BASE64" | base64 --decode > signing-cert.p12
-          security import signing-cert.p12 \
-            -k "$TEMP_KEYCHAIN" \
-            -P "$MACOS_SIGNING_CERTIFICATE_PASSWORD" \
-            -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple: \
-            -s -k "$TEMP_KEYCHAIN_PASSWORD" "$TEMP_KEYCHAIN"
-
-          security list-keychains -d user -s "$TEMP_KEYCHAIN" $(security list-keychains -d user | sed s/\"//g)
-
-          rm signing-cert.p12
-          echo "signed=true" >> "$GITHUB_OUTPUT"
-
       - name: 构建 macOS universal
         run: flutter build macos --release
 
-      - name: 签名 macOS App Bundle
-        if: steps.signing.outputs.signed == 'true'
+      - name: 自签名 macOS App Bundle
         shell: bash
         run: |
           set -euo pipefail
@@ -364,20 +311,10 @@ jobs:
             exit 1
           }
 
-          DEVELOPER_ID="$(security find-identity -v -p basic | grep 'Developer ID Application' | head -1 | awk '{print $2}')"
-          [[ -n "$DEVELOPER_ID" ]] || {
-            echo "未找到 Developer ID Application 证书。" >&2
-            exit 1
-          }
-          echo "使用签名身份: $DEVELOPER_ID"
-
-          codesign --force --deep --sign "$DEVELOPER_ID" \
-            --options runtime \
+          echo "使用 ad-hoc 自签名（未配置官方 Developer ID 签名与公证）"
+          codesign --force --deep --sign - \
             --entitlements macos/Runner/Release.entitlements \
-            --timestamp \
             "$macos_app_bundle"
-
-          codesign --verify --deep --strict --verbose=2 "$macos_app_bundle"
 
       - name: 生成 macOS DMG
         id: dmg
@@ -426,32 +363,6 @@ jobs:
           rm -rf "$staging"
           echo "dmg_suffix=arm64" >> "$GITHUB_OUTPUT"
 
-      - name: 公证 DMG
-        if: steps.signing.outputs.signed == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          dmg_path="dist/SSPU-AllinOne-v${{ needs.prepare.outputs.version }}-macos-arm64.dmg"
-
-          xcrun notarytool submit "$dmg_path" \
-            --apple-id "$MACOS_NOTARY_APPLE_ID" \
-            --team-id "$MACOS_NOTARY_TEAM_ID" \
-            --password "$MACOS_NOTARY_PASSWORD" \
-            --wait \
-            --output-format plist > notarization.plist
-
-          notary_status="$(/usr/libexec/PlistBuddy -c "Print :status" notarization.plist)"
-          if [[ "$notary_status" != "Accepted" ]]; then
-            echo "公证失败: $notary_status" >&2
-            cat notarization.plist >&2
-            exit 1
-          fi
-
-          echo "公证通过，装订票据..."
-          xcrun stapler staple "$dmg_path"
-          echo "装订完成"
-
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: macos-dmg
@@ -460,12 +371,6 @@ jobs:
   build-macos-x86_64:
     needs: prepare
     runs-on: macos-13
-    env:
-      MACOS_SIGNING_CERTIFICATE_BASE64: ${{ secrets.MACOS_SIGNING_CERTIFICATE_BASE64 }}
-      MACOS_SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_SIGNING_CERTIFICATE_PASSWORD }}
-      MACOS_NOTARY_APPLE_ID: ${{ secrets.MACOS_NOTARY_APPLE_ID }}
-      MACOS_NOTARY_TEAM_ID: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
-      MACOS_NOTARY_PASSWORD: ${{ secrets.MACOS_NOTARY_PASSWORD }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -473,54 +378,10 @@ jobs:
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
 
-      - name: 导入 macOS 签名证书
-        id: signing
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          missing_secrets=()
-          for secret_name in \
-            MACOS_SIGNING_CERTIFICATE_BASE64 \
-            MACOS_SIGNING_CERTIFICATE_PASSWORD \
-            MACOS_NOTARY_APPLE_ID \
-            MACOS_NOTARY_TEAM_ID \
-            MACOS_NOTARY_PASSWORD; do
-            if [[ -z "${!secret_name:-}" ]]; then
-              missing_secrets+=("$secret_name")
-            fi
-          done
-
-          if [[ "${#missing_secrets[@]}" -gt 0 ]]; then
-            printf 'macOS x86_64 签名与公证 Secrets 缺失：%s，跳过签名。\n' "${missing_secrets[*]}" >&2
-            echo "signed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          TEMP_KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
-          TEMP_KEYCHAIN="macos-signing.keychain-db"
-          security create-keychain -p "$TEMP_KEYCHAIN_PASSWORD" "$TEMP_KEYCHAIN"
-          security set-keychain-settings -lut 21600 "$TEMP_KEYCHAIN"
-          security unlock-keychain -p "$TEMP_KEYCHAIN_PASSWORD" "$TEMP_KEYCHAIN"
-
-          printf '%s' "$MACOS_SIGNING_CERTIFICATE_BASE64" | base64 --decode > signing-cert.p12
-          security import signing-cert.p12 \
-            -k "$TEMP_KEYCHAIN" \
-            -P "$MACOS_SIGNING_CERTIFICATE_PASSWORD" \
-            -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple: \
-            -s -k "$TEMP_KEYCHAIN_PASSWORD" "$TEMP_KEYCHAIN"
-
-          security list-keychains -d user -s "$TEMP_KEYCHAIN" $(security list-keychains -d user | sed s/\"//g)
-
-          rm signing-cert.p12
-          echo "signed=true" >> "$GITHUB_OUTPUT"
-
       - name: 构建 macOS x86_64
         run: flutter build macos --release
 
-      - name: 签名 macOS App Bundle
-        if: steps.signing.outputs.signed == 'true'
+      - name: 自签名 macOS App Bundle
         shell: bash
         run: |
           set -euo pipefail
@@ -531,20 +392,10 @@ jobs:
             exit 1
           }
 
-          DEVELOPER_ID="$(security find-identity -v -p basic | grep 'Developer ID Application' | head -1 | awk '{print $2}')"
-          [[ -n "$DEVELOPER_ID" ]] || {
-            echo "未找到 Developer ID Application 证书。" >&2
-            exit 1
-          }
-          echo "使用签名身份: $DEVELOPER_ID"
-
-          codesign --force --deep --sign "$DEVELOPER_ID" \
-            --options runtime \
+          echo "使用 ad-hoc 自签名（未配置官方 Developer ID 签名与公证）"
+          codesign --force --deep --sign - \
             --entitlements macos/Runner/Release.entitlements \
-            --timestamp \
             "$macos_app_bundle"
-
-          codesign --verify --deep --strict --verbose=2 "$macos_app_bundle"
 
       - name: 生成 macOS x86_64 DMG
         id: dmg
@@ -591,32 +442,6 @@ jobs:
             "dist/SSPU-AllinOne-v${{ needs.prepare.outputs.version }}-macos-x86_64.dmg"
 
           rm -rf "$staging"
-
-      - name: 公证 DMG
-        if: steps.signing.outputs.signed == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          dmg_path="dist/SSPU-AllinOne-v${{ needs.prepare.outputs.version }}-macos-x86_64.dmg"
-
-          xcrun notarytool submit "$dmg_path" \
-            --apple-id "$MACOS_NOTARY_APPLE_ID" \
-            --team-id "$MACOS_NOTARY_TEAM_ID" \
-            --password "$MACOS_NOTARY_PASSWORD" \
-            --wait \
-            --output-format plist > notarization.plist
-
-          notary_status="$(/usr/libexec/PlistBuddy -c "Print :status" notarization.plist)"
-          if [[ "$notary_status" != "Accepted" ]]; then
-            echo "公证失败: $notary_status" >&2
-            cat notarization.plist >&2
-            exit 1
-          fi
-
-          echo "公证通过，装订票据..."
-          xcrun stapler staple "$dmg_path"
-          echo "装订完成"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/scripts/release/generate_release_metadata.py
+++ b/scripts/release/generate_release_metadata.py
@@ -29,7 +29,6 @@ FILENAME_PATTERN = re.compile(
 EXPECTED_PRODUCT_ASSETS = {
     ("android", "armeabi-v7a", "apk"),
     ("android", "arm64-v8a", "apk"),
-    ("android", "x86", "apk"),
     ("android", "x86_64", "apk"),
     ("windows", "x64", "setup"),
     ("windows", "x64", "portable"),

--- a/test/macos_release_entitlements_test.dart
+++ b/test/macos_release_entitlements_test.dart
@@ -21,18 +21,22 @@ void main() {
     expect(unsignedEntitlements, isNot(contains('keychain-access-groups')));
   });
 
-  test('macOS 正式 Release 要求签名材料齐全并使用公证工具链', () {
+  test('macOS Release 使用 ad-hoc 自签名替代官方签名与公证', () {
     final releaseWorkflow = File(
       '.github/workflows/release.yml',
     ).readAsStringSync();
 
     expect(
       releaseWorkflow,
-      contains('当前公开 Release 必须产出 Developer ID 签名并公证的 macOS DMG'),
+      contains('使用 ad-hoc 自签名（未配置官方 Developer ID 签名与公证）'),
     );
-    expect(releaseWorkflow, isNot(contains('-T /usr/bin/notarytool')));
-    expect(releaseWorkflow, contains('xcrun notarytool submit'));
-    expect(releaseWorkflow, contains('xcrun stapler staple'));
+    expect(releaseWorkflow, contains('codesign --force --deep --sign -'));
+    expect(releaseWorkflow, isNot(contains('xcrun notarytool submit')));
+    expect(releaseWorkflow, isNot(contains('xcrun stapler staple')));
+    expect(
+      releaseWorkflow,
+      isNot(contains('Developer ID Application')),
+    );
     expect(
       releaseWorkflow,
       contains(

--- a/test/macos_release_entitlements_test.dart
+++ b/test/macos_release_entitlements_test.dart
@@ -33,10 +33,7 @@ void main() {
     expect(releaseWorkflow, contains('codesign --force --deep --sign -'));
     expect(releaseWorkflow, isNot(contains('xcrun notarytool submit')));
     expect(releaseWorkflow, isNot(contains('xcrun stapler staple')));
-    expect(
-      releaseWorkflow,
-      isNot(contains('Developer ID Application')),
-    );
+    expect(releaseWorkflow, isNot(contains('Developer ID Application')));
     expect(
       releaseWorkflow,
       contains(

--- a/test/release_metadata_script_test.dart
+++ b/test/release_metadata_script_test.dart
@@ -74,7 +74,6 @@ void main() {
 const _expectedAssetNames = [
   'SSPU-AllinOne-v1.2.0-android-armeabi-v7a.apk',
   'SSPU-AllinOne-v1.2.0-android-arm64-v8a.apk',
-  'SSPU-AllinOne-v1.2.0-android-x86.apk',
   'SSPU-AllinOne-v1.2.0-android-x86_64.apk',
   'SSPU-AllinOne-v1.2.0-windows-x64-setup.exe',
   'SSPU-AllinOne-v1.2.0-windows-x64-portable.zip',


### PR DESCRIPTION
## 发布信息

- 公开版本（不含 `+build`）：0.4.0-beta
- `pubspec.yaml` 完整版本（含 `+build`）：0.4.0-beta+6
- Git Tag：v0.4.0-beta
- 发布通道：beta
- 发布类型：Pre-release（重新构建，版本号与 build 号不变）

## 关联事项

Refs #299 #298 #175 #168

## 分支确认

- [x] 已确认分支流向和 `release` label 使用正确
- [x] 已确认版本号只修改 `pubspec.yaml` 与 `docs/CHANGELOG.md`
- [x] 已确认安装包文件名和 Release 标题不含 `+build`

## 验证记录

- [x] `flutter analyze` + `flutter test`
- [ ] 五平台构建验证（CI 环境）

## 检查清单

- [x] 未提交签名密钥、token 等敏感信息
- [x] `release` label 仅在应触发 Release 的 PR 上添加

---

## 亮点

清源设计系统完整重构，52 个界面全部迁移至纯清源 UI 门面，移除 Fluent UI 依赖，建立完整设计稿与评审文档体系。

## 新增

- 引入清源设计系统统一门面（`YhIcons`/`YhPageScaffold`/`YhAppBar` 等）与 45 个组件，覆盖按钮、输入、反馈、导航、数据展示与领域组件。
- 新增深色模式与主题切换设置（亮/暗/跟随系统，偏好通过 `StorageService.themeMode` 持久化并即时生效）。
- 建立设计稿与自评审文档体系（`docs/design/patterns/` + `docs/design/reviews/`），覆盖全部页面。
- 新增视觉捕获测试矩阵（52 surface × 4 视口 × 亮暗主题）。

## 修复

- 修复课表周网格桌面端视口填充的 RenderFlex 无界高度崩溃。
- 修复首次使用协议弹窗移动端协议卡片空白过大。
- 重写 OSV Scanner 工作流用 CLI 替代破损的 GitHub Action。
- 修正 CI 治理与供应链固定校验。
- 修复 Android 构建移除不支持的 android-x86 目标平台。
- macOS 改为 ad-hoc 自签名替代官方 Developer ID 签名与公证。

## 优化

- 首页仪表盘密度优化：360×800 主页不滚动、消除过大卡片与间距。
- 校历加载态布局优化。
- 文件拆分解耦：`academic_calendar_service.dart` 686→382 行、`student_report_page_parser.dart` 815→620 行等。

## 破坏性变更

- 移除 `fluent_ui` 包依赖与旧 Fluent 设计门面，业务页面全部改用 `Yh*` 门面。
- 移除 `uses-material-design` 声明，业务页面不再直接引用 Material `Icons` 类。

## 已知问题

- 本版本有已知大量 bug，且大概率有恶性 bug，若需稳定请等待 rc 版本，欢迎提 bug issue。
- macOS 签名公证后的钥匙串凭据保存能力仍需继续验证。
- Linux/Android/macOS/iOS 真实构建仅在 CI 环境验证，未在开发机本地验证。
- 部分页面在移动端输入法弹出时仍可能存在局部布局问题。

## 关联 Issue

Refs #168
Refs #175
Refs #298
