### PR TITLE
fix(macos): 修复 ad-hoc 发布包启动失败

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,21 +300,22 @@ jobs:
       - name: 构建 macOS universal
         run: flutter build macos --release
 
-      - name: 自签名 macOS App Bundle
+      - name: 使用无 entitlement 的 ad-hoc 签名 macOS App Bundle
         shell: bash
         run: |
           set -euo pipefail
 
           macos_app_bundle="$(find build/macos/Build/Products/Release -maxdepth 1 -name '*.app' -print -quit)"
-          [[ -n "$macos_app_bundle" ]] || {
-            echo "未找到 macOS .app 产物。" >&2
+          [[ -n "$macos_app_bundle" ]] || { echo "未找到 macOS .app 产物。" >&2; exit 1; }
+          # ad-hoc 签名不得携带 app sandbox、钥匙串访问组等受限 entitlement，
+          # 否则 AMFI 会在启动时拒绝进程。
+          codesign --force --deep --sign - "$macos_app_bundle"
+          codesign --verify --deep --strict --verbose=2 "$macos_app_bundle"
+          if codesign -d --entitlements :- "$macos_app_bundle" 2>&1 \
+            | rg -q 'keychain-access-groups|com\.apple\.security\.'; then
+            echo "ad-hoc 签名后的 macOS App 仍包含受限 entitlement。" >&2
             exit 1
-          }
-
-          echo "使用 ad-hoc 自签名（未配置官方 Developer ID 签名与公证）"
-          codesign --force --deep --sign - \
-            --entitlements macos/Runner/Release.entitlements \
-            "$macos_app_bundle"
+          fi
 
       - name: 生成 macOS DMG
         id: dmg
@@ -324,12 +325,13 @@ jobs:
           mkdir -p dist
 
           macos_app_bundle="$(find build/macos/Build/Products/Release -maxdepth 1 -name '*.app' -print -quit)"
+          dmg_path="dist/SSPU-AllinOne-v${{ needs.prepare.outputs.version }}-macos-universal.dmg"
 
           npm ci --prefix .github/npm/appdmg
 
           staging="dmg-staging"
           mkdir -p "$staging"
-          cp -R "$macos_app_bundle" "$staging/"
+          ditto "$macos_app_bundle" "$staging/SSPU-AllinOne.app"
           cp .github/installer/macos/bg.png "$staging/bg.png"
 
           APP_VERSION="${{ needs.prepare.outputs.public_version }}"
@@ -357,11 +359,10 @@ jobs:
           }
           APPDMG_EOF
 
-          ./.github/npm/appdmg/node_modules/.bin/appdmg "$staging/config.json" \
-            "dist/SSPU-AllinOne-v${{ needs.prepare.outputs.version }}-macos-arm64.dmg"
+          ./.github/npm/appdmg/node_modules/.bin/appdmg "$staging/config.json" "$dmg_path"
 
           rm -rf "$staging"
-          echo "dmg_suffix=arm64" >> "$GITHUB_OUTPUT"
+          echo "dmg_suffix=universal" >> "$GITHUB_OUTPUT"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/README.md
+++ b/README.md
@@ -131,10 +131,17 @@ flutter build macos --release
 - 产物位置：
   `build/macos/Build/Products/Release/`
 - 使用方式：
-  分发生成的 `.app` 包；首次运行若被系统拦截，需要在"系统设置 → 隐私与安全性"中手动放行
-  公开 Release 当前默认提供多架构 DMG：
-  `SSPU-AllinOne-v{version}-macos-arm64.dmg`
-  `SSPU-AllinOne-v{version}-macos-x86_64.dmg`
+  公开 Release 为未公证的 ad-hoc 签名 DMG：
+  `SSPU-AllinOne-v{version}-macos-universal.dmg`
+  将 App 拖入“应用程序”后，确认下载来源可信，再执行：
+
+```bash
+xattr -cr "/Applications/SSPU-AllinOne.app"
+open "/Applications/SSPU-AllinOne.app"
+```
+
+  该包不需要 Apple 开发者证书；发布流程会剥离受限 entitlement，避免
+  ad-hoc 签名 App 被 AMFI 拒绝启动。
 
 ### iOS
 

--- a/scripts/release/generate_release_metadata.py
+++ b/scripts/release/generate_release_metadata.py
@@ -21,7 +21,7 @@ from typing import Dict, List, Tuple
 FILENAME_PATTERN = re.compile(
     r"^SSPU-AllinOne-v(?P<version>.+?)-"
     r"(?P<platform>android|ios|windows|macos|linux)-"
-    r"(?P<arch>armeabi-v7a|arm64-v8a|x86|x86_64|x64|arm64)"
+    r"(?P<arch>armeabi-v7a|arm64-v8a|x86|x86_64|x64|arm64|universal)"
     r"(?:-(?P<kind>setup|portable|unsigned))?"
     r"(?P<ext>\.app\.zip|\.AppImage|\.tar\.gz|\.zip|\.exe|\.dmg|\.deb|\.rpm|\.apk|\.app)$"
 )
@@ -34,7 +34,7 @@ EXPECTED_PRODUCT_ASSETS = {
     ("windows", "x64", "portable"),
     ("windows", "arm64", "setup"),
     ("windows", "arm64", "portable"),
-    ("macos", "arm64", "dmg"),
+    ("macos", "universal", "dmg"),
     ("linux", "x64", "appimage"),
     ("linux", "x64", "deb"),
     ("linux", "x64", "rpm"),

--- a/test/macos_release_entitlements_test.dart
+++ b/test/macos_release_entitlements_test.dart
@@ -11,33 +11,34 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('unsigned macOS release 使用空 entitlements 剥离受限权限', () {
+  test('unsigned macOS 本地 entitlements 剥离受限权限', () {
     final unsignedEntitlements = File(
       'macos/Runner/Release-unsigned.entitlements',
     ).readAsStringSync();
 
-    // unsigned DMG 使用空 entitlements 剥离沙盒与钥匙串权限，避免 AMFI 拒绝启动。
+    // 本地 ad-hoc 构建使用空 entitlements，避免 AMFI 拒绝启动。
     expect(unsignedEntitlements, isNot(contains('com.apple.security.')));
     expect(unsignedEntitlements, isNot(contains('keychain-access-groups')));
   });
 
-  test('macOS Release 使用 ad-hoc 自签名替代官方签名与公证', () {
+  test('macOS Release 使用无 entitlement 的 ad-hoc 签名', () {
     final releaseWorkflow = File(
       '.github/workflows/release.yml',
     ).readAsStringSync();
 
-    expect(
-      releaseWorkflow,
-      contains('使用 ad-hoc 自签名（未配置官方 Developer ID 签名与公证）'),
-    );
+    expect(releaseWorkflow, contains('使用无 entitlement 的 ad-hoc 签名 macOS App Bundle'));
     expect(releaseWorkflow, contains('codesign --force --deep --sign -'));
+    expect(releaseWorkflow, contains('codesign --verify --deep --strict --verbose=2'));
+    expect(releaseWorkflow, contains('仍包含受限 entitlement'));
+    expect(releaseWorkflow, contains('ditto "\$macos_app_bundle"'));
+    expect(releaseWorkflow, isNot(contains('Developer ID Application')));
     expect(releaseWorkflow, isNot(contains('xcrun notarytool submit')));
     expect(releaseWorkflow, isNot(contains('xcrun stapler staple')));
-    expect(releaseWorkflow, isNot(contains('Developer ID Application')));
+    expect(releaseWorkflow, isNot(contains('MACOS_SIGNING_CERTIFICATE_BASE64')));
     expect(
       releaseWorkflow,
       contains(
-        'dist/SSPU-AllinOne-v\${{ needs.prepare.outputs.version }}-macos-arm64.dmg',
+        'dist/SSPU-AllinOne-v\${{ needs.prepare.outputs.version }}-macos-universal.dmg',
       ),
     );
   });
@@ -57,7 +58,7 @@ void main() {
     expect(releaseWorkflow, contains('if [ "\${#DMG_TITLE}" -gt 27 ]; then'));
     expect(releaseWorkflow, contains('"title": "\${DMG_TITLE}"'));
 
-    const currentPublicVersion = '0.2.8-alpha';
+    const currentPublicVersion = '0.4.0-beta';
     expect('SSPU-AIO v$currentPublicVersion'.length, lessThanOrEqualTo(27));
   });
 }

--- a/test/release_metadata_script_test.dart
+++ b/test/release_metadata_script_test.dart
@@ -26,7 +26,8 @@ void main() {
       ).writeAsString('fixture:$assetName');
     }
 
-    final result = await Process.run('python', [
+    final pythonExecutable = Platform.isWindows ? 'python' : 'python3';
+    final result = await Process.run(pythonExecutable, [
       'scripts/release/generate_release_metadata.py',
       '--asset-dir',
       tempDir.path,
@@ -63,11 +64,11 @@ void main() {
     );
 
     expect(macosEntries.length, 1);
-    final arm64Entry = macosEntries.firstWhere(
-      (entry) => entry['arch'] == 'arm64',
+    final universalEntry = macosEntries.firstWhere(
+      (entry) => entry['arch'] == 'universal',
     );
-    expect(arm64Entry['kind'], 'dmg');
-    expect(arm64Entry['filename'], 'SSPU-AllinOne-v1.2.0-macos-arm64.dmg');
+    expect(universalEntry['kind'], 'dmg');
+    expect(universalEntry['filename'], 'SSPU-AllinOne-v1.2.0-macos-universal.dmg');
   });
 }
 
@@ -79,7 +80,7 @@ const _expectedAssetNames = [
   'SSPU-AllinOne-v1.2.0-windows-x64-portable.zip',
   'SSPU-AllinOne-v1.2.0-windows-arm64-setup.exe',
   'SSPU-AllinOne-v1.2.0-windows-arm64-portable.zip',
-  'SSPU-AllinOne-v1.2.0-macos-arm64.dmg',
+  'SSPU-AllinOne-v1.2.0-macos-universal.dmg',
   'SSPU-AllinOne-v1.2.0-linux-x64.AppImage',
   'SSPU-AllinOne-v1.2.0-linux-x64.deb',
   'SSPU-AllinOne-v1.2.0-linux-x64.rpm',


### PR DESCRIPTION
## 变更说明

<!-- 简要说明本次 PR 做了什么，以及为什么需要这样改。 -->

## 关联 Issue

<!-- 需要关闭 Issue 时保留 Closes / Fixes / Resolves；仅引用请写 Refs #123。 -->
<!-- 合并到 develop 后，只有关闭关键字或 GitHub closing reference 会自动关闭 Issue。 -->
Closes #

## Breaking Change

- [ ] 本 PR 引入 Breaking Change（需要迁移或影响现有用户数据）
- [ ] 无 Breaking Change

<!-- 若有 Breaking Change，请在下方说明影响和迁移方案 -->

## 验证记录

<!-- 勾选已执行项；未执行必须写明原因。 -->

### 代码变更（`lib/`、`test/`、平台代码）

- [ ] `flutter analyze --no-fatal-infos`
- [ ] `flutter test`
- [ ] 平台构建验证：
- [ ] 手动验证：

### CI / 文档 / 仓库治理

- [ ] 治理校验：`python scripts/ci/validate_github_governance.py`
- [ ] 文档已同步更新

### 未执行验证

- 原因：

## 检查清单

- [ ] 没有提交无关文件、构建产物或本地自动化配置
- [ ] 没有引入账号、密码、Cookie、Token、私钥、keystore 或真实用户数据
- [ ] 已更新相关文档 / Changelog，或说明无需更新
- [ ] PR 标题符合 `type(scope): 中文摘要` 格式

<!-- Release PR 请改用 release 模板：?template=release.md -->
