### PR TITLE
fix(release): iOS 产物改为 zip 打包避免 publish 崩溃

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -500,13 +500,13 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist
-          cp -R build/ios/iphoneos/Runner.app \
-            "dist/SSPU-AllinOne-v${{ needs.prepare.outputs.version }}-ios-arm64.app"
+          cd build/ios/iphoneos
+          zip -r "$OLDPWD/dist/SSPU-AllinOne-v${{ needs.prepare.outputs.version }}-ios-arm64.app.zip" Runner.app
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ios-app
-          path: dist/SSPU-AllinOne-v${{ needs.prepare.outputs.version }}-ios-arm64.app
+          path: dist/SSPU-AllinOne-v${{ needs.prepare.outputs.version }}-ios-arm64.app.zip
 
   publish:
     if: needs.prepare.result == 'success'

--- a/scripts/release/generate_release_metadata.py
+++ b/scripts/release/generate_release_metadata.py
@@ -23,7 +23,7 @@ FILENAME_PATTERN = re.compile(
     r"(?P<platform>android|ios|windows|macos|linux)-"
     r"(?P<arch>armeabi-v7a|arm64-v8a|x86|x86_64|x64|arm64)"
     r"(?:-(?P<kind>setup|portable|unsigned))?"
-    r"(?P<ext>\.AppImage|\.tar\.gz|\.zip|\.exe|\.dmg|\.deb|\.rpm|\.apk|\.app)$"
+    r"(?P<ext>\.app\.zip|\.AppImage|\.tar\.gz|\.zip|\.exe|\.dmg|\.deb|\.rpm|\.apk|\.app)$"
 )
 
 EXPECTED_PRODUCT_ASSETS = {
@@ -95,7 +95,7 @@ def infer_kind(platform_name: str, extension_name: str) -> str:
         return "apk"
     if platform_name == "macos" and extension_name == ".dmg":
         return "dmg"
-    if platform_name == "ios" and extension_name == ".app":
+    if platform_name == "ios" and extension_name in (".app", ".app.zip"):
         return "app"
     if platform_name == "linux" and extension_name == ".AppImage":
         return "appimage"

--- a/test/release_metadata_script_test.dart
+++ b/test/release_metadata_script_test.dart
@@ -88,5 +88,5 @@ const _expectedAssetNames = [
   'SSPU-AllinOne-v1.2.0-linux-arm64.deb',
   'SSPU-AllinOne-v1.2.0-linux-arm64.rpm',
   'SSPU-AllinOne-v1.2.0-linux-arm64.tar.gz',
-  'SSPU-AllinOne-v1.2.0-ios-arm64.app',
+  'SSPU-AllinOne-v1.2.0-ios-arm64.app.zip',
 ];


### PR DESCRIPTION
iOS .app 目录在 download-artifact merge-multiple 后散落，导致 publish 阶段 metadata 脚本遇到非资产文件崩溃。改为 zip 打包后上传。